### PR TITLE
Small improvements to IsSymmetricDigraph

### DIFF
--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -199,6 +199,13 @@ InstallMethod(IsSymmetricDigraph, "for a digraph by out-neighbours",
 function(D)
   local out, inn, new, i;
 
+  if not IsMultiDigraph(D)
+      and (DigraphNrEdges(D) - Length(DigraphLoops(D))) mod 2 = 1 then
+    return false;
+  elif HasAdjacencyMatrix(D) then
+    TryNextMethod();
+  fi;
+
   out := OutNeighbours(D);
   inn := InNeighbours(D);
   if not ForAll(out, IsSortedList) then
@@ -209,6 +216,22 @@ function(D)
     out := new;
   fi;
   return inn = out;
+end);
+
+InstallMethod(IsSymmetricDigraph, "for a digraph with adjacency matrix",
+[IsDigraph and HasAdjacencyMatrix],
+function(D)
+  local mat, n, i, j;
+  mat := AdjacencyMatrix(D);
+  n := DigraphNrVertices(D);
+  for i in [1 .. n - 1] do
+    for j in [i + 1 .. n] do
+      if mat[i][j] <> mat[j][i] then
+        return false;
+      fi;
+    od;
+  od;
+  return true;
 end);
 
 # Functional: for every vertex v there is exactly one edge with source v

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -238,6 +238,30 @@ gap> gr := Digraph(rec(DigraphNrVertices := 3, DigraphSource := [1, 1, 2, 2, 2, 
 > DigraphRange := [2, 2, 1, 1, 3, 3, 2, 2]));;
 gap> IsSymmetricDigraph(gr);
 true
+gap> D := Digraph([[2], [3], [2]]);;
+gap> IsSymmetricDigraph(D);
+false
+gap> D := Digraph([[2], [2], [2]]);;
+gap> IsSymmetricDigraph(D);
+false
+gap> D := Digraph([[2], [2], [1]]);;
+gap> IsSymmetricDigraph(D);
+false
+gap> D := CycleDigraph(3);;
+gap> AdjacencyMatrix(D);;
+gap> IsSymmetricDigraph(D);
+false
+gap> D := Digraph([[2, 3], [1, 2, 3], [1, 2]]);;
+gap> AdjacencyMatrix(D);;
+gap> IsSymmetricDigraph(D);
+true
+gap> D := Digraph([[2], [2], [2]]);;
+gap> AdjacencyMatrix(D);;
+gap> IsSymmetricDigraph(D);
+false
+gap> D := Digraph([[2], [2], [2, 1]]);;
+gap> IsSymmetricDigraph(D);
+false
 
 #  IsAntisymmetricDigraph
 gap> gr := Digraph(rec(DigraphNrVertices := 10,


### PR DESCRIPTION
For the general method: first check whether there are an odd number of edges (ignoring loops), and return `false` if so. Computing `IsMultiDigraph`, `DigraphNrEdges`, and `DigraphLoops` should be a lot faster than computing the in-neighbours, which is what happens next.

And a method for when we have the adjacency matrix.