### PR TITLE
100% code coverage for gap/attr.gi and associated small fixes and tweaks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,4 +12,10 @@ comment:
   behavior: default
 
 ignore:
- - "extern"         # Do not check coverage on the extern directory
+ - "extern/"
+ - "gap/utils.gi"
+ - "PackageInfo.g"
+ - "init.g"
+ - "makedoc.g"
+ - "read.g"
+ - "tst/testall.g"

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -978,7 +978,7 @@ function(digraph)
   fi;
   oddgirth := infinity;
   for comp in comps do
-    if comps > 1 then
+    if Length(comps) > 1 then  # i.e. if not IsStronglyConnectedDigraph(digraph)
       gr := InducedSubdigraph(digraph, comp);
     else
       gr := digraph;

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1451,18 +1451,6 @@ end);
 InstallMethod(CharacteristicPolynomial, "for a digraph", [IsDigraph],
 D -> CharacteristicPolynomial(AdjacencyMatrix(D)));
 
-InstallMethod(IsVertexTransitive, "for a digraph", [IsDigraph],
-D -> IsTransitive(AutomorphismGroup(D), DigraphVertices(D)));
-
-InstallMethod(IsEdgeTransitive, "for a digraph", [IsDigraph],
-function(D)
-  if IsMultiDigraph(D) then
-    ErrorNoReturn("the argument <D> must be a digraph with no multiple",
-                  " edges,");
-  fi;
-  return IsTransitive(AutomorphismGroup(D), DigraphEdges(D), OnPairs);
-end);
-
 # Things that are attributes for immutable digraphs, but operations for mutable.
 
 # Don't use InstallMethodThatReturnsDigraph since we can do better in this case.

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1217,6 +1217,12 @@ gap> for i in [1 .. 10] do
 > od;
 gap> DigraphOddGirth(D);
 7
+gap> D := DigraphFromDigraph6String("&IWsC_A?_PG_GDKC?cO");
+<immutable digraph with 10 vertices, 22 edges>
+gap> DigraphGirth(D);
+2
+gap> DigraphOddGirth(D);
+3
 
 # DigraphMycielskian
 gap> D1 := DigraphSymmetricClosure(CycleDigraph(2));
@@ -1368,6 +1374,13 @@ gap> gr := MaximalSymmetricSubdigraphWithoutLoops(gr);
 <immutable symmetric digraph with 3 vertices, 4 edges>
 gap> OutNeighbours(gr);
 [ [ 2, 3 ], [ 1 ], [ 1 ] ]
+gap> D := Digraph(IsImmutableDigraph, [[2, 2], [1]]);
+<immutable multidigraph with 2 vertices, 3 edges>
+gap> DigraphRemoveAllMultipleEdges(D);;
+gap> HasDigraphRemoveAllMultipleEdgesAttr(D);
+true
+gap> IsCompleteDigraph(MaximalSymmetricSubdigraph(D));
+true
 
 #  RepresentativeOutNeighbours
 gap> gr := CycleDigraph(5);
@@ -1574,6 +1587,8 @@ fail
 gap> forest := UndirectedSpanningForest(gr);
 fail
 gap> UndirectedSpanningForest(EmptyDigraph(IsMutableDigraph, 0));
+fail
+gap> UndirectedSpanningTree(ChainDigraph(IsMutableDigraph, 4));
 fail
 gap> gr := EmptyDigraph(1);
 <immutable empty digraph with 1 vertex>
@@ -2047,6 +2062,13 @@ gap> MaximalAntiSymmetricSubdigraph(D);
 <immutable antisymmetric digraph with 10 vertices, 45 edges>
 gap> MaximalAntiSymmetricSubdigraph(D);
 <immutable antisymmetric digraph with 10 vertices, 45 edges>
+gap> D := Digraph(IsImmutableDigraph, [[2, 2], [1]]);
+<immutable multidigraph with 2 vertices, 3 edges>
+gap> DigraphRemoveAllMultipleEdges(D);;
+gap> HasDigraphRemoveAllMultipleEdgesAttr(D);
+true
+gap> IsChainDigraph(MaximalAntiSymmetricSubdigraph(D));
+true
 
 # CharacteristicPolynomial
 gap> gr := Digraph([
@@ -2156,6 +2178,11 @@ gap> DigraphTransitiveReduction(gr);
 Error, not yet implemented for non-topologically sortable digraphs,
 gap> DigraphReflexiveTransitiveReduction(gr);
 Error, not yet implemented for non-topologically sortable digraphs,
+gap> D := Digraph(IsImmutableDigraph, [[1, 2, 3], [3], [3]]);;
+gap> DigraphRemoveLoops(D);; HasDigraphRemoveLoopsAttr(D);
+true
+gap> DigraphReflexiveTransitiveReduction(D) = ChainDigraph(3);
+true
 
 # Working examples
 gap> gr1 := ChainDigraph(6);
@@ -2531,6 +2558,14 @@ gap> D := DigraphByAdjacencyMatrix([
 <immutable multidigraph with 3 vertices, 7 edges>
 gap> DigraphNrLoops(D);
 3
+gap> D := CompleteDigraph(IsImmutableDigraph, 3);
+<immutable complete digraph with 3 vertices>
+gap> DigraphHasLoops(D);
+false
+gap> HasDigraphHasLoops(D) and not DigraphHasLoops(D);
+true
+gap> DigraphNrLoops(D) = 0;
+true
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1234,6 +1234,12 @@ gap> gr2 := DigraphAddAllLoops(gr);
 <immutable reflexive multidigraph with 5 vertices, 15 edges>
 gap> OutNeighbours(gr2);
 [ [ 1, 2, 3 ], [ 2, 2, 2, 2 ], [ 5, 1, 3 ], [ 1, 2, 3, 4 ], [ 5 ] ]
+gap> D := Digraph(IsImmutableDigraph,
+> [[1, 3], [2, 1, 5], [3, 4], [2, 3, 4], [5, 1]]);;
+gap> IsReflexiveDigraph(D);
+true
+gap> IsIdenticalObj(D, DigraphAddAllLoops(D));
+true
 
 # ConvertToImmutableDigraphNC
 gap> record := rec(OutNeighbours := [[1, 2], []]);


### PR DESCRIPTION
The individual changes are described in the commit messages.
* codecov: ignore root `*.g` files, `tst/testall.g`, and `gap/utils.gi`.
* `attr.gi`: remove duplicate `IsVertexTransitive` and `IsEdgeTransitive` methods.
* `attr.gi`: fix `if` statement in `DigraphOddGirth`.
* 100% code coverage in `attr.gi`.