### PR TITLE
Update GitHub actions integration

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -1,32 +1,12 @@
-name: "CI"
-
-# Trigger the workflow on push or pull request
-on:
-  pull_request:
-  push:
-    branches-ignore:
-      - rc-v[0-9]+.[0-9]+.[0-9]+
+name: "Digraphs tests"
+on: [push, pull_request]
 
 jobs:
-  lint:
-    name: "lint"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        name: "Check out the repository"
-      - uses: actions/setup-python@v1
-        name: "Set up Python"
-      - uses: BSFishy/pip-action@v1
-        name: "Install gaplint and cpplint with pip"
-        with:
-          packages: |
-            gaplint
-            cpplint
-      - name: "Run gaplint + cpplint"
-        run: bash etc/lint.sh
   test:
     name: "GAP ${{ matrix.gap-branch }}"
     runs-on: ubuntu-latest
+    # Don't run this twice for PRs from branches in the same repository
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap-for-packages@v1
+        name: "Install GAP and clone/compile necessary packages"
         with:
           GAP_PKGS_TO_CLONE: "${{ matrix.pkgs-to-clone }}"
           GAP_PKGS_TO_BUILD: "io orb profiling grape NautyTracesInterface datastructures"
@@ -52,3 +33,4 @@ jobs:
              && curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${DIGRAPHS_LIB}.tar.gz"
              && tar xf "${DIGRAPHS_LIB}.tar.gz"
       - uses: gap-actions/run-test-for-packages@v1
+        name: "Run tst/testall.g"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: "linting"
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: "${{ matrix.linter }}"
+    runs-on: ubuntu-latest
+    # Don't run this twice for PRs from branches in the same repository
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        linter:
+          - gaplint
+          - cpplint
+    steps:
+    - name: "Check out the repository"
+      uses: actions/checkout@v2
+    - name: "Set up Python"
+      uses: actions/setup-python@v1
+    - name: "Install ${{ matrix.linter }} with pip"
+      run: pip install ${{ matrix.linter }}
+    - name: "Run ${{ matrix.linter }} on the Digraphs package"
+      run: bash etc/${{ matrix.linter }}.sh
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -124,7 +124,8 @@ doc/manual.six: doc/*.xml PackageInfo.g
 	($(GAPROOT)/bin/gap.sh -A makedoc.g)
 
 lint:
-	etc/lint.sh
+	etc/gaplint.sh
+	etc/cpplint.sh
 
 format:
 	clang-format -i src/*.[hc]

--- a/etc/cpplint.sh
+++ b/etc/cpplint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cpplint src/*.[ch]

--- a/etc/gaplint.sh
+++ b/etc/gaplint.sh
@@ -4,4 +4,3 @@ set -e
 gaplint --disable W004 *.g gap/*
 gaplint --disable W004 doc/*.xml
 gaplint --disable W004 tst/testinstall.tst tst/standard/*.tst tst/extreme/*.tst tst/workspaces/*.tst
-cpplint src/*.[ch]


### PR DESCRIPTION
This does two things:

1. It implements the linting job along the lines of what Semigroups now does (although, see `.github/workflows/lint.yml`, it perhaps does it a slightly nicer way, combining the two jobs with one matrix).
2. It adds a new `if:` command to the workflows to skip some duplicate jobs on PRs. This means that when a PR is made from a branch in the same repository (e.g. this happens with our `rc-v1.4.1` branches), then the jobs are not run twice (as both a pushed branch, and as a PR). In particular, this skips the jobs associated with the PR, and keeps the jobs for the push. Previously we handled this case with an exception for `rc-v[0-9]+.[0-9]+.[0-9]+` branches, but this is a general solution for any name of branch.
The result is not completely pretty, but [it looks reasonable I think](https://github.com/wilfwilson/Digraphs/pull/1); see https://github.com/wilfwilson/Digraphs/pull/1:

<img width="938" alt="Screen Shot 2021-03-03 at 17 18 36" src="https://user-images.githubusercontent.com/8956868/109845073-a868e880-7c44-11eb-8a19-b7fe265462d5.png">
