### PR TITLE
Fix DigraphCore

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1349,6 +1349,12 @@ function(digraph)
   elif IsCompleteDigraph(digraph) then
     return DigraphVertexLabels(digraph);
   elif IsSymmetricDigraph(digraph) and IsBipartiteDigraph(digraph) then
+    # TODO symmetric is not necessary, you just need bipartite and:
+    # DigraphGirth(digraph) = 2
+    # i.e. not IsAntiSymmetricDigraph(digraph)
+    # i.e. a pair [i, j] with edges i -> j and j -> i.
+    # Given this, the core is [i, j]
+    # This would allow you to <return 3> rather than <return 2> in function <lo>
     i := First(DigraphVertices(digraph),
                i -> OutDegreeOfVertex(digraph, i) > 0);
     return DigraphVertexLabels(digraph){
@@ -1394,7 +1400,7 @@ function(digraph)
     if oddgirth <> infinity then
       return oddgirth;
     fi;
-    return 3;
+    return 2;
   end;
 
   hom      := [];

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2024,6 +2024,17 @@ gap> for i in [1 .. 9] do
 >    od;
 gap> DigraphCore(D);
 [ 1, 2 ]
+gap> D := DigraphFromDigraph6String("&G?_cO`EO?@??");
+<immutable digraph with 8 vertices, 10 edges>
+gap> DigraphCore(D);
+[ 2, 5 ]
+gap> D := DigraphFromDigraph6String("&GSY??A?SA?O?");
+<immutable digraph with 8 vertices, 10 edges>
+gap> DigraphCore(D);
+[ 1, 2 ]
+gap> D := Digraph([[2], [1, 3], []]);;
+gap> DigraphCore(D);
+[ 1, 2 ]
 
 # MaximalAntiSymmetricSubdigraph
 gap> MaximalAntiSymmetricSubdigraph(Digraph([[2, 2], [1]]));


### PR DESCRIPTION
See #436.

The generic part of the method for `DigraphCore` assumes a lower bound of there being three vertices in the core.

The core can't contain only one vertex, since this can only happen when the digraph is either empty, or has a loop - but by the time the generic part of the method is encountered, these cases have been excluded. However, I don't see a good reason to rule out the core having only two vertices.

In any case, changing the default lower bound from should not affect mathematical correctness of results - the only problem is that we're widening the search size for the core. But the test cases that I've added show that this is necessary, anyway (at least in general).