### PR TITLE
Maximal common subdigraph/Minimal common superdigraph

### DIFF
--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -798,3 +798,66 @@ false
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="MaximalCommonSubdigraph">
+  <ManSection>
+    <Oper Name="MaximalCommonSubdigraph" Arg="D1, D2"/>
+    <Returns>A list containing a digraph and two transformations.</Returns>
+    <Description>
+  If <A>D1</A> and <A>D2</A> are digraphs without multiple edges, then
+  <C>MaximalCommonSubdigraph</C> returns a maximal common subgraph <C>M</C> of
+  <A>D1</A> and <A>D2</A> with the maximum number of vertices. So <C>M</C> is a
+  digraph which embeds into both <A>D1</A> and <A>D2</A> and has the largest
+  number of vertices amoung such digraphs.
+
+  It returns a list <C>[M, t1, t2]</C> where <C>M</C> is the maximal common
+  subdigraph and <C>t1, t2</C> are transformations embedding <C>M</C> into
+  <A>D1</A> and <A>D2</A> respectively.
+
+<Example><![CDATA[
+gap> MaximalCommonSubdigraph(PetersenGraph(), CompleteDigraph(10));
+[ <immutable digraph with 2 vertices, 2 edges>, 
+  IdentityTransformation, IdentityTransformation ]
+gap> MaximalCommonSubdigraph(PetersenGraph(),
+> DigraphSymmetricClosure(CycleDigraph(5)));
+[ <immutable digraph with 5 vertices, 10 edges>, 
+  IdentityTransformation, IdentityTransformation ]
+gap> MaximalCommonSubdigraph(NullDigraph(0), CompleteDigraph(10));
+[ <immutable empty digraph with 0 vertices>, IdentityTransformation, 
+  IdentityTransformation ]
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="MinimalCommonSuperdigraph">
+  <ManSection>
+    <Oper Name="MinimalCommonSuperdigraph" Arg="D1, D2"/>
+    <Returns>A list containing a digraph and two transformations.</Returns>
+    <Description>
+  If <A>D1</A> and <A>D2</A> are digraphs without multiple edges, then
+  <C>MinimalCommonSuperdigraph</C> returns a minimal common superdigraph
+  <C>M</C> of <A>D1</A> and <A>D2</A> with the minimum number of vertices.
+  So <C>M</C> is a digraph into which both <A>D1</A> and <A>D2</A> embed and
+  has the smallest number of vertices amoung such digraphs.
+ 
+  It returns a list <C>[M, t1, t2]</C> where <C>M</C> is the minimal common 
+  superdigraph and <C>t1, t2</C> are transformations embedding <A>D1</A> and
+  <A>D2</A> respectively into <C>M</C>.
+<Example><![CDATA[
+gap> MinimalCommonSuperdigraph(PetersenGraph(), CompleteDigraph(10));
+[ <immutable digraph with 18 vertices, 118 edges>, 
+  IdentityTransformation, 
+  Transformation( [ 1, 2, 11, 12, 13, 14, 15, 16, 17, 18, 11, 12, 13,
+      14, 15, 16, 17, 18 ] ) ]
+gap> MinimalCommonSuperdigraph(PetersenGraph(),
+> DigraphSymmetricClosure(CycleDigraph(5)));
+[ <immutable digraph with 10 vertices, 30 edges>, 
+  IdentityTransformation, IdentityTransformation ]
+gap> MinimalCommonSuperdigraph(NullDigraph(0), CompleteDigraph(10));
+[ <immutable digraph with 10 vertices, 90 edges>, 
+  IdentityTransformation, IdentityTransformation ]
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -42,6 +42,8 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
     <#Include Label="RepresentativeOutNeighbours">
     <#Include Label="IsDigraphAutomorphism">
     <#Include Label="IsDigraphColouring">
+    <#Include Label="MaximalCommonSubdigraph">
+    <#Include Label="MinimalCommonSuperdigraph">
   </Section>
 
   <Section><Heading>Homomorphisms of digraphs</Heading>

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -92,3 +92,6 @@ DeclareOperation("DigraphsRespectsColouring",
                  [IsDigraph, IsDigraph, IsTransformation, IsList, IsList]);
 DeclareOperation("DigraphsRespectsColouring",
                  [IsDigraph, IsDigraph, IsPerm, IsList, IsList]);
+
+DeclareOperation("MaximalCommonSubdigraph", [IsDigraph, IsDigraph]);
+DeclareOperation("MinimalCommonSuperdigraph", [IsDigraph, IsDigraph]);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2453,6 +2453,46 @@ false
 gap> IsDigraphEmbedding(ran, src, (), [2, 1], [1, 1, 2]);
 false
 
+# MaximalCommSubdigraph and MinimalCommonSuperDigraph
+gap> MaximalCommonSubdigraph(NullDigraph(0), CompleteDigraph(10));
+[ <immutable empty digraph with 0 vertices>, IdentityTransformation, 
+  IdentityTransformation ]
+gap> MinimalCommonSuperdigraph(NullDigraph(0), CompleteDigraph(10));
+[ <immutable digraph with 10 vertices, 90 edges>, IdentityTransformation, 
+  IdentityTransformation ]
+gap> MaximalCommonSubdigraph(PetersenGraph(), CompleteDigraph(10));
+[ <immutable digraph with 2 vertices, 2 edges>, IdentityTransformation, 
+  IdentityTransformation ]
+gap> MinimalCommonSuperdigraph(PetersenGraph(), CompleteDigraph(10));
+[ <immutable digraph with 18 vertices, 118 edges>, IdentityTransformation, 
+  Transformation( [ 1, 2, 11, 12, 13, 14, 15, 16, 17, 18, 11, 12, 13, 14, 15,
+      16, 17, 18 ] ) ]
+gap> MaximalCommonSubdigraph(NullDigraph(10), CompleteDigraph(10));
+[ <immutable empty digraph with 1 vertex>, IdentityTransformation, 
+  IdentityTransformation ]
+gap> MinimalCommonSuperdigraph(NullDigraph(10), CompleteDigraph(10));
+[ <immutable digraph with 19 vertices, 90 edges>, IdentityTransformation, 
+  Transformation( [ 1, 11, 12, 13, 14, 15, 16, 17, 18, 19, 11, 12, 13, 14, 15,
+     16, 17, 18, 19 ] ) ]
+gap> MaximalCommonSubdigraph(CompleteDigraph(100), CompleteDigraph(100));
+[ <immutable digraph with 100 vertices, 9900 edges>, IdentityTransformation, 
+  IdentityTransformation ]
+gap> MinimalCommonSuperdigraph(CompleteDigraph(100), CompleteDigraph(100));
+[ <immutable digraph with 100 vertices, 9900 edges>, IdentityTransformation, 
+  IdentityTransformation ]
+gap> MaximalCommonSubdigraph(PetersenGraph(),
+> DigraphSymmetricClosure(CycleDigraph(5)));
+[ <immutable digraph with 5 vertices, 10 edges>, IdentityTransformation, 
+  IdentityTransformation ]
+gap> MinimalCommonSuperdigraph(PetersenGraph(),
+> DigraphSymmetricClosure(CycleDigraph(5)));
+[ <immutable digraph with 10 vertices, 30 edges>, IdentityTransformation, 
+  IdentityTransformation ]
+gap> MaximalCommonSubdigraph(Digraph([[1, 1]]), Digraph([[1]]));
+Error, ModularProduct does not support multidigraphs,
+gap> MinimalCommonSuperdigraph(Digraph([[1, 1]]), Digraph([[1]]));
+Error, ModularProduct does not support multidigraphs,
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);
 gap> Unbind(epis);


### PR DESCRIPTION
Implements the functions MaximalCommonSubdigraph and MinimalCommonSuperdigraph.

MaximalCommonSubdigraph takes 2 digraphs and returns a third digraph with maximum vertex set size which embedds in both of them (as well as the embeddings).

MinimalCommonSuperdigraph takes 2 digraphs and returns a third digraph with minimum vertex set size into which both of them embed (as well as the embeddings).

It also includes a function which builds the ModularProduct of 2 digraphs. This is analogous to the modular product of graphs as described here: https://en.wikipedia.org/wiki/Modular_product_of_graphs