### PR TITLE
init: only define GRAPE variables when undefined

### DIFF
--- a/init.g
+++ b/init.g
@@ -27,9 +27,14 @@ fi;
 BindGlobal("DIGRAPHS_IsGrapeLoaded",
            IsPackageMarkedForLoading("grape", "4.8.1"));
 
-if not DIGRAPHS_IsGrapeLoaded then
+# To avoid warnings when GRAPE is not loaded
+if not IsBound(IsGraph) then
   IsGraph := ReturnFalse;
+fi;
+if not IsBound(Vertices) then
   Vertices := IdFunc;
+fi;
+if not IsBound(Adjacency) then
   Adjacency := IdFunc;
 fi;
 


### PR DESCRIPTION
This should remove one of the two remaining incompatibilities between Digraphs and YAGS; see https://github.com/yags/yags/issues/1#issuecomment-780504933.