### PR TITLE
Shorten lines in standard test files

### DIFF
--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -96,7 +96,9 @@ gap> gr := Digraph([[], []]);
 <immutable empty digraph with 2 vertices>
 gap> DigraphDual(gr);
 <immutable digraph with 2 vertices, 4 edges>
-gap> gr := Digraph(rec(DigraphNrVertices := 2, DigraphSource := [], DigraphRange := []));
+gap> gr := Digraph(rec(DigraphNrVertices := 2,
+>                      DigraphSource := [],
+>                      DigraphRange := []));
 <immutable empty digraph with 2 vertices>
 gap> DigraphDual(gr);
 <immutable digraph with 2 vertices, 4 edges>
@@ -170,7 +172,9 @@ gap> adj2 := AdjacencyMatrix(gr);
   [ 0, 0, 0, 0, 2, 0, 0 ] ]
 gap> adj1 = adj2;
 true
-gap> r := rec(DigraphNrVertices := 1, DigraphSource := [1, 1], DigraphRange := [1, 1]);;
+gap> r := rec(DigraphNrVertices := 1,
+>             DigraphSource := [1, 1],
+>             DigraphRange := [1, 1]);;
 gap> gr := Digraph(r);
 <immutable multidigraph with 1 vertex, 2 edges>
 gap> adj1 := AdjacencyMatrix(gr);
@@ -183,12 +187,15 @@ gap> adj1 = adj2;
 true
 gap> AdjacencyMatrix(Digraph([]));
 [  ]
-gap> AdjacencyMatrix(
-> Digraph(rec(DigraphNrVertices := 0, DigraphSource := [], DigraphRange := [])));
+gap> AdjacencyMatrix(Digraph(rec(DigraphNrVertices := 0,
+>                                DigraphSource     := [],
+>                                DigraphRange      := [])));
 [  ]
 
 #  DigraphTopologicalSort
-gap> r := rec(DigraphNrVertices := 20000, DigraphSource := [], DigraphRange := []);;
+gap> r := rec(DigraphNrVertices := 20000,
+>             DigraphSource     := [],
+>             DigraphRange      := []);;
 gap> for i in [1 .. 9999] do
 >   Add(r.DigraphSource, i);
 >   Add(r.DigraphRange, i + 1);
@@ -214,7 +221,9 @@ gap> gr := Digraph([[2], [1]]);
 <immutable digraph with 2 vertices, 2 edges>
 gap> DigraphTopologicalSort(gr);
 fail
-gap> r := rec(DigraphNrVertices := 2, DigraphSource := [1, 1], DigraphRange := [2, 2]);;
+gap> r := rec(DigraphNrVertices := 2,
+>             DigraphSource := [1, 1],
+>             DigraphRange := [2, 2]);;
 gap> multiple := Digraph(r);;
 gap> DigraphTopologicalSort(multiple);
 [ 2, 1 ]
@@ -364,12 +373,14 @@ rec( comps := [ [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] ],
   id := [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ] )
 gap> gr := Digraph(rec(
 > DigraphNrVertices := 100,
-> DigraphSource := [8, 9, 11, 11, 12, 13, 14, 14, 18, 19, 22, 27, 31, 32, 32, 34,
->             37, 40, 45, 48, 50, 52, 58, 58, 58, 59, 60, 60, 65, 66, 73,
->             75, 79, 81, 81, 83, 84, 86, 86, 89, 96, 100, 100, 100],
-> DigraphRange := [54, 62, 28, 55, 70, 37, 20, 32, 53, 16, 42, 66, 63, 13, 73, 89,
->            36, 5, 4, 58, 26, 48, 36, 56, 65, 78, 95, 96, 97, 60, 11, 66,
->            66, 19, 79, 21, 13, 29, 78, 98, 100, 44, 53, 69]));
+> DigraphSource     := [8, 9, 11, 11, 12, 13, 14, 14, 18, 19, 22, 27, 31, 32,
+>                       32, 34, 37, 40, 45, 48, 50, 52, 58, 58, 58, 59, 60, 60,
+>                       65, 66, 73, 75, 79, 81, 81, 83, 84, 86, 86, 89, 96, 100,
+>                       100, 100],
+> DigraphRange      := [54, 62, 28, 55, 70, 37, 20, 32, 53, 16, 42, 66, 63, 13,
+>                       73, 89, 36, 5, 4, 58, 26, 48, 36, 56, 65, 78, 95, 96,
+>                       97, 60, 11, 66, 66, 19, 79, 21, 13, 29, 78, 98, 100, 44,
+>                       53, 69]));
 <immutable digraph with 100 vertices, 44 edges>
 gap> OutNeighbours(gr);
 [ [  ], [  ], [  ], [  ], [  ], [  ], [  ], [ 54 ], [ 62 ], [  ], [ 28, 55 ], 
@@ -423,7 +434,9 @@ gap> DigraphShortestDistances(Digraph([]));
 [  ]
 gap> mat := DigraphShortestDistances(Digraph([[], []]));
 [ [ 0, fail ], [ fail, 0 ] ]
-gap> r := rec(DigraphVertices := [1 .. 15], DigraphSource := [], DigraphRange := []);;
+gap> r := rec(DigraphVertices := [1 .. 15],
+>             DigraphSource   := [],
+>             DigraphRange    := []);;
 gap> for i in [1 .. 15] do
 >   for j in [1 .. 15] do
 >     Add(r.DigraphSource, i);
@@ -448,8 +461,9 @@ gap> Display(DigraphShortestDistances(complete15));
   [  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,  1 ],
   [  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1 ],
   [  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0 ] ]
-gap> r := rec(DigraphNrVertices := 7, DigraphRange := [3, 5, 5, 4, 6, 2, 5, 3, 3, 7, 2],
->  DigraphSource := [1, 1, 1, 2, 2, 3, 3, 4, 5, 5, 7]);;
+gap> r := rec(DigraphNrVertices := 7,
+>             DigraphRange      := [3, 5, 5, 4, 6, 2, 5, 3, 3, 7, 2],
+>             DigraphSource     := [1, 1, 1, 2, 2, 3, 3, 4, 5, 5, 7]);;
 gap> gr := Digraph(r);
 <immutable multidigraph with 7 vertices, 11 edges>
 gap> Display(DigraphShortestDistances(gr));
@@ -473,8 +487,9 @@ gap> DigraphShortestDistances(gr);
 [ [ 0, 1, 1 ], [ 1, 0, 1 ], [ 1, 1, 0 ] ]
 
 #  OutNeighbours and InNeighbours
-gap> gr := Digraph(rec(DigraphNrVertices := 10, DigraphSource := [1, 1, 5, 5, 7, 10],
-> DigraphRange := [3, 3, 1, 10, 7, 1]));
+gap> gr := Digraph(rec(DigraphNrVertices := 10,
+>                      DigraphSource := [1, 1, 5, 5, 7, 10],
+>                      DigraphRange := [3, 3, 1, 10, 7, 1]));
 <immutable multidigraph with 10 vertices, 6 edges>
 gap> InNeighbours(gr);
 [ [ 5, 10 ], [  ], [ 1, 1 ], [  ], [  ], [  ], [ 7 ], [  ], [  ], [ 5 ] ]
@@ -542,10 +557,10 @@ gap> InDegrees(gr2);
 gap> InDegreeSequence(gr2);
 [ 5, 5, 5, 5, 4, 3, 1, 0 ]
 gap> r := rec(DigraphNrVertices := 8,
-> DigraphSource := [1, 1, 1, 2, 2, 2, 2, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 7, 7,
->             7, 7, 7, 7, 8, 8],
-> DigraphRange := [6, 7, 1, 1, 3, 3, 6, 5, 1, 4, 4, 4, 8, 1, 3, 4, 6, 7, 7, 7, 1, 4,
->            5, 6, 5, 7, 5, 6]);;
+> DigraphSource := [1, 1, 1, 2, 2, 2, 2, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6,
+>                   7, 7, 7, 7, 7, 7, 8, 8],
+> DigraphRange := [6, 7, 1, 1, 3, 3, 6, 5, 1, 4, 4, 4, 8, 1, 3, 4, 6, 7, 7, 7,
+>                  1, 4, 5, 6, 5, 7, 5, 6]);;
 gap> gr3 := Digraph(r);
 <immutable multidigraph with 8 vertices, 28 edges>
 gap> OutDegrees(gr3);
@@ -1964,8 +1979,8 @@ gap> DigraphCore(D);
 [ 8 .. 29 ]
 gap> IsDigraphCore(InducedSubdigraph(D, DigraphCore(D)));
 true
-gap> str := ".qb`hOAW@fAiG]g??aGD[TXAbjgWl^?fkG{~cA@p`e~EIRlHSxBFHx\\RJ@ERCYhVSoIDvIE?c?x_\
-> YBJg?IWmoN_djWMyKnckGkdMqBsQMBWsBaK?\\BBFWOvY[vcHp]N";;
+gap> str := ".qb`hOAW@fAiG]g??aGD[TXAbjgWl^?fkG{~cA@p`e~EIRlHSxBFHx\\RJ@ERCYhV\
+> SoIDvIE?c?x_YBJg?IWmoN_djWMyKnckGkdMqBsQMBWsBaK?\\BBFWOvY[vcHp]N";;
 gap> D := DigraphFromDiSparse6String(str);
 <immutable digraph with 50 vertices, 79 edges>
 gap> DigraphCore(D);
@@ -2206,7 +2221,8 @@ gap> gr := Digraph([[2], [1]]);
 gap> SetIsSymmetricDigraph(gr, true);
 gap> gr = DigraphReverse(gr);
 true
-gap> DigraphReverse(Digraph(IsMutableDigraph, [[2], [1]])) = CompleteDigraph(2);
+gap> DigraphReverse(Digraph(IsMutableDigraph, [[2], [1]]))
+> = CompleteDigraph(2);
 true
 
 # DigraphCartesianProductProjections
@@ -2246,7 +2262,8 @@ gap> IsIdempotent(proj[2]);
 true
 gap> RankOfTransformation(proj[3]);
 2
-gap> P := DigraphRemoveAllMultipleEdges(ReducedDigraph(OnDigraphs(D, proj[2])));;
+gap> P := DigraphRemoveAllMultipleEdges(
+> ReducedDigraph(OnDigraphs(D, proj[2])));;
 gap> IsIsomorphicDigraph(CycleDigraph(4), P);
 true
 gap> G := RandomDigraph(12);; 
@@ -2257,7 +2274,8 @@ gap> IsIdempotent(proj[1]);
 true
 gap> RankOfTransformation(proj[2]);
 50
-gap> P := DigraphRemoveAllMultipleEdges(ReducedDigraph(OnDigraphs(D, proj[2])));;
+gap> P := DigraphRemoveAllMultipleEdges(
+> ReducedDigraph(OnDigraphs(D, proj[2])));;
 gap> IsIsomorphicDigraph(H, P);
 true
 
@@ -2267,8 +2285,8 @@ gap> D := DigraphFromDigraph6String("&Sq_MN|bDCLy~Xj}u}GxOLlGfqJtnSQ|l\
 <immutable digraph with 20 vertices, 205 edges>
 gap> M := DigraphMaximalMatching(D);; IsMaximalMatching(D, M);
 true
-gap> D := DigraphFromDigraph6String(IsMutable, "&Sq_MN|bDCLy~Xj}u}GxOLlGfqJtnSQ|l\
-> Q?lYvjbqN~XNNAQYDJE[UHOhyGOqtsjCWJy[");
+gap> D := DigraphFromDigraph6String(IsMutable,
+> "&Sq_MN|bDCLy~Xj}u}GxOLlGfqJtnSQ|lQ?lYvjbqN~XNNAQYDJE[UHOhyGOqtsjCWJy[");
 <mutable digraph with 20 vertices, 205 edges>
 gap> M := DigraphMaximalMatching(D);; IsMaximalMatching(D, M);
 true
@@ -2281,7 +2299,8 @@ gap> D;
 <mutable digraph with 4 vertices, 4 edges>
 
 # DigraphMaximumMatching
-gap> D := DigraphFromDiSparse6String(".]cBn@kqAlt?EpclQp|M}bAgFjHkoDsIuACyCM_Hj");
+gap> D := DigraphFromDiSparse6String(
+> ".]cBn@kqAlt?EpclQp|M}bAgFjHkoDsIuACyCM_Hj");
 <immutable digraph with 30 vertices, 26 edges>
 gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
 true
@@ -2498,7 +2517,8 @@ gap> D := Digraph([[1, 4, 4], [2, 2, 4], [4], [3, 5], [5]]);
 <immutable multidigraph with 5 vertices, 10 edges>
 gap> DigraphNrLoops(D);
 4
-gap> D := Digraph(IsMutableDigraph, [[1, 2], [2, 3], [3, 4], [1, 4, 5], [2, 5]]);
+gap> D := Digraph(IsMutableDigraph,
+>                 [[1, 2], [2, 3], [3, 4], [1, 4, 5], [2, 5]]);
 <mutable digraph with 5 vertices, 11 edges>
 gap> DigraphNrLoops(D);
 5

--- a/tst/standard/cliques.tst
+++ b/tst/standard/cliques.tst
@@ -507,7 +507,8 @@ gap> IsMutable(cliques) or ForAny(cliques, IsMutable);
 false
 
 # Test CliquesFinder on graphs with more than 512 vertices
-gap> CliquesFinder(NullDigraph(513), fail, [], infinity, [], [], true, fail, true);
+gap> CliquesFinder(
+> NullDigraph(513), fail, [], infinity, [], [], true, fail, true);
 [ [ 1 ] ]
 gap> gr := DigraphSymmetricClosure(ChainDigraph(513));
 <immutable symmetric digraph with 513 vertices, 1024 edges>
@@ -601,15 +602,20 @@ ll automorphism if <aut_grp> is not given,
 gap> DigraphsCliquesFinder(NullDigraph(2), fail, [], 4, [], [1], true, fail);
 Error, the 6th argument <exclude> must be invaraint under <aut_grp>, or the fu\
 ll automorphism if <aut_grp> is not given,
-gap> DigraphsCliquesFinder(CompleteDigraph(2), fail, [], 4, [1, 2], [], true, fail);
+gap> DigraphsCliquesFinder(
+> CompleteDigraph(2), fail, [], 4, [1, 2], [], true, fail);
 [ [ 1, 2 ] ]
-gap> DigraphsCliquesFinder(CompleteDigraph(2), fail, [], 4, [], [1, 2], true, fail);
+gap> DigraphsCliquesFinder(
+> CompleteDigraph(2), fail, [], 4, [], [1, 2], true, fail);
 [  ]
-gap> DigraphsCliquesFinder(CompleteDigraph(2), fail, [], 4, [], [], true, 3);
+gap> DigraphsCliquesFinder(
+> CompleteDigraph(2), fail, [], 4, [], [], true, 3);
 [  ]
-gap> DigraphsCliquesFinder(NullDigraph(2), fail, [], 4, [1, 2], [], true, fail);
+gap> DigraphsCliquesFinder(
+> NullDigraph(2), fail, [], 4, [1, 2], [], true, fail);
 [  ]
-gap> DigraphsCliquesFinder(CompleteDigraph(2), fail, [], 4, [1, 2], [], true, 2);
+gap> DigraphsCliquesFinder(
+> CompleteDigraph(2), fail, [], 4, [1, 2], [], true, 2);
 [ [ 1, 2 ] ]
 gap> f := function(a, b)
 > Add(a, Size(b));

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -40,11 +40,15 @@ gap> Digraph(rec(DigraphNrVertices := n, DigraphRange := r));
 Error, the argument <record> must be a record with components 'DigraphSource',\
  'DigraphRange', and either 'DigraphVertices' or 'DigraphNrVertices' (but not \
 both),
-gap> Digraph(rec(DigraphNrVertices := n, DigraphSource := s, DigraphVertices := v));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphSource     := s,
+>                DigraphVertices   := v));
 Error, the argument <record> must be a record with components 'DigraphSource',\
  'DigraphRange', and either 'DigraphVertices' or 'DigraphNrVertices' (but not \
 both),
-gap> Digraph(rec(DigraphNrVertices := n, DigraphRange := r, DigraphVertices := v));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphRange      := r,
+>                DigraphVertices   := v));
 Error, the argument <record> must be a record with components 'DigraphSource',\
  'DigraphRange', and either 'DigraphVertices' or 'DigraphNrVertices' (but not \
 both),
@@ -52,41 +56,69 @@ gap> Digraph(rec(DigraphSource := s, DigraphRange := r));
 Error, the argument <record> must be a record with components 'DigraphSource',\
  'DigraphRange', and either 'DigraphVertices' or 'DigraphNrVertices' (but not \
 both),
-gap> Digraph(rec(DigraphNrVertices := n, DigraphSource := s, DigraphRange := 4));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphSource     := s,
+>                DigraphRange      := 4));
 Error, the record components 'DigraphSource' and 'DigraphRange' must be lists,
-gap> Digraph(rec(DigraphNrVertices := n, DigraphSource := 1, DigraphRange := r));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphSource     := 1,
+>                DigraphRange      := r));
 Error, the record components 'DigraphSource' and 'DigraphRange' must be lists,
-gap> Digraph(rec(DigraphNrVertices := n, DigraphSource := [1, 2], DigraphRange := r));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphSource     := [1, 2],
+>                DigraphRange      := r));
 Error, the record components 'DigraphSource' and 'DigraphRange' must have equa\
 l length,
-gap> Digraph(rec(DigraphNrVertices := "a", DigraphSource := s, DigraphRange := r));
+gap> Digraph(rec(DigraphNrVertices := "a",
+>                DigraphSource     := s,
+>                DigraphRange      := r));
 Error, the record component 'DigraphNrVertices' must be a non-negative integer\
 ,
-gap> Digraph(rec(DigraphNrVertices := -3, DigraphSource := s, DigraphRange := r));
+gap> Digraph(rec(DigraphNrVertices := -3,
+>                DigraphSource     := s,
+>                DigraphRange      := r));
 Error, the record component 'DigraphNrVertices' must be a non-negative integer\
 ,
-gap> Digraph(
-> rec(DigraphNrVertices := 2, DigraphVertices := [1 .. 3], DigraphSource := [2], DigraphRange := [2]));
+gap> Digraph(rec(DigraphNrVertices := 2, DigraphVertices := [1 .. 3],
+>                DigraphSource     := [2],
+>                DigraphRange      := [2]));
 Error, the record must only have one of the components 'DigraphVertices' and '\
 DigraphNrVertices', not both,
-gap> Digraph(rec(DigraphNrVertices := n, DigraphSource := [0 .. 2], DigraphRange := r));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphSource     := [0 .. 2],
+>                DigraphRange      := r));
 Error, the record component 'DigraphSource' is invalid,
-gap> Digraph(rec(DigraphNrVertices := n, DigraphSource := [2 .. 4], DigraphRange := r));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphSource     := [2 .. 4],
+>                DigraphRange      := r));
 Error, the record component 'DigraphSource' is invalid,
-gap> Digraph(rec(DigraphVertices := 2, DigraphSource := s, DigraphRange := r));
+gap> Digraph(rec(DigraphVertices := 2,
+>                DigraphSource     := s,
+>                DigraphRange      := r));
 Error, the record component 'DigraphVertices' must be a list,
-gap> Digraph(rec(DigraphNrVertices := n, DigraphSource := [1, 2, 4], DigraphRange := r));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphSource     := [1, 2, 4],
+>                DigraphRange      := r));
 Error, the record component 'DigraphSource' is invalid,
-gap> Digraph(rec(DigraphVertices := v, DigraphSource := [1, 2, 4], DigraphRange := r));
+gap> Digraph(rec(DigraphVertices := v,
+>                DigraphSource   := [1, 2, 4],
+>                DigraphRange    := r));
 Error, the record component 'DigraphSource' is invalid,
-gap> Digraph(rec(DigraphNrVertices := n, DigraphSource := s, DigraphRange := [1, 4, 2]));
+gap> Digraph(rec(DigraphNrVertices := n,
+>                DigraphSource     := s,
+>                DigraphRange      := [1, 4, 2]));
 Error, the record component 'DigraphRange' is invalid,
-gap> Digraph(rec(DigraphVertices := v, DigraphSource := s, DigraphRange := [1, 4, 2]));
+gap> Digraph(rec(DigraphVertices := v,
+>                DigraphSource   := s,
+>                DigraphRange    := [1, 4, 2]));
 Error, the record component 'DigraphRange' is invalid,
-gap> Digraph(rec(DigraphVertices := "abc", DigraphSource := "acbab", DigraphRange := "cbabb"));
+gap> Digraph(rec(DigraphVertices := "abc",
+>                DigraphSource   := "acbab",
+>                DigraphRange    := "cbabb"));
 <immutable digraph with 3 vertices, 5 edges>
-gap> Digraph(rec(
-> DigraphVertices := [1, 1, 2], DigraphSource := [1, 2], DigraphRange := [1, 2]));
+gap> Digraph(rec(DigraphVertices := [1, 1, 2],
+>                DigraphSource   := [1, 2],
+>                DigraphRange    := [1, 2]));
 Error, the record component 'DigraphVertices' must be duplicate-free,
 
 #  Digraph (by nrvertices, source, and range)
@@ -340,8 +372,9 @@ gap> OutNeighbours(gr);
   [ 2, 4, 5, 5, 7, 10, 10, 10 ], [ 9 ], [ 1, 4, 6, 7, 9 ], 
   [ 2, 3, 6, 6, 6, 6, 6, 7, 10 ], [ 3, 4, 4, 5, 8, 9 ], [ 3, 4, 8, 8, 9, 10 ],
   [ 1, 2, 2, 3, 3, 3, 5, 6, 9, 10 ], [ 2, 3, 3, 3, 4, 4, 4, 4, 5, 6, 9 ] ]
-gap> r := rec(DigraphNrVertices := 10, DigraphSource := ShallowCopy(DigraphSource(gr)),
-> DigraphRange := ShallowCopy(DigraphRange(gr)));;
+gap> r := rec(DigraphNrVertices := 10,
+>             DigraphSource     := ShallowCopy(DigraphSource(gr)),
+>             DigraphRange      := ShallowCopy(DigraphRange(gr)));;
 gap> gr2 := Digraph(r);
 <immutable multidigraph with 10 vertices, 73 edges>
 gap> HasAdjacencyMatrix(gr2);
@@ -547,29 +580,38 @@ gap> RandomLattice(-1);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `RandomLattice' on 1 arguments
 
-# The list of random lattice Digraph6Strings D was generated by running the following command
+# The list of random lattice Digraph6Strings D was generated by running:
 # D := List([1 .. 100], x -> Digraph6String(RandomLattice(7)));
 gap> D := [
-> "&F~grwcIB?_", "&G~tSrCO{D?oC", "&F~kqG{IB?_", "&J~}jSpw`O~_t?a?{?g?o?_", "&H~zzIWxAGH?wB?G",
-> "&G~t[~DosD?oC", "&F~kqG{IB?_", "&H~z~IgrAGN?gB?G", "&I~|TR~DSKoP?{@OB?C", "&G~s[jFOcD?oC",
-> "&G~sc~EocF?oC", "&G~tSrCO{D?oC", "&F~kqG{IB?_", "&F~kqG{IB?_", "&I~|nqTFKKoP?{@OB?C",
-> "&I~|OrPCCNoP?{@OB?C", "&F~kqG{IB?_", "&G~tSrCO{D?oC", "&H~ynMWbAWN?gB?G", "&G~tSrCO{D?oC",
-> "&I~|Sr~DKLOP?{@OB?C", "&F~hrgcIB?_", "&G~s[rCOsD?oC", "&G~tCtCO{D?oC", "&F~lQG{IB?_",
-> "&F~hrgcIB?_", "&I~|DRrDKGOP?{@OB?C", "&F~jRWcIB?_", "&G~tSpCO{D?oC", "&F~mrGcMB?_",
-> "&F~iRwcMB?_", "&F~lQG{IB?_", "&F~lQG{IB?_", "&H~yhKw`BwH?wB?G", "&I~|zqdEKGO^?{@OB?C",
-> "&G~tSrCO{D?oC", "&G~tSrCO{D?oC", "&G~tSrCO{D?oC", "&F~kqG{IB?_", "&F~lQG{IB?_", "&G~skxCOcF?oC",
-> "&J~}dCggoo__~?a?{?g?o?_", "&F~lQG{IB?_", "&G~usdEocD?oC", "&G~tSrCO{D?oC", "&H~ybLG`BWH?wB?G",
-> "&F~irgcIB?_", "&I~|TRBCCNoT?{@OB?C", "&F~iqwcMB?_", "&H~yTHgxAGH?gB?G", "&F~nqg{IB?_",
-> "&I~|PRRCCNoR?{@OB?C", "&F~lqWcMB?_", "&J~}lKhgoo__~?e?s?g?o?_", "&F~nqW{IB?_", "&G~tSrCO{D?oC",
-> "&F~jrWkMB?_", "&G~vKpCO{D?oC", "&F~irgcIB?_", "&H~y~LwnAWN?gB?G", "&F~kqG{IB?_",
-> "&I~|zqdEKGO^?{@OB?C", "&G~t{`EocF?oC", "&H~zNGW~AGN?wB?G", "&H~zNGW~AgN?gB?G", "&F~nQgsIB?_",
-> "&F~hrwkMB?_", "&G~vkbEocF?oC", "&G~s{zCOkF?oC", "&F~grwkMB?_", "&G~tKtCO{D?oC", "&F~nqwsIB?_",
-> "&J~}jKpw_o~_r?a?{?g?o?_", "&F~nqg{IB?_", "&G~s{~DO{D?oC", "&G~tSrCO{D?oC",
-> "&K~~\\tGdCTBr@p?`?P?N?D?B?@", "&G~tSrCO{D?oC", "&H~zjKW`BwJ?gB?G", "&K~~PrG^FnAd@b?`?R?N?D?B?@",
-> "&H~ydKW`AWN?gB?G", "&F~lQG{IB?_", "&G~tSrCO{D?oC", "&H~zNGg~AGN?gB?G", "&G~u[bFocF?oC",
-> "&H~yrMwrAGN?wB?G", "&G~t{zEocF?oC", "&H~yhJw`BWH?wB?G", "&G~uk`FokF?oC", "&F~lqGcMB?_",
-> "&F~kqG{IB?_", "&G~sC~EocF?oC", "&F~lQG{IB?_", "&G~s[~EocF?oC", "&G~tKpCO{D?oC", "&F~jrGcMB?_",
-> "&I~|SrNCKNoR?{@OB?C", "&F~lQG{IB?_", "&F~irgcIB?_", "&F~kqG{IB?_"];;
+> "&F~grwcIB?_", "&G~tSrCO{D?oC", "&F~kqG{IB?_",
+> "&J~}jSpw`O~_t?a?{?g?o?_", "&H~zzIWxAGH?wB?G", "&G~t[~DosD?oC",
+> "&F~kqG{IB?_", "&H~z~IgrAGN?gB?G", "&I~|TR~DSKoP?{@OB?C",
+> "&G~s[jFOcD?oC", "&G~sc~EocF?oC", "&G~tSrCO{D?oC", "&F~kqG{IB?_",
+> "&F~kqG{IB?_", "&I~|nqTFKKoP?{@OB?C", "&I~|OrPCCNoP?{@OB?C",
+> "&F~kqG{IB?_", "&G~tSrCO{D?oC", "&H~ynMWbAWN?gB?G", "&G~tSrCO{D?oC",
+> "&I~|Sr~DKLOP?{@OB?C", "&F~hrgcIB?_", "&G~s[rCOsD?oC", "&G~tCtCO{D?oC",
+> "&F~lQG{IB?_", "&F~hrgcIB?_", "&I~|DRrDKGOP?{@OB?C", "&F~jRWcIB?_",
+> "&G~tSpCO{D?oC", "&F~mrGcMB?_", "&F~iRwcMB?_", "&F~lQG{IB?_",
+> "&F~lQG{IB?_", "&H~yhKw`BwH?wB?G", "&I~|zqdEKGO^?{@OB?C",
+> "&G~tSrCO{D?oC", "&G~tSrCO{D?oC", "&G~tSrCO{D?oC", "&F~kqG{IB?_",
+> "&F~lQG{IB?_", "&G~skxCOcF?oC", "&J~}dCggoo__~?a?{?g?o?_",
+> "&F~lQG{IB?_", "&G~usdEocD?oC", "&G~tSrCO{D?oC", "&H~ybLG`BWH?wB?G",
+> "&F~irgcIB?_", "&I~|TRBCCNoT?{@OB?C", "&F~iqwcMB?_", "&H~yTHgxAGH?gB?G",
+> "&F~nqg{IB?_", "&I~|PRRCCNoR?{@OB?C", "&F~lqWcMB?_",
+> "&J~}lKhgoo__~?e?s?g?o?_", "&F~nqW{IB?_", "&G~tSrCO{D?oC",
+> "&F~jrWkMB?_", "&G~vKpCO{D?oC", "&F~irgcIB?_", "&H~y~LwnAWN?gB?G",
+> "&F~kqG{IB?_", "&I~|zqdEKGO^?{@OB?C", "&G~t{`EocF?oC",
+> "&H~zNGW~AGN?wB?G", "&H~zNGW~AgN?gB?G", "&F~nQgsIB?_", "&F~hrwkMB?_",
+> "&G~vkbEocF?oC", "&G~s{zCOkF?oC", "&F~grwkMB?_", "&G~tKtCO{D?oC",
+> "&F~nqwsIB?_", "&J~}jKpw_o~_r?a?{?g?o?_", "&F~nqg{IB?_",
+> "&G~s{~DO{D?oC", "&G~tSrCO{D?oC", "&K~~\\tGdCTBr@p?`?P?N?D?B?@",
+> "&G~tSrCO{D?oC", "&H~zjKW`BwJ?gB?G", "&K~~PrG^FnAd@b?`?R?N?D?B?@",
+> "&H~ydKW`AWN?gB?G", "&F~lQG{IB?_", "&G~tSrCO{D?oC", "&H~zNGg~AGN?gB?G",
+> "&G~u[bFocF?oC", "&H~yrMwrAGN?wB?G", "&G~t{zEocF?oC",
+> "&H~yhJw`BWH?wB?G", "&G~uk`FokF?oC", "&F~lqGcMB?_", "&F~kqG{IB?_",
+> "&G~sC~EocF?oC", "&F~lQG{IB?_", "&G~s[~EocF?oC", "&G~tKpCO{D?oC",
+> "&F~jrGcMB?_", "&I~|SrNCKNoR?{@OB?C", "&F~lQG{IB?_", "&F~irgcIB?_",
+> "&F~kqG{IB?_"];;
 gap> D := List(D, x -> DigraphFromDigraph6String(x));;
 gap> iso := [];; 
 gap> iso_distr := [];;
@@ -603,15 +645,16 @@ gap> for i in [1 .. Length(D)] do
 > od;
 
 # The total number of nonisomorphic digraphs generated, out of 100. 
-# It is known that there are 53 distinct lattices on 7 points according to OEIS A006966
+# There are 53 distinct lattices on 7 points according to OEIS A006966
 gap> Length(iso);
 41
 
-# The distribution of nonisomorhpic generated lattices. 
-# To the left is the number of times a particular lattice occurs among the randomly generated ones. 
-# To the right is how many distinct lattices have
-# this number of occurences.
-# So entry [3, 5] means that there were five distinct lattices each of which was generated 3 times.
+# The distribution of nonisomorhpic generated lattices.
+# To the left is the number of times a particular lattice occurs among the
+# randomly generated ones.
+# To the right is how many distinct lattices have # this number of occurrences.
+# So entry [3, 5] means that there were five distinct lattices each of which was
+# generated 3 times.
 gap> Display(Collected(iso_distr));
 [ [   1,  26 ],
   [   2,   7 ],
@@ -633,8 +676,12 @@ gap> Display(Collected(eq_distr));
   [  12,   1 ] ]
 
 #  Equals (\=) for two digraphs
-gap> r1 := rec(DigraphNrVertices := 2, DigraphSource := [1, 1, 2], DigraphRange := [1, 2, 2]);;
-gap> r2 := rec(DigraphNrVertices := 2, DigraphSource := [1, 1, 2], DigraphRange := [2, 1, 2]);;
+gap> r1 := rec(DigraphNrVertices := 2,
+>              DigraphSource     := [1, 1, 2],
+>              DigraphRange      := [1, 2, 2]);;
+gap> r2 := rec(DigraphNrVertices := 2,
+>              DigraphSource     := [1, 1, 2],
+>              DigraphRange      := [2, 1, 2]);;
 gap> gr1 := Digraph(r1);
 <immutable digraph with 2 vertices, 3 edges>
 gap> gr2 := Digraph(r2);
@@ -659,7 +706,9 @@ gap> gr1 = gr2;
 false
 gap> gr1 := Digraph([[], [], []]);
 <immutable empty digraph with 3 vertices>
-gap> gr2 := Digraph(rec(DigraphNrVertices := 3, DigraphSource := [], DigraphRange := []));
+gap> gr2 := Digraph(rec(DigraphNrVertices := 3,
+>                       DigraphSource     := [],
+>                       DigraphRange      := []));
 <immutable empty digraph with 3 vertices>
 gap> gr1 = gr2;
 true
@@ -705,8 +754,9 @@ gap> gr1 = gr5;
 true
 gap> graph1 := Digraph([[2], [1], []]);
 <immutable digraph with 3 vertices, 2 edges>
-gap> graph2 := Digraph(rec(
-> DigraphNrVertices := 3, DigraphSource := [1, 2], DigraphRange := [2, 1]));
+gap> graph2 := Digraph(rec(DigraphNrVertices := 3,
+>                          DigraphSource     := [1, 2],
+>                          DigraphRange      := [2, 1]));
 <immutable digraph with 3 vertices, 2 edges>
 gap> graph1 = graph2;
 true
@@ -727,35 +777,43 @@ true
 gap> gr1 = gr1;
 true
 gap> gr1 := Digraph([[2], []]);;
-gap> gr2 := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [], DigraphRange := []));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 1,
+>                       DigraphSource     := [],
+>                       DigraphRange      := []));;
 gap> gr1 = gr2;  # Different number of vertices
 false
-gap> gr2 := Digraph(rec(
-> DigraphNrVertices := 2, DigraphSource := [1, 2], DigraphRange := [1, 2]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 2,
+>                       DigraphSource     := [1, 2],
+>                       DigraphRange      := [1, 2]));;
 gap> gr1 = gr2;  # Different number of edges
 false
-gap> EmptyDigraph(2) =
-> Digraph(rec(DigraphNrVertices := 2, DigraphSource := [], DigraphRange := []));  # Both empty
+gap> EmptyDigraph(2) = Digraph(rec(DigraphNrVertices := 2,
+>                                  DigraphSource     := [],
+>                                  DigraphRange      := []));  # Both empty
 true
 gap> gr1 := Digraph([[], [1, 2]]);;
 gap> gr1 = gr2;  # |out1[1]| = 0, |out2[1]| <> =
 false
 gap> gr1 := Digraph([[1, 1], [2, 2]]);;
-gap> gr2 := Digraph(rec(
-> DigraphNrVertices := 2, DigraphSource := [1, 2, 2, 2], DigraphRange := [1, 2, 2, 2]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 2,
+>                       DigraphSource     := [1, 2, 2, 2],
+>                       DigraphRange      := [1, 2, 2, 2]));;
 gap> gr1 = gr2;  # |out1[1]| = 2, |out2[1]| = 1
 false
-gap> gr2 := Digraph(rec(
-> DigraphNrVertices := 2, DigraphSource := [1, 1, 1, 2], DigraphRange := [1, 1, 1, 2]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 2,
+>                       DigraphSource     := [1, 1, 1, 2],
+>                       DigraphRange      := [1, 1, 1, 2]));;
 gap> gr1 = gr2;  # |out1[1]| = 2, |out2[1]| = 3
 false
 gap> gr1 := Digraph([[1, 2], [2, 1]]);;
-gap> gr2 := Digraph(rec(
-> DigraphNrVertices := 2, DigraphSource := [1, 1, 2, 2], DigraphRange := [1, 2, 2, 2]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 2,
+>                       DigraphSource     := [1, 1, 2, 2],
+>                       DigraphRange      := [1, 2, 2, 2]));;
 gap> gr1 = gr2;  # Different contents of out[2]
 false
-gap> gr2 := Digraph(rec(
-> DigraphNrVertices := 2, DigraphSource := [1, 1, 2, 2], DigraphRange := [1, 2, 1, 2]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 2,
+>                       DigraphSource     := [1, 1, 2, 2],
+>                       DigraphRange      := [1, 2, 1, 2]));;
 gap> gr1 = gr2;  # out[2] sorted differently
 true
 gap> gr1 := Digraph(
@@ -774,7 +832,9 @@ gap> r2 :=
 >  10, 3, 9, 7, 6, 10, 9, 3, 5, 8, 4, 7, 1, 7, 4, 3, 8, 5, 10, 6, 9, 2,
 >  4, 8, 5, 9, 7, 1, 10, 6, 3, 2, 5, 8, 7, 10, 4, 9, 1, 5, 8, 3, 2, 1, 6,
 >  7, 10, 4, 4, 1, 5, 8, 3, 9, 7, 2, 6, 9, 6, 5, 7, 8, 10, 2, 3, 4];;
-gap> gr2 := Digraph(rec(DigraphNrVertices := 10, DigraphSource := s, DigraphRange := r2));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 10,
+>                       DigraphSource     := s,
+>                       DigraphRange      := r2));;
 gap> gr1 = gr2;
 true
 gap> gr1 := Digraph([[2], []]);;
@@ -786,8 +846,9 @@ gap> gr1 = gr2;  # Different number of edges
 false
 gap> EmptyDigraph(2) = Digraph([[], []]);  # Both empty digraphs
 true
-gap> gr1 := Digraph(rec(
-> DigraphNrVertices := 2, DigraphSource := [1, 2], DigraphRange := [1, 2]));;
+gap> gr1 := Digraph(rec(DigraphNrVertices := 2,
+>                       DigraphSource     := [1, 2],
+>                       DigraphRange      := [1, 2]));;
 gap> OutNeighbours(gr1);;
 gap> gr1 = gr2;  # Equal outneighbours
 true
@@ -828,34 +889,48 @@ gap> gr1 := RandomDigraph(10, 0.264);;
 gap> gr2 := Digraph(List(ShallowCopy(OutNeighbours(gr1)), Reversed));;
 gap> gr1 = gr2;
 true
-gap> gr1 := Digraph(rec(DigraphNrVertices := 0, DigraphSource := [], DigraphRange := []));;
+gap> gr1 := Digraph(rec(DigraphNrVertices := 0,
+>                       DigraphSource     := [],
+>                       DigraphRange      := []));;
 gap> gr1 = gr1;  # IsIdenticalObj
 true
-gap> gr2 := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [], DigraphRange := []));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 1,
+>                       DigraphSource     := [],
+>                       DigraphRange      := []));;
 gap> gr1 = gr2;  # Different number of vertices
 false
-gap> gr1 := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [1], DigraphRange := [1]));;
+gap> gr1 := Digraph(rec(DigraphNrVertices := 1,
+>                       DigraphSource     := [1],
+>                       DigraphRange      := [1]));;
 gap> gr1 = gr2;  # Different sources
 false
-gap> gr2 := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [1], DigraphRange := [1]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 1,
+>                       DigraphSource     := [1],
+>                       DigraphRange      := [1]));;
 gap> gr1 = gr2;  # Equal range
 true
-gap> gr1 := Digraph(rec(
-> DigraphNrVertices := 3, DigraphSource := [1, 2, 2, 3, 3], DigraphRange := [1, 1, 2, 2, 3]));;
-gap> gr2 := Digraph(rec(
-> DigraphNrVertices := 3, DigraphSource := [1, 2, 2, 3, 3], DigraphRange := [1, 2, 2, 3, 2]));;
+gap> gr1 := Digraph(rec(DigraphNrVertices := 3,
+>                       DigraphSource     := [1, 2, 2, 3, 3],
+>                       DigraphRange      := [1, 1, 2, 2, 3]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 3,
+>                       DigraphSource     := [1, 2, 2, 3, 3],
+>                       DigraphRange      := [1, 2, 2, 3, 2]));;
 gap> gr1 = gr2;  # Different contents of out[2]
 false
-gap> gr1 := Digraph(rec(
-> DigraphNrVertices := 3, DigraphSource := [1, 2, 2, 3, 3], DigraphRange := [1, 1, 2, 2, 3]));;
-gap> gr2 := Digraph(rec(
-> DigraphNrVertices := 3, DigraphSource := [1, 2, 2, 3, 3], DigraphRange := [1, 2, 1, 3, 3]));;
+gap> gr1 := Digraph(rec(DigraphNrVertices := 3,
+>                       DigraphSource     := [1, 2, 2, 3, 3],
+>                       DigraphRange      := [1, 1, 2, 2, 3]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 3,
+>                       DigraphSource     := [1, 2, 2, 3, 3],
+>                       DigraphRange      := [1, 2, 1, 3, 3]));;
 gap> gr1 = gr2;  # Different contents of out[3]
 false
-gap> gr1 := Digraph(rec(
-> DigraphNrVertices := 3, DigraphSource := [1, 2, 2, 3, 3], DigraphRange := [1, 1, 2, 2, 3]));;
-gap> gr2 := Digraph(rec(
-> DigraphNrVertices := 3, DigraphSource := [1, 2, 2, 3, 3], DigraphRange := [1, 2, 1, 3, 2]));;
+gap> gr1 := Digraph(rec(DigraphNrVertices := 3,
+>                       DigraphSource     := [1, 2, 2, 3, 3],
+>                       DigraphRange      := [1, 1, 2, 2, 3]));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 3,
+>                       DigraphSource     := [1, 2, 2, 3, 3],
+>                       DigraphRange      := [1, 2, 1, 3, 2]));;
 gap> gr1 = gr2;  # out[2] and out[3] sorted differently
 true
 gap> s :=
@@ -873,8 +948,12 @@ gap> r2 :=
 >  10, 3, 9, 7, 6, 10, 9, 3, 5, 8, 4, 7, 1, 7, 4, 3, 8, 5, 10, 6, 9, 2,
 >  4, 8, 5, 9, 7, 1, 10, 6, 3, 2, 5, 8, 7, 10, 4, 9, 1, 5, 8, 3, 2, 1, 6,
 >  7, 10, 4, 4, 1, 5, 8, 3, 9, 7, 2, 6, 9, 6, 5, 7, 8, 10, 2, 3, 4];;
-gap> gr1 := Digraph(rec(DigraphNrVertices := 10, DigraphSource := s, DigraphRange := r1));;
-gap> gr2 := Digraph(rec(DigraphNrVertices := 10, DigraphSource := s, DigraphRange := r2));;
+gap> gr1 := Digraph(rec(DigraphNrVertices := 10,
+>                       DigraphSource     := s,
+>                       DigraphRange      := r1));;
+gap> gr2 := Digraph(rec(DigraphNrVertices := 10,
+>                       DigraphSource     := s,
+>                       DigraphRange      := r2));;
 gap> gr1 = gr2;
 true
 
@@ -1057,7 +1136,8 @@ gap> SetDigraphVertexLabel(gr, 1, "w");
 gap> DigraphVertexLabels(DigraphCopy(gr))[1];
 "w"
 gap> gr := Digraph(rec(DigraphVertices := ["a", Group((1, 2))],
-> DigraphSource := [Group((1, 2))], DigraphRange := ["a"]));
+>                      DigraphSource   := [Group((1, 2))],
+>                      DigraphRange    := ["a"]));
 <immutable digraph with 2 vertices, 1 edge>
 gap> DigraphVertexLabels(gr);
 [ "a", Group([ (1,2) ]) ]
@@ -1490,14 +1570,22 @@ e number of edges in the reflexive transitive reduction of the second argument\
 , where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
 p homomorphism from group i to group j,
 gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
-> [[-2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+> [[-2, 1, hom21],
+>  [3, 1, hom31],
+>  [4, 1, hom41],
+>  [5, 2, hom52],
+>  [5, 3, hom53]]);;
 Error, Digraphs: AsSemigroup usage,
 the third argument must be a list of triples [i, j, hom] of length equal to th\
 e number of edges in the reflexive transitive reduction of the second argument\
 , where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
 p homomorphism from group i to group j,
 gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
-> [[2, -1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+> [[2, -1, hom21],
+>  [3, 1, hom31],
+>  [4, 1, hom41],
+>  [5, 2, hom52],
+>  [5, 3, hom53]]);;
 Error, Digraphs: AsSemigroup usage,
 the third argument must be a list of triples [i, j, hom] of length equal to th\
 e number of edges in the reflexive transitive reduction of the second argument\

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -55,8 +55,10 @@ gap> dot{[1 .. 50]};
 gap> dot{[51 .. 75]};
 "1\n1 -> 2\n1 -> 2\n1 -> 3\n}\n"
 gap> r := rec(DigraphVertices := [1 .. 8],
-> DigraphSource := [1, 1, 2, 2, 3, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 7, 7, 7, 7, 8, 8],
-> DigraphRange := [6, 7, 1, 6, 5, 1, 4, 8, 1, 3, 6, 6, 7, 7, 1, 4, 4, 5, 7, 5, 6]);;
+> DigraphSource := [1, 1, 2, 2, 3, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 7, 7, 7, 7, 8,
+>                   8],
+> DigraphRange  := [6, 7, 1, 6, 5, 1, 4, 8, 1, 3, 6, 6, 7, 7, 1, 4, 4, 5, 7, 5,
+>                   6]);;
 gap> gr1 := Digraph(r);
 <immutable multidigraph with 8 vertices, 21 edges>
 gap> DotDigraph(gr1){[50 .. 109]};
@@ -518,7 +520,9 @@ gap> Print(DotPreorderDigraph(gr){[1 .. 94]}, "\n");
 digraph graphname {
 node [shape=Mrecord, height=0.5, fixedsize=true]ranksep=1;
 1 [label=
-gap> gr := DigraphDisjointUnion(CompleteDigraph(10), CompleteDigraph(5), CycleDigraph(2));;
+gap> gr := DigraphDisjointUnion(CompleteDigraph(10),
+>                               CompleteDigraph(5),
+>                               CycleDigraph(2));;
 gap> gr := DigraphReflexiveTransitiveClosure(DigraphAddEdge(gr, [10, 11]));;
 gap> IsPreorderDigraph(gr);
 true

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -1099,21 +1099,22 @@ fail
 gap> DigraphEmbedding(gr1, gr1);
 IdentityTransformation
 gap> D := NullDigraph(2);;
-gap> DD := DigraphFromDiSparse6String(
-> ".~?C?_W@GN?e??@`W?wJ`cAG^?EG_@AEH?CacDWj@M??ga{Igq?WG_gbO?_J?}L_I_IFG~@?G_u_A\
-> AhBAiPOD`IB_QCEOxAck@HNB}KpK_KMhSBQ?`Hd[L?z`CIxY?}VOU`OGGteCVxHbcNXBd}JxO_uYo|\
-> bwVxmBiXxqEy\\ODf[SwOfwL`tgCOpncU`p~`e[WcA_JxYgsD@dg{Bpu`[bYRAc]hoHAd_BDIe@`hg\
-> Boed{ZwiaGOxFCs]HyeQ]XAbYL`}fmhogCSaYhEyTaR_?JAIdOYaTiwD@EEm@hFFObiqBSiYs@CQPK\
-> EaQWHBAMW]`Whw\\IIC?hAgPIKJQ[qjaciiTeYSP\\IWiXk_s[@pf?^BBa?SpkfiUwBAGRH[ck_zL@\
-> oJZNKq?PCGknHi_wciolS@O\\IuaGJLANx]LQD_]bW]J\\@_QPxK?uG@m?I_tCcnrDLMD@XKQLQ[b[\
-> cqX_?QA[e{]qlislBXjmGozLyXYTMQUQP_grj?aSkz^f{qrTiiQAtgWsrUhYXb@jsorreWbRCNAA_b\
-> IqSwxL}CQ_I_zru`sK@]GShrQNIziUes^K?`c?gSa?CGEaKDghAYEGkAmL_bbg@WHAyGHB?YPobcg@\
-> gHAuR_TdC?`D_KGhUAONxY@IVOC@IVpUDqVGkeKDW[B?KXf@MJGXdySg[e{YgfEiL`CCwSPUfKVpm`\
-> sH?ef[NgECY^?XfwB@u`SNiAEE[WD@uOiGCOSII@Y`Hk_W[yNDmGIQ?O\\iOeId_\\daCwOCgWGW@w\
-> Sp_hobyOb_]y_A{OpLhIJaO`wTydAOdhugQiPaikN@GIa\\HBGmJaIj?Xw@A?ZhC`ElOHj[@HsjgRA\
-> THqG@AF}PpJHyoQtkKM`bGenigk[oWNIokHH_{LaugGlbG_sJGZEkhWMA[gGPFusOcKEsoyEqtP~aG\
-> MPll_T`iKuBOWgIArIdAG@C`{PGGb]^Zb?ehwnKewWiLWwhPmUBjemsgGvIu{@RLIDrB`i{IQM]bBq\
-> cKyWLFcnzxKICIyKyEgI@g{XDeGbN");;
+gap> DD := DigraphFromDiSparse6String(Concatenation(
+> ".~?C?_W@GN?e??@`W?wJ`cAG^?EG_@AEH?CacDWj@M??ga{Igq?WG_gbO?_J?}L_I_IFG~@?",
+> "G_u_AAhBAiPOD`IB_QCEOxAck@HNB}KpK_KMhSBQ?`Hd[L?z`CIxY?}VOU`OGGteCVxHbcNXB",
+> "d}JxO_uYo|bwVxmBiXxqEy\\ODf[SwOfwL`tgCOpncU`p~`e[WcA_JxYgsD@dg{Bpu`[bYRAc",
+> "]hoHAd_BDIe@`hgBoed{ZwiaGOxFCs]HyeQ]XAbYL`}fmhogCSaYhEyTaR_?JAIdOYaTiwD@E",
+> "Em@hFFObiqBSiYs@CQPKEaQWHBAMW]`Whw\\IIC?hAgPIKJQ[qjaciiTeYSP\\IWiXk_s[@pf",
+> "?^BBa?SpkfiUwBAGRH[ck_zL@oJZNKq?PCGknHi_wciolS@O\\IuaGJLANx]LQD_]bW]J\\@_",
+> "QPxK?uG@m?I_tCcnrDLMD@XKQLQ[b[cqX_?QA[e{]qlislBXjmGozLyXYTMQUQP_grj?aSkz^",
+> "f{qrTiiQAtgWsrUhYXb@jsorreWbRCNAA_bIqSwxL}CQ_I_zru`sK@]GShrQNIziUes^K?`c?",
+> "gSa?CGEaKDghAYEGkAmL_bbg@WHAyGHB?YPobcg@gHAuR_TdC?`D_KGhUAONxY@IVOC@IVpUD",
+> "qVGkeKDW[B?KXf@MJGXdySg[e{YgfEiL`CCwSPUfKVpm`sH?ef[NgECY^?XfwB@u`SNiAEE[W",
+> "D@uOiGCOSII@Y`Hk_W[yNDmGIQ?O\\iOeId_\\daCwOCgWGW@wSp_hobyOb_]y_A{OpLhIJaO",
+> "`wTydAOdhugQiPaikN@GIa\\HBGmJaIj?Xw@A?ZhC`ElOHj[@HsjgRATHqG@AF}PpJHyoQtkK",
+> "M`bGenigk[oWNIokHH_{LaugGlbG_sJGZEkhWMA[gGPFusOcKEsoyEqtP~aGMPll_T`iKuBOW",
+> "gIArIdAG@C`{PGGb]^Zb?ehwnKewWiLWwhPmUBjemsgGvIu{@RLIDrB`i{IQM]bBqcKyWLFcn",
+> "zxKICIyKyEgI@g{XDeGbN"));;
 gap> DigraphEmbedding(D, DD);
 IdentityTransformation
 gap> D := DigraphDisjointUnion(CycleDigraph(3), CycleDigraph(5));;
@@ -1571,10 +1572,10 @@ gap> EmbeddingsDigraphsRepresentatives(NullDigraph(2),
 
 #
 gap> D1 := NullDigraph(2);;
-gap> D2 := DigraphFromDiSparse6String(
-> ".~?@c_oAN?xSA_XcBf?q^?YK?iooXja]oBJGlgZ_CLzgQoAn?kWjDIK[?P[c_qpNLM{{KFRMns`Wm\
-> tSNCuT^Z?a[rvOeCCdvGixXG`ZFc__AF?hKMg?IaGH]gGIAm?z?_lpGdmRUzMYQmoASkoKS]prafo[\
-> wws?[R_AcjsseVtaiXLcvXSwg`v@gfKBQ^KJc|n]D\\thb");;
+gap> D2 := DigraphFromDiSparse6String(Concatenation(
+> ".~?@c_oAN?xSA_XcBf?q^?YK?iooXja]oBJGlgZ_CLzgQoAn?kWjDIK[?P[c_qpNLM{",
+> "{KFRMns`WmtSNCuT^Z?a[rvOeCCdvGixXG`ZFc__AF?hKMg?IaGH]gGIAm?z?_lpGdmR",
+> "UzMYQmoASkoKS]prafo[wws?[R_AcjsseVtaiXLcvXSwg`v@gfKBQ^KJc|n]D\\thb"));;
 gap> DigraphMonomorphism(D1, D2);
 IdentityTransformation
 gap> D1 := CompleteDigraph(2);;
@@ -2287,9 +2288,11 @@ gap> gr1 := ChainDigraph(3);
 <immutable chain digraph with 3 vertices>
 gap> gr2 := ChainDigraph(6);
 <immutable chain digraph with 6 vertices>
-gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]), [1 .. 3], [1 .. 6]);
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]),
+> [1 .. 3], [1 .. 6]);
 true
-gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]), [1 .. 3], [1, 1, 2, 3, 4, 5]);   
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]),
+> [1 .. 3], [1, 1, 2, 3, 4, 5]);   
 false
 gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]),
 > [2, 2, 1], [2, 2, 1, 3, 4, 5]);
@@ -2375,9 +2378,11 @@ gap> src := Digraph([[1], [1, 2], [1, 3]]);
 <immutable digraph with 3 vertices, 5 edges>
 gap> ran := Digraph([[1], [1, 2]]);
 <immutable digraph with 2 vertices, 3 edges>
-gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]), [1, 2, 2], [1, 2]);
+gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]),
+> [1, 2, 2], [1, 2]);
 true
-gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]), [1, 2, 3], [1, 2]);
+gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]),
+> [1, 2, 3], [1, 2]);
 false
 gap> IsDigraphEpimorphism(src, src, Transformation([1, 2, 3]),
 >                         [1, 1, 2], [1, 1, 2]);

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -106,8 +106,9 @@ gap> str := Sparse6String(gr);
 ":~?Bf_O?_F"
 gap> DigraphFromSparse6String(str);
 <immutable digraph with 231 vertices, 4 edges>
-gap> gr := Digraph(rec(DigraphNrVertices := 2 ^ 17, DigraphSource := [1, 1, 3, 4, 10, 100],
-> DigraphRange := [3, 4, 1, 1, 100, 10]));
+gap> gr := Digraph(rec(DigraphNrVertices := 2 ^ 17,
+>                      DigraphSource     := [1, 1, 3, 4, 10, 100],
+>                      DigraphRange      := [3, 4, 1, 1, 100, 10]));
 <immutable digraph with 131072 vertices, 6 edges>
 gap> str := Sparse6String(gr);
 ":~_??_?A???_??_@b??H"
@@ -140,14 +141,16 @@ gap> str := DiSparse6String(gr);
 ".CgXoHe@J"
 gap> DigraphFromDiSparse6String(str) = gr;
 true
-gap> gr := Digraph(rec(DigraphNrVertices := 1617, DigraphSource := [1 .. 100],
-> DigraphRange := Concatenation([1 .. 50], [1 .. 50] * 0 + 51)));
+gap> gr := Digraph(rec(DigraphNrVertices := 1617,
+>        DigraphSource     := [1 .. 100],
+>        DigraphRange      := Concatenation([1 .. 50], [1 .. 50] * 0 + 51)));
 <immutable digraph with 1617 vertices, 100 edges>
 gap> str := DiSparse6String(gr);;
 gap> DigraphFromDiSparse6String(str) = gr;
 true
-gap> gr := Digraph(rec(DigraphNrVertices := 2 ^ 17, DigraphSource := [1 .. 100],
-> DigraphRange := Concatenation([50 .. 98], [-1050 .. -1000] * -1)));
+gap> gr := Digraph(rec(DigraphNrVertices := 2 ^ 17,
+>        DigraphSource := [1 .. 100],
+>        DigraphRange  := Concatenation([50 .. 98], [-1050 .. -1000] * -1)));
 <immutable digraph with 131072 vertices, 100 edges>
 gap> str := DiSparse6String(gr);;
 gap> DigraphFromDiSparse6String(str) = gr;
@@ -158,8 +161,9 @@ gap> str := DiSparse6String(gr);
 ".CgXo?eWCn"
 gap> gr = DigraphFromDiSparse6String(str);
 true
-gap> gr := Digraph(rec(DigraphNrVertices := 7890, DigraphSource := [1 .. 100] * 0 + 1000,
-> DigraphRange := [1 .. 100] * 0 + 2000));
+gap> gr := Digraph(rec(DigraphNrVertices := 7890,
+>                      DigraphSource     := [1 .. 100] * 0 + 1000,
+>                      DigraphRange      := [1 .. 100] * 0 + 2000));
 <immutable multidigraph with 7890 vertices, 100 edges>
 gap> str := DiSparse6String(gr);;
 gap> gr = DigraphFromDiSparse6String(str);
@@ -186,8 +190,9 @@ gap> ReadDigraphs(filename);
   <immutable digraph with 1000 vertices, 1000 edges>, 
   <immutable multidigraph with 5 vertices, 13 edges> ]
 gap> gr[1] := Digraph([[5], [1, 2, 5], [1], [2], [4]]);;
-gap> gr[2] := Digraph(rec(DigraphNrVertices := 105, DigraphSource := [1 .. 100],
-> DigraphRange := [1 .. 100] * 0 + 52));;
+gap> gr[2] := Digraph(rec(DigraphNrVertices := 105,
+>                         DigraphSource     := [1 .. 100],
+>                         DigraphRange      := [1 .. 100] * 0 + 52));;
 gap> gr[3] := EmptyDigraph(0);;
 gap> gr[4] := Digraph([[6, 7], [6, 9], [1, 3, 4, 5, 8, 9],
 > [1, 2, 3, 4, 5, 6, 7, 10], [1, 5, 6, 7, 10], [2, 4, 5, 9, 10],
@@ -208,8 +213,9 @@ IO_OK
 gap> gr[1] := Digraph([[5], [1, 2, 5], [1], [2], [4]]);;
 gap> DigraphGroup(gr[1]);
 Group(())
-gap> gr[2] := Digraph(rec(DigraphNrVertices := 105, DigraphSource := [1 .. 100],
-> DigraphRange := [1 .. 100] * 0 + 52));;
+gap> gr[2] := Digraph(rec(DigraphNrVertices := 105,
+>                         DigraphSource     := [1 .. 100],
+>                         DigraphRange      := [1 .. 100] * 0 + 52));;
 gap> gr[3] := EmptyDigraph(0);;
 gap> gr[4] := Digraph([[6, 7], [6, 9], [1, 3, 4, 5, 8, 9],
 > [1, 2, 3, 4, 5, 6, 7, 10], [1, 5, 6, 7, 10], [2, 4, 5, 9, 10],

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -335,8 +335,10 @@ Error, the 2nd argument <partition> is not a valid partition of the vertices [\
 1 .. 3] of the 1st argument <D>,
 gap> gr := Digraph(rec(
 > DigraphNrVertices := 8,
-> DigraphSource := [1, 1, 2, 2, 3, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 7, 7, 7, 7, 8, 8],
-> DigraphRange := [6, 7, 1, 6, 5, 1, 4, 8, 1, 3, 4, 6, 7, 7, 1, 4, 5, 6, 7, 5, 6]));
+> DigraphSource := [1, 1, 2, 2, 3, 4, 4, 4, 5, 5, 5, 5, 5, 6, 7, 7, 7, 7, 7, 8,
+>                   8],
+> DigraphRange := [6, 7, 1, 6, 5, 1, 4, 8, 1, 3, 4, 6, 7, 7, 1, 4, 5, 6, 7, 5,
+>                  6]));
 <immutable digraph with 8 vertices, 21 edges>
 gap> qr := QuotientDigraph(gr, [[1], [2, 3, 5, 7], [4, 6, 8]]);
 <immutable digraph with 3 vertices, 8 edges>
@@ -354,8 +356,9 @@ gap> DigraphOutEdges(gr, 5);
 Error, the 2nd argument <v> is not a vertex of the 1st argument <D>,
 gap> DigraphInEdges(gr, 1000);
 Error, the 2nd argument <v> is not a vertex of the 1st argument <D>,
-gap> gr := Digraph(rec(DigraphVertices := ["a", "b", "c"], DigraphSource := ["a", "a", "b"],
-> DigraphRange := ["b", "b", "c"]));
+gap> gr := Digraph(rec(DigraphVertices := ["a", "b", "c"],
+>                      DigraphSource   := ["a", "a", "b"],
+>                      DigraphRange    := ["b", "b", "c"]));
 <immutable multidigraph with 3 vertices, 3 edges>
 gap> DigraphInEdges(gr, 1);
 [  ]
@@ -427,7 +430,9 @@ gap> IsDigraphEdge(gr, [1000, 1]);
 true
 gap> IsDigraphEdge(gr, [1000, 600]);
 false
-gap> gr := Digraph(rec(DigraphNrVertices := 2, DigraphSource := [1], DigraphRange := [2]));
+gap> gr := Digraph(rec(DigraphNrVertices := 2,
+>                      DigraphSource     := [1],
+>                      DigraphRange      := [2]));
 <immutable digraph with 2 vertices, 1 edge>
 gap> IsDigraphEdge(gr, [2, 1]);
 false
@@ -593,7 +598,9 @@ gap> gr2 := DigraphAddVertices(gr, [SymmetricGroup(2), Group(())]);
 <immutable digraph with 3 vertices, 1 edge>
 gap> DigraphVertexLabels(gr2);
 [ Alt( [ 1 .. 5 ] ), Sym( [ 1 .. 2 ] ), Group(()) ]
-gap> gr := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [1], DigraphRange := [1]));
+gap> gr := Digraph(rec(DigraphNrVertices := 1,
+>                      DigraphSource     := [1],
+>                      DigraphRange      := [1]));
 <immutable digraph with 1 vertex, 1 edge>
 gap> gr2 := DigraphAddVertices(gr, 2);
 <immutable digraph with 3 vertices, 1 edge>
@@ -604,12 +611,16 @@ gap> gr2 := DigraphAddVertices(gr, 2);
 <immutable digraph with 3 vertices, 1 edge>
 gap> DigraphVertexLabels(gr2);
 [ true, 2, 3 ]
-gap> gr := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [1], DigraphRange := [1]));;
+gap> gr := Digraph(rec(DigraphNrVertices := 1,
+>                      DigraphSource     := [1],
+>                      DigraphRange      := [1]));;
 gap> gr2 := DigraphAddVertices(gr, [SymmetricGroup(2), Group(())]);
 <immutable digraph with 3 vertices, 1 edge>
 gap> DigraphVertexLabels(gr2);
 [ 1, Sym( [ 1 .. 2 ] ), Group(()) ]
-gap> gr := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [1], DigraphRange := [1]));;
+gap> gr := Digraph(rec(DigraphNrVertices := 1,
+>                      DigraphSource     := [1],
+>                      DigraphRange      := [1]));;
 gap> SetDigraphVertexLabels(gr, [AlternatingGroup(5)]);
 gap> gr2 := DigraphAddVertices(gr, [SymmetricGroup(2), Group(())]);
 <immutable digraph with 3 vertices, 1 edge>
@@ -1841,7 +1852,8 @@ gap> D;
 <mutable digraph with 5 vertices, 7 edges>
 
 # DigraphAddAllLoops - mutable
-gap> D := Digraph(IsMutableDigraph, [[1], [3, 4], [5, 6], [4, 2, 3], [4, 5], [1]]);
+gap> D := Digraph(IsMutableDigraph,
+> [[1], [3, 4], [5, 6], [4, 2, 3], [4, 5], [1]]);
 <mutable digraph with 6 vertices, 11 edges>
 gap> DigraphAddAllLoops(D);
 <mutable digraph with 6 vertices, 14 edges>
@@ -2001,7 +2013,8 @@ gap> DigraphCartesianProduct(D, D, D);
 <mutable digraph with 27 vertices, 81 edges>
 gap> D := DigraphMutableCopy(CycleDigraph(3));
 <mutable digraph with 3 vertices, 3 edges>
-gap> DigraphCartesianProduct(D, CycleDigraph(3), CycleDigraph(3), CycleDigraph(3));
+gap> DigraphCartesianProduct(
+> D, CycleDigraph(3), CycleDigraph(3), CycleDigraph(3));
 <mutable digraph with 81 vertices, 324 edges>
 gap> D := DigraphCartesianProduct(ChainDigraph(3), CycleDigraph(3));
 <immutable digraph with 9 vertices, 15 edges>

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -51,14 +51,18 @@ gap> IsMultiDigraph(gr2);
 false
 gap> source := [1 .. 10000];;
 gap> range := List(source, x -> Random(source));;
-gap> r := rec (DigraphVertices := [1 .. 10000], DigraphSource := source, DigraphRange := range);;
+gap> r := rec (DigraphVertices := [1 .. 10000],
+>              DigraphSource   := source,
+>              DigraphRange    := range);;
 gap> gr3 := Digraph(r);
 <immutable digraph with 10000 vertices, 10000 edges>
 gap> IsMultiDigraph(gr3);
 false
 gap> Add(source, 10000);;
 gap> Add(range, range[10000]);;
-gap> r := rec(DigraphVertices := [1 .. 10000], DigraphSource := source, DigraphRange := range);;
+gap> r := rec(DigraphVertices := [1 .. 10000],
+>             DigraphSource   := source,
+>             DigraphRange    := range);;
 gap> gr4 := Digraph(r);
 <immutable multidigraph with 10000 vertices, 10001 edges>
 gap> IsMultiDigraph(gr4);
@@ -75,14 +79,18 @@ gap> IsMultiDigraph(loop);
 false
 gap> IsAcyclicDigraph(loop);
 false
-gap> r := rec(DigraphVertices := [1, 2], DigraphSource := [1, 1], DigraphRange := [2, 2]);;
+gap> r := rec(DigraphVertices := [1, 2],
+>             DigraphSource   := [1, 1],
+>             DigraphRange    := [2, 2]);;
 gap> multiple := Digraph(r);
 <immutable multidigraph with 2 vertices, 2 edges>
 gap> IsMultiDigraph(multiple);
 true
 gap> IsAcyclicDigraph(multiple);
 true
-gap> r := rec(DigraphVertices := [1 .. 100], DigraphSource := [], DigraphRange := []);;
+gap> r := rec(DigraphVertices := [1 .. 100],
+>             DigraphSource   := [],
+>             DigraphRange    := []);;
 gap> for i in [1 .. 100] do
 >   for j in [1 .. 100] do
 >     Add(r.DigraphSource, i);
@@ -95,7 +103,9 @@ gap> IsMultiDigraph(complete100);
 false
 gap> IsAcyclicDigraph(complete100);
 false
-gap> r := rec(DigraphVertices := [1 .. 20000], DigraphSource := [], DigraphRange := []);;
+gap> r := rec(DigraphVertices := [1 .. 20000],
+>             DigraphSource   := [],
+>             DigraphRange    := []);;
 gap> for i in [1 .. 9999] do
 >   Add(r.DigraphSource, i);
 >   Add(r.DigraphRange, i + 1);
@@ -234,8 +244,9 @@ gap> g6 := Digraph([[1, 2, 4], [1, 3], [2, 3, 4], [3, 1]]);
 <immutable digraph with 4 vertices, 10 edges>
 gap> IsSymmetricDigraph(g6);
 true
-gap> gr := Digraph(rec(DigraphNrVertices := 3, DigraphSource := [1, 1, 2, 2, 2, 2, 3, 3],
-> DigraphRange := [2, 2, 1, 1, 3, 3, 2, 2]));;
+gap> gr := Digraph(rec(DigraphNrVertices := 3,
+>                      DigraphSource     := [1, 1, 2, 2, 2, 2, 3, 3],
+>                      DigraphRange      := [2, 2, 1, 1, 3, 3, 2, 2]));;
 gap> IsSymmetricDigraph(gr);
 true
 gap> D := Digraph([[2], [3], [2]]);;
@@ -265,10 +276,12 @@ false
 
 #  IsAntisymmetricDigraph
 gap> gr := Digraph(rec(DigraphNrVertices := 10,
-> DigraphSource := [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 6,
->  6, 6, 6, 6, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 9, 9, 9, 9, 10, 10, 10, 10, 10],
-> DigraphRange := [2, 4, 6, 10, 3, 5, 7, 4, 7, 1, 9, 10, 4, 6, 9, 8, 4, 3, 7, 1, 6,
->  8, 2, 3, 9, 7, 10, 9, 4, 1, 8, 9, 3, 1, 4, 2, 5, 2, 1, 10, 5, 6, 2, 4, 8]));
+>  DigraphSource := [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 5,
+>                    5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 9, 9,
+>                    9, 9, 10, 10, 10, 10, 10],
+>  DigraphRange  := [2, 4, 6, 10, 3, 5, 7, 4, 7, 1, 9, 10, 4, 6, 9, 8, 4, 3, 7,
+>                    1, 6, 8, 2, 3, 9, 7, 10, 9, 4, 1, 8, 9, 3, 1, 4, 2, 5, 2,
+>                    1, 10, 5, 6, 2, 4, 8]));
 <immutable digraph with 10 vertices, 45 edges>
 gap> IsAntisymmetricDigraph(gr);
 true
@@ -298,11 +311,14 @@ gap> IsAntisymmetricDigraph(gr);
 false
 
 #  IsEmptyDigraph
-gap> gr1 := Digraph(rec(DigraphNrVertices := 5, DigraphSource := [], DigraphRange := []));;
+gap> gr1 := Digraph(rec(DigraphNrVertices := 5,
+>                       DigraphSource     := [],
+>                       DigraphRange      := []));;
 gap> IsEmptyDigraph(gr1);
 true
-gap> gr2 :=
-> Digraph(rec(DigraphVertices := [1 .. 6], DigraphSource := [6], DigraphRange := [1]));;
+gap> gr2 := Digraph(rec(DigraphVertices := [1 .. 6],
+>                       DigraphSource   := [6],
+>                       DigraphRange    := [1]));;
 gap> IsEmptyDigraph(gr2);
 false
 gap> gr3 := DigraphNC([[], [], [], []]);;
@@ -321,8 +337,9 @@ gap> IsEmptyDigraph(gr6);
 false
 
 #  IsTournament
-gap> gr := Digraph(rec(
-> DigraphNrVertices := 2, DigraphSource := [1, 1], DigraphRange := [2, 2]));
+gap> gr := Digraph(rec(DigraphNrVertices := 2,
+>                      DigraphSource     := [1, 1],
+>                      DigraphRange      := [2, 2]));
 <immutable multidigraph with 2 vertices, 2 edges>
 gap> IsTournament(gr);
 false
@@ -562,15 +579,21 @@ gap> gr := Digraph([[6, 7], [6, 9], [1, 2, 4, 5, 8, 9],
 <immutable multidigraph with 10 vertices, 55 edges>
 gap> DigraphHasLoops(gr);
 false
-gap> gr := Digraph(rec(DigraphNrVertices := 0, DigraphSource := [], DigraphRange := []));
+gap> gr := Digraph(rec(DigraphNrVertices := 0,
+>                      DigraphSource     := [],
+>                      DigraphRange      := []));
 <immutable empty digraph with 0 vertices>
 gap> DigraphHasLoops(gr);
 false
-gap> gr := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [], DigraphRange := []));
+gap> gr := Digraph(rec(DigraphNrVertices := 1,
+>                      DigraphSource     := [],
+>                      DigraphRange      := []));
 <immutable empty digraph with 1 vertex>
 gap> DigraphHasLoops(gr);
 false
-gap> gr := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [1], DigraphRange := [1]));
+gap> gr := Digraph(rec(DigraphNrVertices := 1,
+>                      DigraphSource     := [1],
+>                      DigraphRange      := [1]));
 <immutable digraph with 1 vertex, 1 edge>
 gap> DigraphHasLoops(gr);
 true
@@ -579,8 +602,8 @@ gap> r := rec(DigraphNrVertices := 10,
 > [1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6,
 >  6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 9, 9, 9, 10, 10, 10, 10,
 >  10, 10],
-> DigraphRange := [6, 7, 6, 9, 1, 2, 4, 5, 8, 9, 1, 2, 3, 4, 5, 6, 7, 10, 1, 5, 6,
->  7, 10, 2, 4, 5, 9, 10, 3, 4, 5, 6, 7, 8, 9, 10, 1, 3, 5, 7, 8, 9, 1, 2, 5,
+> DigraphRange := [6, 7, 6, 9, 1, 2, 4, 5, 8, 9, 1, 2, 3, 4, 5, 6, 7, 10, 1, 5,
+>  6, 7, 10, 2, 4, 5, 9, 10, 3, 4, 5, 6, 7, 8, 9, 10, 1, 3, 5, 7, 8, 9, 1, 2, 5,
 >  1, 2, 4, 6, 7, 8]);;
 gap> gr := Digraph(r);
 <immutable digraph with 10 vertices, 51 edges>
@@ -1196,27 +1219,29 @@ true
 
 # Big partial order digraph
 gap> gr := DigraphFromDiSparse6String(Concatenation(
-> ".~?CI_A?WA_M@G@_G@gB?]@?G_SAWA?Y@oJ__BGH?uA_M_IAoO_oCWL@IB_R_{DGB?mB?U_sDwM@",
-> "aBoX_KCGP@WEwQ@[FGR@_FWS@cFgT@gFwB@A?oO_KCGZACGwZAGGw[AUFOcAYF_f`{IG_Ae@?U`[",
-> "IwWAqEOl`gJgC@mF?jBAFOkBEF_lBIFomBMG?nBQ@?ZAE@?ZAI@?ZAMH?oBWMGdB?LowaWKOya[K",
-> "_xBmI?rBqIOsBuI_tBy@?`AMH?uCA@?aaOHOuB[OgCAIHOvCQ@?baOM@?CYMP@C]HOwCYMOyCKPp",
-> "HbgPPHbkQw{CgRG|C_RW}CyNpN_SIwkDEJPQawSwnDQ@OobCSPUbGS`VbKSpWbOT@XbSTPY_SK?u",
-> "_SK?v_SK?wbcT`[DyM`UDsVgzD[WG{D_Vp`bsUPabwU`bb{Upc_SL`?bcOP[EY@OvCIMOyCKV@\\",
-> "Ea@OvCQM`DDsYgDB_PgxC[V`kc_VpfEuM`HDwZHID{W@hEsZxJE?YpncoWPpcsW`oFIR`bEw[xNE",
-> "O\\HOES\\WDC?Ph@C[X`vc_Xpw_SOhBEWY@yc_Q`fEc]wDCQH@DE_Y`|cgQphEk^gDCQPPiGAQpj",
-> "GE@PEc[Z@vGMQ@lF_`HmFc`XHEo_xIEsZqCG]Z`oFo`QGckZqFf?[P~G_ahpGGahqGq[qJGu\\AH",
-> "Gy\\QEG}\\aO_G@gF@?cgGAKcwHCWdGIGKdWA_KCAV`CeGQACeWRAOegSC[ewTGOfG`AGeGBH]Ga",
-> "WH}@?bHaH?dC?Oa]IEHQ_IEHaba[gaca_OQdacQAeag`QfcCOqa_OeA^aCO`CI?ihBCSgabIm@A^",
-> "cOgAlcSgqm_SPa`c[QPvFggaoc_Q`wFkiQpccgqocgQqkJCkxJI{kxKJURQsJYRaqJ]RpxJaSAEJ",
-> "e?qQaGcqzaSdA{ccdQ|g[da}hcigQCGoHBHkoXIHooiGHsoy^i?ialKU@Q`IiH@yFsgqjK]grEK]",
-> "hBHa[oRGKiI@zISobJfohrKgciBL_OmxCJorxDJssHJJwsYIJ{sgDIgjZ?LQC`|LU^aZKCth~KKt",
-> "yJKOuGDK}_BOLi_RPLm_bQLqbBRLu@gPHKvweJswHKLGwYLLwwgDIuCaVMAHqZH{wRdcsjRBMGxi",
-> "MLcwrcM]GP|G?jbELQ_AmMQjRDkWtBcMmxBja_fa_KSxhMI[iqmKWxrjMybrMM_yRiMozRncC]p}",
-> "IoqH}GCganMeOamKYOqnK_qRhNMjbEMmO`|MgzBtmgzRti{qRkNUyzkMs|Rxms}XNIcjAnM{{rtN",
-> "e_QnMg|YOJg{BpNG|BuN[}ByNk~B|fc^Aqfo^qqJO{XzNG|H~GGlAtNG|H}K_|bwNu^RvNi_atN_",
-> "~ZvN_}b|n[}bznmcR}N|?C@OH?sCOT@cFObAiQ@ECgR`QDWaaSOgea]IGhaiOxCcUQPycg]xJcqR",
-> "XMc}SH{fsgx}f}_I@gI`yGgeaiJgqbYMg}cIPheeiZhqfYciUhifiajinjMlItjYlywjemj?kEoj",
-> "BkQqZIkmrJLkytZUl]uJXmkyjrNI}Rv"));
+> ".~?CI_A?WA_M@G@_G@gB?]@?G_SAWA?Y@oJ__BGH?uA_M_IAoO_oCWL@IB_R_{DGB?mB",
+> "?U_sDwM@aBoX_KCGP@WEwQ@[FGR@_FWS@cFgT@gFwB@A?oO_KCGZACGwZAGGw[AUFOcAY",
+> "F_f`{IG_Ae@?U`[IwWAqEOl`gJgC@mF?jBAFOkBEF_lBIFomBMG?nBQ@?ZAE@?ZAI@?ZA",
+> "MH?oBWMGdB?LowaWKOya[K_xBmI?rBqIOsBuI_tBy@?`AMH?uCA@?aaOHOuB[OgCAIHOv",
+> "CQ@?baOM@?CYMP@C]HOwCYMOyCKPpHbgPPHbkQw{CgRG|C_RW}CyNpN_SIwkDEJPQawSw",
+> "nDQ@OobCSPUbGS`VbKSpWbOT@XbSTPY_SK?u_SK?v_SK?wbcT`[DyM`UDsVgzD[WG{D_V",
+> "p`bsUPabwU`bb{Upc_SL`?bcOP[EY@OvCIMOyCKV@\\Ea@OvCQM`DDsYgDB_PgxC[V`kc",
+> "_VpfEuM`HDwZHID{W@hEsZxJE?YpncoWPpcsW`oFIR`bEw[xNEO\\HOES\\WDC?Ph@C[X",
+> "`vc_Xpw_SOhBEWY@yc_Q`fEc]wDCQH@DE_Y`|cgQphEk^gDCQPPiGAQpjGE@PEc[Z@vGM",
+> "Q@lF_`HmFc`XHEo_xIEsZqCG]Z`oFo`QGckZqFf?[P~G_ahpGGahqGq[qJGu\\AHGy\\Q",
+> "EG}\\aO_G@gF@?cgGAKcwHCWdGIGKdWA_KCAV`CeGQACeWRAOegSC[ewTGOfG`AGeGBH]",
+> "GaWH}@?bHaH?dC?Oa]IEHQ_IEHaba[gaca_OQdacQAeag`QfcCOqa_OeA^aCO`CI?ihBC",
+> "SgabIm@A^cOgAlcSgqm_SPa`c[QPvFggaoc_Q`wFkiQpccgqocgQqkJCkxJI{kxKJURQs",
+> "JYRaqJ]RpxJaSAEJe?qQaGcqzaSdA{ccdQ|g[da}hcigQCGoHBHkoXIHooiGHsoy^i?ia",
+> "lKU@Q`IiH@yFsgqjK]grEK]hBHa[oRGKiI@zISobJfohrKgciBL_OmxCJorxDJssHJJws",
+> "YIJ{sgDIgjZ?LQC`|LU^aZKCth~KKtyJKOuGDK}_BOLi_RPLm_bQLqbBRLu@gPHKvweJs",
+> "wHKLGwYLLwwgDIuCaVMAHqZH{wRdcsjRBMGxiMLcwrcM]GP|G?jbELQ_AmMQjRDkWtBcM",
+> "mxBja_fa_KSxhMI[iqmKWxrjMybrMM_yRiMozRncC]p}IoqH}GCganMeOamKYOqnK_qRh",
+> "NMjbEMmO`|MgzBtmgzRti{qRkNUyzkMs|Rxms}XNIcjAnM{{rtNe_QnMg|YOJg{BpNG|B",
+> "uN[}ByNk~B|fc^Aqfo^qqJO{XzNG|H~GGlAtNG|H}K_|bwNu^RvNi_atN_~ZvN_}b|n[}",
+> "bznmcR}N|?C@OH?sCOT@cFObAiQ@ECgR`QDWaaSOgea]IGhaiOxCcUQPycg]xJcqRXMc}",
+> "SH{fsgx}f}_I@gI`yGgeaiJgqbYMg}cIPheeiZhqfYciUhifiajinjMlItjYlywjemj?k",
+> "EojBkQqZIkmrJLkytZUl]uJXmkyjrNI}Rv"));
 <immutable digraph with 266 vertices, 919 edges>
 gap> gr := DigraphReflexiveTransitiveClosure(gr);
 <immutable preorder digraph with 266 vertices, 10772 edges>


### PR DESCRIPTION
I have been slightly annoyed on occasion by long lines when looking in test files, so I just shortened them all to get it over and done with. It would be nice if the linter enforced line lengths on test files so they don't creep back in.

~~In the process of doing this, I discovered some commented-out tests in `tst/standard/display.tst` that I guess predate the Semigroups package requiring Digraphs, and Semigroups had its own copy of `Splash`?.~~

~~Everything seems fine with Semigroups loaded on my end. So reinstating these might improve our code coverage!~~