### PR TITLE
Make behaviour of `DigraphRemoveEdge{s}` consistent when removing no edges

### DIFF
--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -279,6 +279,16 @@ InstallMethod(DigraphRemoveEdges, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
 {D, edges} -> MakeImmutable(DigraphRemoveEdges(DigraphMutableCopy(D), edges)));
 
+InstallMethod(DigraphRemoveEdges, "for an immutable digraph and an empty list",
+[IsImmutableDigraph, IsList and IsEmpty],
+{D, edges} -> D);
+
+InstallMethod(DigraphRemoveEdge, "for an immutable digraph and a list",
+[IsImmutableDigraph, IsList and IsEmpty],
+function(D, edges)
+  ErrorNoReturn("the 2nd argument must be non empty,");
+end);
+
 InstallMethod(DigraphReverseEdge,
 "for a mutable digraph by out-neighbours and two positive integers",
 [IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -39,6 +39,13 @@ gap> DigraphRemoveEdges(gr, [[2, 1]]);
 <immutable digraph with 2 vertices, 1 edge>
 gap> last = gr;
 true
+gap> DigraphRemoveEdges(gr, []);
+<immutable digraph with 2 vertices, 1 edge>
+gap> last = gr;
+true
+gap> DigraphRemoveEdges(gr, [[1, 3]]);
+Error, the 3rd argument <ran> must be a vertex of the digraph <D> that is the \
+1st argument,
 gap> DigraphRemoveEdges(gr, [[1, 2]]);
 <immutable empty digraph with 2 vertices>
 gap> gr := DigraphFromDigraph6String("&DtGsw_");
@@ -78,6 +85,8 @@ Error, the 2nd argument <src> must be a vertex of the digraph <D> that is the \
 gap> DigraphRemoveEdge(gr, [1, 3]);
 Error, the 3rd argument <ran> must be a vertex of the digraph <D> that is the \
 1st argument,
+gap> DigraphRemoveEdge(gr, []);
+Error, the 2nd argument must be non empty,
 gap> gr := DigraphRemoveEdge(gr, [2, 1]);
 <immutable digraph with 2 vertices, 1 edge>
 gap> DigraphEdges(gr);


### PR DESCRIPTION
Added an additional method to preserve properties in the case of empty removals.

This addresses issue #260. _(Note from Wilf: currently only partially.)_