### PR TITLE
Correct some capitalisation in the manual

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -729,7 +729,7 @@ rec( comps := [ [ 1, 2 ], [ 3, 4, 5 ] ], id := [ 1, 1, 2, 2, 2 ] )
     than <M>1</M>, then this operation returns <K>fail</K>.
     <P/>
 
-    See section <Ref Subsect="Definitions" Style="Number" /> for the definition
+    See Section <Ref Subsect="Definitions" Style="Number" /> for the definition
     of a directed cycle, and the definition of a loop.
 
     <P/>
@@ -906,7 +906,7 @@ gap> DigraphDiameter(D);
   <Description>
     This attribute returns the <E>girth</E> of the digraph <A>digraph</A>.
     The <E>girth</E> of a digraph is the length of its shortest simple circuit.
-    See section <Ref Subsect="Definitions" Style="Number" /> for the definitions
+    See Section <Ref Subsect="Definitions" Style="Number" /> for the definitions
     of simple circuit, directed cycle, and loop.
     <P/>
 
@@ -1180,7 +1180,7 @@ gap> ArticulationPoints(ChainDigraph(2));
     If <A>digraph</A> is a digraph, then <C>DigraphAllSimpleCircuits</C>
     returns a list of the <E>simple circuits</E> in <A>digraph</A>. <P/>
 
-    See section <Ref Subsect="Definitions" Style="Number" /> for the definition
+    See Section <Ref Subsect="Definitions" Style="Number" /> for the definition
     of a simple circuit, and related notions. Note that a loop is a simple
     circuit. <P/>
 
@@ -1232,7 +1232,7 @@ gap> DigraphAllSimpleCircuits(D);
   <Returns>A list of vertices, or <K>fail</K>.</Returns>
   <Description>
     If <A>digraph</A> is a digraph, then <C>DigraphLongestSimpleCircuit</C>
-    returns the longest <E>simple circuit</E> in <A>digraph</A>. See section
+    returns the longest <E>simple circuit</E> in <A>digraph</A>. See Section
     <Ref Subsect="Definitions" Style="Number" /> for the definition of simple
     circuit, and the definition of length for a simple circuit.<P/>
 
@@ -1318,7 +1318,7 @@ fail
     If a digraph <A>digraph</A> has at least one directed cycle, then the period
     is the greatest positive integer which divides the lengths of all directed
     cycles of <A>digraph</A>.  If <A>digraph</A> has no directed cycles, then
-    this function returns <M>0</M>.  See section <Ref Subsect="Definitions"
+    this function returns <M>0</M>.  See Section <Ref Subsect="Definitions"
       Style="Number" /> for the definition of a directed cycle. <P/>
 
     A digraph with a period of <M>1</M> is said to be <E>aperiodic</E>.  See

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1275,7 +1275,7 @@ true
   <Description>
     This operation returns <K>true</K> if there exists a non-trivial directed
     walk from vertex <A>u</A> to vertex <A>v</A> in the digraph <A>digraph</A>,
-    and <K>false</K> if there does not exist such a directed walk.  See section
+    and <K>false</K> if there does not exist such a directed walk.  See Section
     <Ref Subsect="Definitions" Style="Number" /> for the definition of a
     non-trivial directed walk.
     <P/>
@@ -1435,7 +1435,7 @@ gap> NextIterator(iter);
   <Description>
     If <A>digraph</A> is a digraph and <A>v</A> is a vertex in <A>digraph</A>,
     then this operation returns the length of the longest directed walk in
-    <A>digraph</A> which begins at vertex <A>v</A>.  See section <Ref
+    <A>digraph</A> which begins at vertex <A>v</A>.  See Section <Ref
       Subsect="Definitions" Style="Number" /> for the definitions of directed
     walk, directed cycle, and loop.
     <P/>
@@ -1538,7 +1538,7 @@ gap> DigraphDistanceSet(D, 2, 0);
     If there is a directed path in the digraph <A>digraph</A> between vertex
     <A>u</A> and vertex <A>v</A>, then this operation returns the length of the
     shortest such directed path.  If no such directed path exists, then this
-    operation returns <K>fail</K>. See section <Ref Subsect="Definitions"
+    operation returns <K>fail</K>. See Section <Ref Subsect="Definitions"
       Style="Number" /> for the definition of a directed path. <P/>
 
     If the second form is used, then <A>list</A> should be a list of length two,


### PR DESCRIPTION
We should consistently refer to sections as `Section <nr>` rather than `section <nr>`.