### PR TITLE
Fix CI: get latest package versions slightly more robustly, via the GitHub API

### DIFF
--- a/ci/docker-test.sh
+++ b/ci/docker-test.sh
@@ -142,7 +142,7 @@ for PKG in "${PKGS[@]}"; do
 
   # Get the relevant version number
   if [ "${PACKAGES[0]}" == "latest" ] || [ "$PKG" == "profiling" ]; then
-    VERSION=`$CURL -s "https://github.com/gap-packages/$PKG/releases/latest" | grep \<title\>Release | awk -F' ' '{print $2}'`
+    VERSION=`$CURL -s "https://api.github.com/repos/gap-packages/${PKG}/releases" | grep tag_name | head -n 1 | awk -F'"' '{print $4}'`
   else
     VERSION=`grep "\"$PKG\"" $GAP_HOME/pkg/digraphs/PackageInfo.g | awk -F'"' '{print $4}' | cut -c3-`
   fi
@@ -150,6 +150,8 @@ for PKG in "${PKGS[@]}"; do
   if [ -z $VERSION ]; then
     bold "Could not determine the version number of the package $PKG!! Aborting..."
     exit 1
+  elif [ "${VERSION:0:1}" == "v" ]; then
+    VERSION=${VERSION:1}
   fi
 
   URL="https://github.com/gap-packages/$PKG/releases/download/v$VERSION/$PKG-$VERSION.tar.gz"

--- a/scripts/travis-build-dependencies.sh
+++ b/scripts/travis-build-dependencies.sh
@@ -74,7 +74,7 @@ for PKG in "${PKGS[@]}"; do
 
   # Get the relevant version number
   if [ "${PACKAGES[0]}" == "latest" ] || [ "$PKG" == "profiling" ]; then
-    VERSION=`$CURL -s "https://github.com/gap-packages/$PKG/releases/latest" | grep \<title\>Release | awk -F' ' '{print $2}'`
+    VERSION=`$CURL -s "https://api.github.com/repos/gap-packages/${PKG}/releases" | grep tag_name | head -n 1 | awk -F'"' '{print $4}'`
   else
     VERSION=`grep "\"$PKG\"" $GAPROOT/pkg/digraphs/PackageInfo.g | awk -F'"' '{print $4}' | cut -c3-`
   fi
@@ -82,6 +82,8 @@ for PKG in "${PKGS[@]}"; do
   if [ -z $VERSION ]; then
     echo -e "\nCould not determine the version number of the package $PKG!! Aborting..."
     exit 1
+  elif [ "${VERSION:0:1}" == "v" ]; then
+    VERSION=${VERSION:1}
   fi
 
   URL="https://github.com/gap-packages/$PKG/releases/download/v$VERSION/$PKG-$VERSION.tar.gz"


### PR DESCRIPTION
Previously we were scraping the webpage of package releases. No we're at least scraping the API page for the package releases, which is hopefully slightly less likely to change.

(Ultimately this could be done much more robustly by properly interacting with the GitHub API, but that would take time, and here's a quick fix, hopefully!)

It's also not good that some of the CI scripts are essentially duplicated between Appveyor and Azure Pipelines. Unifying them, or abandoning Appveyor (possibly in favour of Cwygin in GitHub Actions) would be a good idea imo.