### PR TITLE
Don't copy an immutable digraph when adding zero vertices

### DIFF
--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -320,8 +320,10 @@ true
 
     If <A>digraph</A> belongs to <Ref Filt="IsMutableDigraph"/>, then the
     vertices are added directly to <A>digraph</A>, which is changed in-place.
-    If <A>digraph</A> belongs to <Ref Filt="IsImmutableDigraph"/>, then the
-    result is returned as an immutable digraph.
+    If <A>digraph</A> belongs to <Ref Filt="IsImmutableDigraph"/>, then
+    <A>digraph</A> itself is returned if no vertices are added
+    (i.e. <C><A>m</A>=0</C> or <A>labels</A> is empty), otherwise
+    the result is a new immutable digraph.
     <P/>
 
     <Example><![CDATA[

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -63,8 +63,12 @@ end);
 
 InstallMethod(DigraphAddVertices, "for an immutable digraph and list",
 [IsImmutableDigraph, IsList],
-{D, labels} -> MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D),
-                                                labels)));
+function(D, labels)
+  if IsEmpty(labels) then
+    return D;
+  fi;
+  return MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), labels));
+end);
 
 InstallMethod(DigraphAddVertices, "for a mutable digraph and an integer",
 [IsMutableDigraph, IsInt],
@@ -79,7 +83,12 @@ end);
 
 InstallMethod(DigraphAddVertices, "for an immutable digraph and an integer",
 [IsImmutableDigraph, IsInt],
-{D, m} -> MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), m)));
+function(D, m)
+  if m = 0 then
+    return D;
+  fi;
+  return MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), m));
+end);
 
 # Included for backwards compatibility, even though the 2nd arg is redundant.
 # See https://github.com/digraphs/Digraphs/issues/264

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -617,17 +617,9 @@ gap> DigraphVertexLabels(gr2);
 [ Alt( [ 1 .. 5 ] ), Sym( [ 1 .. 2 ] ), Group(()) ]
 gap> DigraphAddVertices(gr2, -1);
 Error, the 2nd argument <m> must be a non-negative integer,
-gap> gr3 := DigraphAddVertices(gr2, 0);
-<immutable digraph with 3 vertices, 1 edge>
-gap> IsIdenticalObj(gr2, gr3);
-false
-gap> gr2 = gr3;
+gap> IsIdenticalObj(gr2, DigraphAddVertices(gr2, 0));
 true
-gap> gr3 := DigraphAddVertices(gr2, []);
-<immutable digraph with 3 vertices, 1 edge>
-gap> IsIdenticalObj(gr2, gr3);
-false
-gap> gr2 = gr3;
+gap> IsIdenticalObj(gr2, DigraphAddVertices(gr2, []));
 true
 
 #  DigraphAddVertices (redundant three-argument version)


### PR DESCRIPTION
This is similar to #338 and #340, for edges (although I made these changes over a year ago!).