### PR TITLE
Gap410

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@
 
 ##  <#GAPDoc Label="PKGVERSIONDATA">
 ##  <!ENTITY VERSION                  "1.3.0">
-##  <!ENTITY GAPVERS                  "4.9.0">
+##  <!ENTITY GAPVERS                  "4.10.0">
 ##  <!ENTITY GRAPEVERS                "4.8.1">
 ##  <!ENTITY IOVERS                   "4.5.1">
 ##  <!ENTITY ORBVERS                  "4.8.2">

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ For questions, remarks, suggestions, and issues please use the
 
 ## Installation
 
-It is assumed that you have a working copy of [GAP][] with version number 4.9.0
-or higher.  The most up-to-date version of GAP, and instructions on how to
-install it, can be obtained from the
+It is assumed that you have a working copy of [GAP][] with version number
+4.10.0 or higher.  The most up-to-date version of GAP, and instructions on how
+to install it, can be obtained from the 
 [main GAP webpage](https://www.gap-system.org).
 
 The following is a summary of the steps that should lead to a successful

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -55,13 +55,6 @@ Obj IsPermGroup;
 Obj IsDigraphAutomorphism;
 Obj LargestMovedPointPerms;
 
-#if !defined(GAP_KERNEL_MAJOR_VERSION) || GAP_KERNEL_MAJOR_VERSION < 3
-// compatibility with GAP <= 4.9
-static inline Obj NEW_PLIST_IMM(UInt type, Int plen) {
-  return NEW_PLIST(type | IMMUTABLE, plen);
-}
-#endif
-
 static inline bool IsAttributeStoringRep(Obj o) {
   return (CALL_1ARGS(IsAttributeStoringRepObj, o) == True ? true : false);
 }

--- a/src/planar.c
+++ b/src/planar.c
@@ -32,13 +32,6 @@
 #include "planarity/graphK4Search.h"
 #endif
 
-#if !defined(GAP_KERNEL_MAJOR_VERSION) || GAP_KERNEL_MAJOR_VERSION < 3
-// compatibility with GAP <= 4.9
-static inline Obj NEW_PLIST_IMM(UInt type, Int plen) {
-  return NEW_PLIST(type | IMMUTABLE, plen);
-}
-#endif
-
 // Forward declaration of the main function in this file.
 Obj boyers_planarity_check(Obj digraph, int flags, bool krtwsk);
 


### PR DESCRIPTION
This PR removes the last vestiges of GAP 4.9 from Digraphs, since we now require (and have for some time, without realising) 4.10. 