### PR TITLE
Speed up `OnDigraphs` for a digraph and a permutation

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2561,10 +2561,10 @@ function(D)
   p    := Permutation(Transformation(topo), topo);
 
   C := DigraphMutableCopyIfImmutable(D);
-  OnDigraphs(C, p ^ -1);       # changes C in-place
-  DIGRAPH_TRANS_REDUCTION(C);  # changes C in-place
+  OnDigraphsNC(C, p ^ -1);       # changes C in-place
+  DIGRAPH_TRANS_REDUCTION(C);    # changes C in-place
   ClearDigraphEdgeLabels(C);
-  OnDigraphs(C, p);            # changes C in-place
+  OnDigraphsNC(C, p);            # changes C in-place
   if IsImmutableDigraph(D) then
     MakeImmutable(C);
     SetDigraphTransitiveReductionAttr(D, C);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -819,7 +819,7 @@ function(L1, L2)
   in1, in2, mask, defined, not_in_image, FindNextAmong, Recurse;
 
   p := PermList(Reversed(DigraphWelshPowellOrder(L1)));
-  L1 := OnDigraphs(L1, p ^ -1);
+  L1 := OnDigraphsNC(L1, p ^ -1);
 
   # We compute the join/meet table to avoid having to do this twice if L1 or L2
   # is mutable

--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -214,7 +214,7 @@ function(D)
   if IsMultiDigraph(D) then
     return OnMultiDigraphs(D, BlissCanonicalLabelling(D));
   fi;
-  return OnDigraphs(D, BlissCanonicalLabelling(D));
+  return OnDigraphsNC(D, BlissCanonicalLabelling(D));
 end);
 
 InstallMethod(BlissCanonicalDigraph, "for a digraph and vertex coloring",
@@ -223,7 +223,7 @@ function(D, colors)
   if IsMultiDigraph(D) then
     return OnMultiDigraphs(D, BlissCanonicalLabelling(D, colors));
   fi;
-  return OnDigraphs(D, BlissCanonicalLabelling(D, colors));
+  return OnDigraphsNC(D, BlissCanonicalLabelling(D, colors));
 end);
 
 InstallMethodThatReturnsDigraph(NautyCanonicalDigraph, "for a digraph",
@@ -233,7 +233,7 @@ function(D)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
-  return OnDigraphs(D, NautyCanonicalLabelling(D));
+  return OnDigraphsNC(D, NautyCanonicalLabelling(D));
 end);
 
 InstallMethod(NautyCanonicalDigraph, "for a digraph and vertex coloring",
@@ -243,7 +243,7 @@ function(D, colors)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
-  return OnDigraphs(D, NautyCanonicalLabelling(D, colors));
+  return OnDigraphsNC(D, NautyCanonicalLabelling(D, colors));
 end);
 
 # Automorphism group
@@ -349,7 +349,7 @@ function(C, D)
   if IsMultiDigraph(C) then
     act := OnMultiDigraphs;
   else
-    act := OnDigraphs;
+    act := OnDigraphsNC;
   fi;
 
   if HasBlissCanonicalLabelling(C) and HasBlissCanonicalLabelling(D)
@@ -400,7 +400,7 @@ function(C, D, c1, c2)
   elif IsMultiDigraph(C) then
     act := OnMultiDigraphs;
   else
-    act := OnDigraphs;
+    act := OnDigraphsNC;
   fi;
 
   if DIGRAPHS_UsingBliss or IsMultiDigraph(C) then
@@ -489,7 +489,7 @@ function(C, D, c1, c2)
     return [label1[1] / label2[1], label1[2] / label2[2]];
   fi;
 
-  if OnDigraphs(C, label1) <> OnDigraphs(D, label2) then
+  if OnDigraphsNC(C, label1) <> OnDigraphsNC(D, label2) then
     return fail;
   fi;
   return label1 / label2;

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -62,6 +62,8 @@ DeclareOperation("DIGRAPHS_GraphProduct", [IsDigraph, IsDigraph, IsFunction]);
 # 4. Actions . . .
 DeclareOperation("OnDigraphs", [IsDigraph, IsPerm]);
 DeclareOperation("OnDigraphs", [IsDigraph, IsTransformation]);
+DeclareOperation("OnDigraphsNC", [IsDigraph, IsPerm]);
+DeclareOperation("OnDigraphsNC", [IsDigraph, IsTransformation]);
 DeclareOperation("OnTuplesDigraphs", [IsDigraphCollection, IsPerm]);
 DeclareOperation("OnSetsDigraphs", [IsDigraphCollection, IsPerm]);
 DeclareOperation("OnMultiDigraphs", [IsDigraph, IsPermCollection]);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -997,17 +997,15 @@ InstallMethod(OnDigraphs, "for a mutable digraph by out-neighbours and a perm",
 [IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPerm],
 function(D, p)
   local out, permed;
-  if p = () then
+  if SmallestMovedPoint(p) > DigraphNrVertices(D) then
     return D;
+  elif ForAny(DigraphVertices(D), i -> i ^ p > DigraphNrVertices(D)) then
+    ErrorNoReturn("the 2nd argument <p> must be a permutation that permutes ",
+                  "the vertices of the digraph <D> that is the 1st argument.");
   fi;
 
   out := D!.OutNeighbours;
   permed := Permuted(out, p);
-  if Length(permed) > DigraphNrVertices(D) then
-    ErrorNoReturn("the 2nd argument <p> must be a permutation that permutes ",
-                  "the vertices of the digraph <D> that is the 1st argument,");
-  fi;
-
   out{DigraphVertices(D)} := permed;
   Apply(out, x -> OnTuples(x, p));
   ClearDigraphEdgeLabels(D);
@@ -1017,7 +1015,7 @@ end);
 InstallMethod(OnDigraphs, "for a immutable digraph and a perm",
 [IsImmutableDigraph, IsPerm],
 function(D, p)
-  if p = () then
+  if SmallestMovedPoint(p) > DigraphNrVertices(D) then
     return D;
   fi;
   return MakeImmutable(OnDigraphs(DigraphMutableCopy(D), p));
@@ -1028,7 +1026,7 @@ InstallMethod(OnDigraphs,
 [IsMutableDigraph and IsDigraphByOutNeighboursRep, IsTransformation],
 function(D, t)
   local old, new, v;
-  if ForAll(DigraphVertices(D), i -> i ^ t = i) then
+  if SmallestMovedPoint(t) > DigraphNrVertices(D) then
     return D;
   elif ForAny(DigraphVertices(D), i -> i ^ t > DigraphNrVertices(D)) then
     ErrorNoReturn("the 2nd argument <t> must be a transformation that ",
@@ -1048,7 +1046,7 @@ end);
 InstallMethod(OnDigraphs, "for a immutable digraph and a transformation",
 [IsImmutableDigraph, IsTransformation],
 function(D, t)
-  if ForAll(DigraphVertices(D), i -> i ^ t = i) then
+  if SmallestMovedPoint(t) > DigraphNrVertices(D) then
     return D;
   fi;
   return MakeImmutable(OnDigraphs(DigraphMutableCopy(D), t));

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -996,7 +996,7 @@ end);
 InstallMethod(OnDigraphs, "for a mutable digraph by out-neighbours and a perm",
 [IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPerm],
 function(D, p)
-  local out, permed;
+  local out;
   if SmallestMovedPoint(p) > DigraphNrVertices(D) then
     return D;
   elif ForAny(DigraphVertices(D), i -> i ^ p > DigraphNrVertices(D)) then
@@ -1005,8 +1005,7 @@ function(D, p)
   fi;
 
   out := D!.OutNeighbours;
-  permed := Permuted(out, p);
-  out{DigraphVertices(D)} := permed;
+  out{DigraphVertices(D)} := Permuted(out, p);
   Apply(out, x -> OnTuples(x, p));
   ClearDigraphEdgeLabels(D);
   return D;

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -1001,7 +1001,7 @@ function(D, p)
     return D;
   elif ForAny(DigraphVertices(D), i -> i ^ p > DigraphNrVertices(D)) then
     ErrorNoReturn("the 2nd argument <p> must be a permutation that permutes ",
-                  "the vertices of the digraph <D> that is the 1st argument.");
+                  "the vertices of the digraph <D> that is the 1st argument");
   fi;
 
   out := D!.OutNeighbours;
@@ -1031,7 +1031,7 @@ function(D, t)
   elif ForAny(DigraphVertices(D), i -> i ^ t > DigraphNrVertices(D)) then
     ErrorNoReturn("the 2nd argument <t> must be a transformation that ",
                   "maps every vertex of the digraph <D> that is the 1st ",
-                  "argument, to another vertex.");
+                  "argument, to another vertex");
   fi;
   old := D!.OutNeighbours;
   new := List(DigraphVertices(D), x -> []);
@@ -1062,7 +1062,7 @@ InstallMethod(OnSetsDigraphs,
 [IsDigraphCollection and IsHomogeneousList, IsPerm],
 function(S, p)
   if not IsSet(S) then
-    ErrorNoReturn("the first argument must be a set (a strictly sorted list),");
+    ErrorNoReturn("the first argument must be a set (a strictly sorted list)");
   fi;
   return Set(S, D -> OnDigraphs(DigraphMutableCopyIfMutable(D), p));
 end);
@@ -1083,7 +1083,7 @@ function(D, perms)
             i -> i ^ perms[2] > DigraphNrEdges(D)) then
     ErrorNoReturn("the 2nd entry of the 2nd argument <perms> must ",
                   "permute the edges of the digraph <D> that is the 1st ",
-                  "argument,");
+                  "argument");
   fi;
 
   return OnDigraphs(D, perms[1]);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -996,15 +996,19 @@ end);
 InstallMethod(OnDigraphs, "for a mutable digraph by out-neighbours and a perm",
 [IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPerm],
 function(D, p)
-  local out;
-  if ForAll(DigraphVertices(D), i -> i ^ p = i) then
+  local out, permed;
+  if p = () then
     return D;
-  elif ForAny(DigraphVertices(D), i -> i ^ p > DigraphNrVertices(D)) then
+  fi;
+
+  out := D!.OutNeighbours;
+  permed := Permuted(out, p);
+  if Length(permed) > DigraphNrVertices(D) then
     ErrorNoReturn("the 2nd argument <p> must be a permutation that permutes ",
                   "the vertices of the digraph <D> that is the 1st argument,");
   fi;
-  out := D!.OutNeighbours;
-  out{DigraphVertices(D)} := Permuted(out, p);
+
+  out{DigraphVertices(D)} := permed;
   Apply(out, x -> OnTuples(x, p));
   ClearDigraphEdgeLabels(D);
   return D;
@@ -1013,7 +1017,7 @@ end);
 InstallMethod(OnDigraphs, "for a immutable digraph and a perm",
 [IsImmutableDigraph, IsPerm],
 function(D, p)
-  if ForAll(DigraphVertices(D), i -> i ^ p = i) then
+  if p = () then
     return D;
   fi;
   return MakeImmutable(OnDigraphs(DigraphMutableCopy(D), p));

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -1010,6 +1010,9 @@ InstallMethod(OnDigraphsNC,
 [IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPerm],
 function(D, p)
   local out;
+  if p = () then
+    return D;
+  fi;
   out := D!.OutNeighbours;
   out{DigraphVertices(D)} := Permuted(out, p);
   Apply(out, x -> OnTuples(x, p));
@@ -1021,6 +1024,9 @@ InstallMethod(OnDigraphsNC, "for a immutable digraph and a perm",
 [IsImmutableDigraph, IsPerm],
 function(D, p)
   local out, permed;
+  if p = () then
+    return D;
+  fi;
   out := D!.OutNeighbours;
   permed := Permuted(out, p);
   Apply(permed, x -> OnTuples(x, p));

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -1031,7 +1031,6 @@ InstallMethod(OnDigraphs,
 "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
 function(D, t)
-  local old, new, v;
   if ForAll(DigraphVertices(D), i -> i ^ t = i) then
     return D;
   elif ForAny(DigraphVertices(D), i -> i ^ t > DigraphNrVertices(D)) then

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -98,7 +98,7 @@ gap> h := (1, 2, 3, 4);
 (1,2,3,4)
 gap> OnDigraphs(gr, h);
 Error, the 2nd argument <p> must be a permutation that permutes the vertices o\
-f the digraph <D> that is the 1st argument,
+f the digraph <D> that is the 1st argument
 gap> gr := Digraph([[1, 1, 1, 3, 5], [], [3, 2, 4, 5], [2, 5], [1, 2, 1]]);
 <immutable multidigraph with 5 vertices, 14 edges>
 gap> DigraphEdges(gr);
@@ -108,7 +108,7 @@ gap> p1 := (2, 4)(3, 6, 5);
 (2,4)(3,6,5)
 gap> OnDigraphs(gr, p1);
 Error, the 2nd argument <p> must be a permutation that permutes the vertices o\
-f the digraph <D> that is the 1st argument,
+f the digraph <D> that is the 1st argument
 gap> p2 := (1, 3, 4, 2);
 (1,3,4,2)
 gap> OnDigraphs(gr, p2);
@@ -125,7 +125,7 @@ gap> p1 := (1, 5, 4, 2, 3);
 (1,5,4,2,3)
 gap> OnDigraphs(gr, p1);
 Error, the 2nd argument <p> must be a permutation that permutes the vertices o\
-f the digraph <D> that is the 1st argument,
+f the digraph <D> that is the 1st argument
 gap> p2 := (1, 4)(2, 3);
 (1,4)(2,3)
 gap> OnDigraphs(gr, p2);
@@ -142,7 +142,7 @@ gap> OutNeighbours(gr);
 gap> t := Transformation([4, 2, 3, 4]);;
 gap> OnDigraphs(gr, t);
 Error, the 2nd argument <t> must be a transformation that maps every vertex of\
- the digraph <D> that is the 1st argument, to another vertex.
+ the digraph <D> that is the 1st argument, to another vertex
 gap> t := Transformation([1, 2, 1]);;
 gap> gr := OnDigraphs(gr, t);
 <immutable multidigraph with 3 vertices, 3 edges>
@@ -173,7 +173,7 @@ gap> D := [DigraphReverse(ChainDigraph(3)), ChainDigraph(3)];;
 gap> IsSet(D);
 false
 gap> OnSetsDigraphs(D, (1, 2));
-Error, the first argument must be a set (a strictly sorted list),
+Error, the first argument must be a set (a strictly sorted list)
 gap> D := Reversed(D);;
 gap> OnSetsDigraphs(D, (1, 3)) = D;
 true
@@ -209,7 +209,7 @@ gap> OnMultiDigraphs(gr1, [(1, 3)]);
 Error, the 2nd argument <perms> must be a pair of permutations,
 gap> OnMultiDigraphs(gr1, [(1, 3), (1, 7)]);
 Error, the 2nd entry of the 2nd argument <perms> must permute the edges of the\
- digraph <D> that is the 1st argument,
+ digraph <D> that is the 1st argument
 
 #  DomainForAction
 gap> DomainForAction(RandomDigraph(10), SymmetricGroup(10), OnDigraphs);


### PR DESCRIPTION
This came up from some code which was heavily using digraphs. this almost doubled the speed of the algorithm, as it turns out these GAP-level checks were dominating the run-time of OnDigraphs.

* Instead of checking if the permutation fixes the vertices, check
if it is the identity (which is much cheaper, although catches
less cases)

* Do not check explictly if the permutation maps the vertices
  of the graph to itself, do the mapping then check afterwards.