### PR TITLE
Implement initial GitHub actions support for CI

### DIFF
--- a/.github/workflows/GAP.yml
+++ b/.github/workflows/GAP.yml
@@ -1,0 +1,32 @@
+name: "GAP tests"
+
+# Trigger the workflow on push or pull request
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: "GAP ${{ matrix.gap-branch }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        digraphs-lib:
+          - digraphs-lib-0.6
+        gap-branch:
+          - master
+          - stable-4.11
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gap-actions/setup-gap-for-packages@v1
+        with:
+          GAP_PKGS_TO_CLONE: "NautyTracesInterface"
+          GAP_PKGS_TO_BUILD: "io orb profiling grape NautyTracesInterface datastructures"
+          GAPBRANCH: ${{ matrix.gap-branch }}
+      - name: "Install digraphs-lib"
+        run: curl --retry 5 -L -O https://digraphs.github.io/Digraphs/${{ matrix.digraphs-lib }}.tar.gz
+             && tar xf ${{ matrix.digraphs-lib }}.tar.gz
+      - uses: gap-actions/run-test-for-packages@v1

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,0 +1,6 @@
+LoadPackage("digraphs");
+if DigraphsTestInstall() and DigraphsTestAll() and DigraphsTestExtreme() then
+  FORCE_QUIT_GAP(0);
+fi;
+
+FORCE_QUIT_GAP(1);


### PR DESCRIPTION
For now, this should suffice for getting a useful CI system back. This takes advantage of @ssiccha's work on https://github.com/gap-actions and @fingolfin's https://github.com/gap-system/pkg-ci-scripts. As you can see, it doesn't use much code.

Currently, all of the package tests are run with GAP `master` and `stable-4.11`. We can add `stable-4.10` and `stable-4.9` support if we manually compile NautyTracesInterface (which should be easy but that can come later).

This means we're missing the linting test, testing with different versions of packages, and also our custom code coverage test, for now. However, this system includeas Codecov integration - so we could look into turning that on. This also doesn't use Docker, but it is quite possible that someone using this kind of setup for a GAP package will do that, and then we can copy their solution.

So does it work? [Here is a hopefully successful build](https://github.com/wilfwilson/Digraphs/actions/runs/363257535) with the current contents of this PR, and [here is a build where I deliberately introduced an error](https://github.com/wilfwilson/Digraphs/actions/runs/363199153)  into `testinstall.tst`.

The list of all builds is at https://github.com/wilfwilson/Digraphs/actions