### PR TITLE
Resolve Issue #413 (OutNeighbours performance)

### DIFF
--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -18,7 +18,7 @@ DeclareAttribute("DigraphNrLoops", IsDigraph);
 
 DeclareAttribute("DigraphRange", IsDigraph);
 DeclareAttribute("DigraphSource", IsDigraph);
-DeclareGlobalFunction("OutNeighbors", OutNeighbours);
+DeclareGlobalFunction("OutNeighbors");
 DeclareAttribute("InNeighbours", IsDigraph);
 DeclareSynonymAttr("InNeighbors", InNeighbours);
 DeclareAttribute("DigraphAdjacencyFunction", IsDigraph);

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -18,8 +18,7 @@ DeclareAttribute("DigraphNrLoops", IsDigraph);
 
 DeclareAttribute("DigraphRange", IsDigraph);
 DeclareAttribute("DigraphSource", IsDigraph);
-DeclareAttribute("OutNeighbours", IsDigraph);
-DeclareSynonymAttr("OutNeighbors", OutNeighbours);
+DeclareGlobalFunction("OutNeighbors", OutNeighbours);
 DeclareAttribute("InNeighbours", IsDigraph);
 DeclareSynonymAttr("InNeighbors", InNeighbours);
 DeclareAttribute("DigraphAdjacencyFunction", IsDigraph);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -11,6 +11,8 @@
 InstallMethod(DigraphNrVertices, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep], DIGRAPH_NR_VERTICES);
 
+InstallGlobalFunction(OutNeighbors, OutNeighbours);
+
 # The next method is (yet another) DFS which simultaneously computes:
 # 1. *articulation points* as described in
 #   https://www.eecs.wsu.edu/~holder/courses/CptS223/spr08/slides/graphapps.pdf

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -11,9 +11,6 @@
 InstallMethod(DigraphNrVertices, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep], DIGRAPH_NR_VERTICES);
 
-InstallMethod(OutNeighbours, "for a digraph by out-neighbours",
-[IsDigraphByOutNeighboursRep], DIGRAPH_OUT_NEIGHBOURS);
-
 # The next method is (yet another) DFS which simultaneously computes:
 # 1. *articulation points* as described in
 #   https://www.eecs.wsu.edu/~holder/courses/CptS223/spr08/slides/graphapps.pdf

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -87,7 +87,7 @@ Obj FuncOutNeighbours(Obj self, Obj D) {
     RNamOutNeighbours = RNamName("OutNeighbours");
   }
   if (!CALL_1ARGS(IsDigraph, D)) {
-    ErrorQuit("the expected a digraph, not a %s", (Int) TNAM_OBJ(D), 0L);
+    ErrorQuit("expected a digraph, not a %s", (Int) TNAM_OBJ(D), 0L);
   } else if (IsbPRec(D, RNamOutNeighbours)) {
     return ElmPRec(D, RNamOutNeighbours);
   } else {

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -86,7 +86,9 @@ Obj FuncOutNeighbours(Obj self, Obj D) {
   if (!RNamOutNeighbours) {
     RNamOutNeighbours = RNamName("OutNeighbours");
   }
-  if (IsbPRec(D, RNamOutNeighbours)) {
+  if (!CALL_1ARGS(IsDigraph, D)) {
+    ErrorQuit("the expected a digraph, not a %s", (Int) TNAM_OBJ(D), 0L);
+  } else if (IsbPRec(D, RNamOutNeighbours)) {
     return ElmPRec(D, RNamOutNeighbours);
   } else {
     ErrorQuit(
@@ -2127,7 +2129,7 @@ static StructGVarFunc GVarFuncs[] = {
      FuncDIGRAPH_SOURCE_RANGE,
      "src/digraphs.c:FuncDIGRAPH_SOURCE_RANGE"},
 
-    {"DIGRAPH_OUT_NEIGHBOURS",
+    {"OutNeighbours",
      1,
      "D",
      FuncOutNeighbours,


### PR DESCRIPTION
This PR makes `OutNeighbours` a function rather than an attribute, to avoid the performance penalty of the return value being copied for mutable digraphs. This might not be desirable, but I can't think why it isn't at the moment, and the fact that the test all run after this change at least partially indicates that it might be desirable. 

This resolves both #413 and #318.