### PR TITLE
Add DigraphShortestPathSpanningTree

### DIFF
--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1400,13 +1400,61 @@ fail
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DigraphShortestPathSpanningTree">
+<ManSection>
+  <Oper Name="DigraphShortestPathSpanningTree" Arg="digraph, v"/>
+  <Returns>A digraph, or <K>fail</K>.</Returns>
+  <Description>
+    If <A>v</A> is a vertex in <A>digraph</A> and every other
+    vertex of <A>digraph</A> is reachable from <A>v</A>,
+    then this operation returns the shortest path spanning tree of
+    <A>digraph</A> rooted at <A>v</A>.
+    If there exist vertices in <A>digraph</A> (other than <A>v</A>) that are
+    not reachable from <A>v</A>, then <C>DigraphShortestPathSpanningTree</C>
+    returns <K>fail</K>.  See <Ref Oper="IsReachable"/>. <P/>
+
+    The <E>shortest path spanning tree of <A>digraph</A> rooted at <A>v</A></E>
+    is a subdigraph of <A>digraph</A> that is a directed tree, with unique
+    source vertex <A>v</A>, and where for each other vertex <A>u</A> in
+    <A>digraph</A>, the unique directed path from <A>v</A> to <A>u</A> in the
+    tree is the lexicographically-least shortest directed path from <A>v</A> to
+    <A>u</A> in <A>digraph</A>. <P/>
+
+    See <Ref Prop="IsDirectedTree"/>, <Ref Attr="DigraphSources"/>, and
+    <Ref Oper="DigraphShortestPath"/>. <P/>
+    
+    If <A>digraph</A> belongs to <Ref Filt="IsMutableDigraph"/>, then
+    <A>digraph</A> is modified in place. If <A>digraph</A> belongs to <Ref
+    Filt="IsImmutableDigraph"/>, then the spanning tree is a new immutable
+    digraph.
+
+<Example><![CDATA[
+gap> D := Digraph([[1, 2], [3], [2, 4], [1], [2, 4]]);
+<immutable digraph with 5 vertices, 8 edges>
+gap> ForAll([2 .. 5], v -> IsReachable(D, 1, v));
+false
+gap> DigraphShortestPathSpanningTree(D, 1);
+fail
+gap> tree := DigraphShortestPathSpanningTree(D, 5);
+<immutable digraph with 5 vertices, 4 edges>
+gap> OutNeighbours(tree);
+[ [  ], [ 3 ], [  ], [ 1 ], [ 2, 4 ] ]
+gap> ForAll(DigraphVertices(D), v ->
+> DigraphShortestPath(D, 5, v) = DigraphPath(tree, 5, v));
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<!-- TODO is it *the* lexicographically least shortest path? -->
 <#GAPDoc Label="DigraphShortestPath">
 <ManSection>
   <Oper Name="DigraphShortestPath" Arg="digraph, u, v"/>
   <Returns>A pair of lists, or <K>fail</K>.</Returns>
   <Description>
-    Returns the shortest directed path in the digraph digraph from the vertex
-    <A>u</A> to the vertex <A>v</A>, if such a path exists. If <C><A>u</A> =
+    Returns a shortest directed path in the digraph <A>digraph</A> from vertex
+    <A>u</A> to vertex <A>v</A>, if such a path exists. If <C><A>u</A> =
     <A>v</A></C>, then the shortest non-trivial cycle is returned, again, if it
     exists. Otherwise, this operation returns <K>fail</K>.  See Section
     <Ref Subsect="Definitions" Style="Text"/> for the definition of a directed

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -33,6 +33,7 @@
     <#Include Label="MaximalSymmetricSubdigraph">
     <#Include Label="MaximalAntiSymmetricSubdigraph">
     <#Include Label="UndirectedSpanningTree">
+    <#Include Label="DigraphShortestPathSpanningTree">
     <#Include Label="QuotientDigraph">
     <#Include Label="DigraphReverse">
     <#Include Label="DigraphDual">

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  attr.gi
-##  Copyright (C) 2014-19                                James D. Mitchell
+##  Copyright (C) 2014-21                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -740,39 +740,37 @@ BindGlobal("DIGRAPH_ConnectivityDataForVertex",
 function(D, v)
   local data, out_nbs, record, orbnum, reps, i, next, laynum, localGirth,
         layers, sum, localParameters, nprev, nhere, nnext, lnum, localDiameter,
-        layerNumbers, x, y;
-  data := DIGRAPHS_ConnectivityData(D);
+        layerNumbers, x, y, tree, expand, stab, edges, edge;
 
+  data := DIGRAPHS_ConnectivityData(D);
   if IsBound(data[v]) then
     return data[v];
   fi;
 
-  out_nbs := OutNeighbours(D);
+  expand := false;
   if HasDigraphGroup(D) then
-    record          := DIGRAPHS_Orbits(DigraphStabilizer(D, v),
-                                       DigraphVertices(D));
+    stab            := DigraphStabilizer(D, v);
+    record          := DIGRAPHS_Orbits(stab, DigraphVertices(D));
     orbnum          := record.lookup;
     reps            := List(record.orbits, Representative);
-    i               := 1;
-    next            := [orbnum[v]];
-    laynum          := [1 .. Length(reps)] * 0;
-    laynum[next[1]] := 1;
-    localGirth      := -1;
-    layers          := [next];
-    sum             := 1;
-    localParameters := [];
+    if Length(record.orbits) < DigraphNrVertices(D) then
+        expand := true;
+    fi;
   else
     orbnum          := [1 .. DigraphNrVertices(D)];
     reps            := [1 .. DigraphNrVertices(D)];
-    i               := 1;
-    next            := [orbnum[v]];
-    laynum          := [1 .. Length(reps)] * 0;
-    laynum[next[1]] := 1;
-    localGirth      := -1;
-    layers          := [next];
-    sum             := 1;
-    localParameters := [];
   fi;
+  out_nbs         := OutNeighbours(D);
+  i               := 1;
+  next            := [orbnum[v]];
+  laynum          := ListWithIdenticalEntries(Length(reps), 0);
+  laynum[next[1]] := 1;
+  tree            := ListWithIdenticalEntries(DigraphNrVertices(D), 0);
+  tree[v]         := -1;
+  localGirth      := -1;
+  layers          := [next];
+  sum             := 1;
+  localParameters := [];
 
   # localDiameter is the length of the longest shortest path starting at v
   #
@@ -780,6 +778,9 @@ function(D, v)
   # each i between 1 and localDiameter where c_i (respectively a_i and b_i) is
   # the number of vertices at distance i − 1 (respectively i and i + 1) from v
   # that are adjacent to a vertex w at distance i from v.
+
+  # <tree> gives a shortest path spanning tree rooted at <v> and is used by
+  # the ShortestPathSpanningTree method.
 
   while Length(next) > 0 do
     next := [];
@@ -799,6 +800,16 @@ function(D, v)
           AddSet(next, orbnum[y]);
           nnext := nnext + 1;
           laynum[orbnum[y]] := i + 1;
+          if not expand then
+            tree[y] := reps[x];
+          else
+            edges := Orbit(stab, [reps[x], y], OnTuples);
+            for edge in edges do
+              if tree[edge[2]] = 0 or tree[edge[2]] > edge[1] then
+                tree[edge[2]] := edge[1];
+              fi;
+            od;
+          fi;
         fi;
       od;
       if (localGirth = -1 or localGirth = 2 * i - 1) and nprev > 1 then
@@ -837,9 +848,12 @@ function(D, v)
   for i in [1 .. DigraphNrVertices(D)] do
      layerNumbers[i] := laynum[orbnum[i]];
   od;
-  data[v] := rec(layerNumbers := layerNumbers, localDiameter := localDiameter,
-                 localGirth := localGirth, localParameters := localParameters,
-                 layers := layers);
+  data[v] := rec(layerNumbers    := layerNumbers,
+                 localDiameter   := localDiameter,
+                 localGirth      := localGirth,
+                 localParameters := localParameters,
+                 layers          := layers,
+                 spstree         := tree);
   return data[v];
 end);
 

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -118,7 +118,9 @@ DeclareOperation("DigraphShortestDistance", [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("DigraphShortestDistance", [IsDigraph, IsList, IsList]);
 DeclareOperation("DigraphShortestDistance", [IsDigraph, IsList]);
 DeclareOperation("DigraphShortestPath", [IsDigraph, IsPosInt, IsPosInt]);
+DeclareOperation("DigraphShortestPathSpanningTree", [IsDigraph, IsPosInt]);
 DeclareOperation("VerticesReachableFrom", [IsDigraph, IsPosInt]);
+
 # 10. Operations for vertices . . .
 DeclareOperation("PartialOrderDigraphJoinOfVertices",
                  [IsDigraph, IsPosInt, IsPosInt]);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -2184,10 +2184,77 @@ gap> OutNeighbours(last);
   [ 23, 25, 33, 35, 38, 40, 1, 2, 6, 7, 11, 12, 16, 17, 26, 27, 41, 42, 49 ], 
   [ 21, 24, 31, 34, 36, 39, 2, 3, 7, 8, 12, 13, 17, 18, 27, 28, 42, 43, 50 ] ]
 
+# DigraphShortestPathSpanningTree
+gap> D := Digraph([[2, 3, 4], [1, 3, 4, 5], [1, 2], [5], [4]]);
+<immutable digraph with 5 vertices, 11 edges>
+gap> OutNeighbours(DigraphShortestPathSpanningTree(D, 1));
+[ [ 2, 3, 4 ], [ 5 ], [  ], [  ], [  ] ]
+gap> OutNeighbours(DigraphShortestPathSpanningTree(D, 2));
+[ [  ], [ 1, 3, 4, 5 ], [  ], [  ], [  ] ]
+gap> OutNeighbours(DigraphShortestPathSpanningTree(D, 3));
+[ [ 4 ], [ 5 ], [ 1, 2 ], [  ], [  ] ]
+gap> DigraphShortestPathSpanningTree(D, 4);
+fail
+gap> DigraphShortestPathSpanningTree(D, 5);
+fail
+gap> OutNeighbours(DigraphShortestPathSpanningTree(D, 6));
+Error, the 2nd argument <v> must be a vertex of the digraph <D>
+
+#
+gap> D1 := Digraph([[], [1], [2, 4], [5], []]);
+<immutable digraph with 5 vertices, 4 edges>
+gap> SetDigraphVertexLabels(D1, Elements(CyclicGroup(IsPermGroup, 5)));
+gap> DigraphGroup(D1);
+Group([ (1,5)(2,4) ])
+gap> D2 := DigraphShortestPathSpanningTree(D1, 3);;
+gap> D1 = D2;
+true
+gap> DigraphVertexLabels(D2);
+[ (), (1,2,3,4,5), (1,3,5,2,4), (1,4,2,5,3), (1,5,4,3,2) ]
+gap> IsDirectedTree(D2);
+true
+
+#
+gap> D1 := DigraphFromDigraph6String("&GG@STD?eIA?_");
+<immutable digraph with 8 vertices, 16 edges>
+gap> SetDigraphVertexLabels(D1, "abcdefgh");
+gap> g := AsList(DihedralGroup(IsPermGroup, 16));;
+gap> for i in [1 .. DigraphNrEdges(D1)] do
+>   e := DigraphEdges(D1)[i];
+>   SetDigraphEdgeLabel(D1, e[1], e[2], g[i]);
+> od;
+gap> D2 := DigraphMutableCopy(D1);
+<mutable digraph with 8 vertices, 16 edges>
+gap> DigraphShortestPathSpanningTree(D2, 1);
+fail
+gap> DigraphShortestPathSpanningTree(D2, 2);;
+gap> D2;
+<mutable digraph with 8 vertices, 7 edges>
+gap> for i in [1 .. DigraphNrEdges(D2)] do
+>   e := DigraphEdges(D2)[i];
+>   if DigraphEdgeLabel(D1, e[1], e[2]) <> DigraphEdgeLabel(D1, e[1], e[2]) then
+>     Print("fail!");
+>   fi;
+> od;
+gap> DigraphVertexLabels(D2);
+"abcdefgh"
+gap> OutNeighbours(D2);
+[ [ 3 ], [ 4, 6, 8 ], [  ], [  ], [  ], [ 1, 5, 7 ], [  ], [  ] ]
+gap> IsDirectedTree(D2);
+true
+
+#
+gap> DigraphShortestPathSpanningTree(EmptyDigraph(0), 1);
+Error, the 2nd argument <v> must be a vertex of the digraph <D>
+gap> DigraphShortestPathSpanningTree(EmptyDigraph(1), 1);
+<immutable empty digraph with 1 vertex>
+
 #DIGRAPHS_UnbindVariables
 gap> Unbind(a);
 gap> Unbind(adj);
 gap> Unbind(b);
+gap> Unbind(D1);
+gap> Unbind(D2);
 gap> Unbind(e);
 gap> Unbind(edges);
 gap> Unbind(edges2);


### PR DESCRIPTION
Dear James and Wilf, 

I have been using digraphs in a course on group theory. When using CayleyDigraph, I noticed that there was a minor mistake during the creation of a CayleyDigraph. The action was OnRight, it should be OnLeftInverse

Furthermore, when playing with Rubik's cube, in particular the small one, it turned out that having an operation that returns a Shortest Path Spanning Tree with relation to a given vertex would be very handy. I noticed that such a tree is almost there when the ConnectivityDataForVertex is computed. I added some lines of code to make sure the tree is stored. Also it would be useful if the Edges of a CayleyDigraph were labeled, which I also did. 

Finally I've created an operation DigraphShortestPathSpanningTree

Best regards,

Jan
