### PR TITLE
Copy immutable lists given to `SetDigraphVertexLabels` (Issue #414)

### DIFF
--- a/doc/labels.xml
+++ b/doc/labels.xml
@@ -24,8 +24,8 @@
     <A>i</A>. <P/>
 
     If <A>digraph</A> is a digraph created from a record with a component
-    <C>vertices</C>, then the labels of the vertices are set to the value of
-    this component.<P/>
+    <C>DigraphVertices</C>, then the labels of the vertices are set to
+    the value of this component.<P/>
 
     Induced subdigraphs, and some other operations which create new digraphs from
     old ones, inherit their labels from their parents.

--- a/doc/labels.xml
+++ b/doc/labels.xml
@@ -71,15 +71,23 @@ gap> DigraphVertexLabel(D, 1);
     copy of the labels of the vertices in <A>digraph</A>.
     <C>SetDigraphVertexLabels</C> can be used to set the labels of the vertices
     in <A>digraph</A> to the list of
-    arbitrary &GAP; objects <A>list</A>. <P/>
+    arbitrary &GAP; objects <A>list</A>, which must be of the same length
+    as the number of vertices of <A>digraph</A>. <P/>
+
+    If the list <A>list</A> is immutable, then the vertex labels are set to a
+    mutable copy of <A>list</A>. Otherwise, the labels are set to exactly
+    <A>list</A>. <P/>
 
     The label of a vertex can be changed an arbitrary number of times. If no
     label has been set for the vertex <A>i</A>, then the default value is
     <A>i</A>. <P/>
 
     If <A>digraph</A> is a digraph created from a record with a component
-    <C>vertices</C>, then the labels of the vertices are set to the value of
-    this component.<P/>
+    <C>DigraphVertices</C>, then the labels of the vertices are set to the
+    value of this component. As in the above, if the component is immutable
+    then the digraph's vertex labels are set to a mutable copy of
+    <C>DigraphVertices</C>. Otherwise, they are set to exactly
+    <C>DigraphVertices</C>. <P/>
 
     Induced subdigraphs, and other operations which create new digraphs from
     old ones, inherit their labels from their parents.

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -61,6 +61,9 @@ function(D, names)
                   "to the number of vertices of the digraph <D> that is the ",
                   "1st argument,");
   fi;
+  if not IsMutable(names) then
+    names := ShallowCopy(names);
+  fi;
   D!.vertexlabels := names;
 end);
 

--- a/tst/standard/labels.tst
+++ b/tst/standard/labels.tst
@@ -79,6 +79,12 @@ gap> DigraphVertexLabels(gr);
 [ 1, 3, 4, 5, 6, 7, 8, 9, 10 ]
 gap> D := NullDigraph(5);;
 gap> RemoveDigraphVertexLabel(D, 6);
+gap> A := Immutable([1, 2]);
+[ 1, 2 ]
+gap> D := CycleDigraph(2);
+<immutable cycle digraph with 2 vertices>
+gap> SetDigraphVertexLabels(D, A);
+gap> SetDigraphVertexLabel(D, 2, "b");
 
 #  DigraphEdgeLabels
 gap> gr := Digraph([[2, 3], [3], [1, 5], [], [4]]);


### PR DESCRIPTION
This PR fixes issue #414, per the discussion with @james-d-mitchell and @wilfwilson.

When calling `SetDigraphVertexLabels` with an immutable list, the list is replaced with a mutable copy of itself, so that a digraph's vertex labels can't be immutable.