### PR TITLE
Test against GAP stable-4.10 on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,27 +19,30 @@ jobs:
       - name: "Run gaplint + cpplint . . ."
         run: bash etc/lint.sh
   test:
-    name: "GAP ${{ matrix.gap-branch }} on ${{ matrix.os }}"
-    runs-on: ${{ matrix.os }}
+    name: "GAP ${{ matrix.gap-branch }}"
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-        digraphs-lib:
-          - digraphs-lib-0.6
         gap-branch:
           - master
           - stable-4.11
+        pkgs-to-clone:
+          - NautyTracesInterface
+
+        include:
+          - gap-branch: stable-4.10
+            pkgs-to-clone: datastructures
 
     steps:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap-for-packages@v1
         with:
-          GAP_PKGS_TO_CLONE: "NautyTracesInterface"
+          GAP_PKGS_TO_CLONE: "${{ matrix.pkgs-to-clone }}"
           GAP_PKGS_TO_BUILD: "io orb profiling grape NautyTracesInterface datastructures"
           GAPBRANCH: ${{ matrix.gap-branch }}
       - name: "Install digraphs-lib"
-        run: curl --retry 5 -L -O https://digraphs.github.io/Digraphs/${{ matrix.digraphs-lib }}.tar.gz
-             && tar xf ${{ matrix.digraphs-lib }}.tar.gz
+        run: DIGRAPHS_LIB="digraphs-lib-0.6"
+             && curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${DIGRAPHS_LIB}.tar.gz"
+             && tar xf "${DIGRAPHS_LIB}.tar.gz"
       - uses: gap-actions/run-test-for-packages@v1


### PR DESCRIPTION
This was slightly tricky to set up because:
* the newest `master` branch of `NautyTracesInterface` requires `GAP >=4.11`, so we don't install `NautyTracesInterface` for the `stable-4.10` job (which makes the `stable-4.10` job much faster than `stable-4.11` etc).
* the version of `datastructures` that is included with `GAP 4.10` is `0.2.4` which is too old for Digraphs. So we have to install a newer version separately.