### PR TITLE
Add code coverage and GitHub actions badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.198140.svg)](https://doi.org/10.5281/zenodo.198140)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/digraphs/digraphs/master)
+[![Build status](https://github.com/digraphs/Digraphs/workflows/CI/badge.svg?branch=master)](https://github.com/digraphs/Digraphs/actions?query=workflow%3ACI+branch%3Amaster)
+[![Code coverage](https://codecov.io/gh/digraphs/Digraphs/branch/master/graphs/badge.svg)](https://codecov.io/gh/digraphs/Digraphs/branch/master)
 
 ## README
 


### PR DESCRIPTION
This adds a badge to the README showing the code coverage percentage and the build status in GitHub actions, both for the master branch.

Since we merge our stable branches into our master branch periodically, I don't see how we can easily have the badge showing the status for the master branch in the master branch, but showing the status for the stable branch in the stable branch. So I've just gone for the master branch everywhere.

You can see the result of this by scrolling down to [the README on this page](https://github.com/wilfwilson/Digraphs/tree/add-more-badges-to-README).

The GitHub actions badge will show 'no status' until we merge stable-1.3 into master. This is because the master branch doesn't yet have the fully up-to-date CI.