### PR TITLE
Codecov integration: replace the PR comment by PR statuses

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,14 +2,20 @@ coverage:
   precision: 2      # Report coverage to 2 decimal places
   round: down       # Round down
   range: "90...100" # Anything below 90% is coloured red (considered bad)
-  status:           # Various customisations that it seems should be off
-    project: off
-    patch: off
-    changes: off
 
-comment:
-  layout: "header, diff, changes, tree"
-  behavior: default
+  status: # GitHub status checks to add to a PR
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+    changes:
+      default:
+        informational: true
+
+# Comment to post on PRs
+comment: false
 
 ignore:
  - "extern/"


### PR DESCRIPTION
See the 'status' bit at the bottom of this PR for the new look (it may not appear immediately, until a CI job has finished). This has the advantage that you don't get email notifications of the Codecov comment, which always initially show that code coverage has declined (even when it hasn't, once all the jobs are complete).

If we want, we eventually can make some or all of these checks be 'required' ones in order for a PR to be merged.