### PR TITLE
doc: fix typo in the doc

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -83,7 +83,7 @@ gap> DigraphNrVertices(D);
     <P/>
 
     The entries of <C>DigraphEdges(</C><A>digraph</A><C>)</C> are in one-to-one
-    corresponence with the edges of <A>digraph</A>.  Hence
+    correspondence with the edges of <A>digraph</A>.  Hence
     <C>DigraphEdges(</C><A>digraph</A><C>)</C> is duplicate-free if and only if
     <A>digraph</A> contains no multiple edges. <P/>
 
@@ -1956,7 +1956,7 @@ gap> D;
     and the reverse edge <C>[j,i]</C> is an edge of <A>digraph</A>.
     In other words, for every
     symmetric pair of edges <C>[i,j]</C> and <C>[j,i]</C> in <A>digraph</A>, where 
-    <C>i</C> and <C>j</C> are distinct, it discards the the edge
+    <C>i</C> and <C>j</C> are distinct, it discards the edge
     <M>[\max(i,j),\min(i,j)]</M>.
     <P/>
 

--- a/doc/cliques.xml
+++ b/doc/cliques.xml
@@ -147,7 +147,7 @@ true]]></Example>
         <C>DigraphMaximalClique</C> greedily enlarge the clique <A>include</A>
         until it cannot continue.  The result is guaranteed to be a maximal
         clique. This may or may not return an answer more quickly than using
-        <Ref Func="DigraphMaximalCliques"/>.  with a limit of 1.
+        <Ref Func="DigraphMaximalCliques"/> with a limit of 1.
       </Item>
       <Mark>Three arguments</Mark>
       <Item>
@@ -348,7 +348,7 @@ gap> DigraphMaximalCliques(D);
         independent set <A>include</A> until it cannot continue.  The result
         is guaranteed to be a maximal independent set. This may or may not
         return an answer more quickly than using <Ref
-          Func="DigraphMaximalIndependentSets"/>.  with a limit of 1.
+          Func="DigraphMaximalIndependentSets"/> with a limit of 1.
       </Item>
       <Mark>Three arguments</Mark>
       <Item>

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -205,7 +205,7 @@
       <Mark>for a binary relation</Mark>
       <Item>
         if <A>obj</A> is a binary relation on the points <C>[1 .. n]</C> for
-        some posititve integer <M>n</M>, then this function returns the digraph
+        some positive integer <M>n</M>, then this function returns the digraph
         defined by <A>obj</A>. Specifically, this function returns a digraph
         which has <M>n</M> vertices, and which has an edge with source <C>i</C>
         and range <C>j</C> if and only if <C>[i,j]</C> is a pair in


### PR DESCRIPTION
Fix some misspellings and other heinous errors in the manual. 