### PR TITLE
ViewString: special case for trees and forests

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -2144,7 +2144,7 @@ gap> D := Digraph([[1, 2, 1, 3], [1], [4], [3, 4, 3]]);
 gap> UndirectedSpanningTree(D);
 fail
 gap> forest := UndirectedSpanningForest(D);
-<immutable symmetric digraph with 4 vertices, 4 edges>
+<immutable undirected forest digraph with 4 vertices, 4 edges>
 gap> OutNeighbours(forest);
 [ [ 2 ], [ 1 ], [ 4 ], [ 3 ] ]
 gap> IsUndirectedSpanningForest(D, forest);
@@ -2159,7 +2159,7 @@ true
 gap> D := CompleteDigraph(4);
 <immutable complete digraph with 4 vertices>
 gap> tree := UndirectedSpanningTree(D);
-<immutable symmetric digraph with 4 vertices, 6 edges>
+<immutable undirected tree digraph with 4 vertices>
 gap> IsUndirectedSpanningTree(D, tree);
 true
 gap> tree = UndirectedSpanningForest(D);

--- a/doc/examples.xml
+++ b/doc/examples.xml
@@ -654,13 +654,13 @@ ent sizes 5 and 5>
     See also <Ref Oper="StarDigraph"/> and <Ref Prop="IsUndirectedTree"/>.
 <Example><![CDATA[
 gap> D := BananaTree(2, 4);
-<immutable connected symmetric digraph with 9 vertices, 16 edges>
+<immutable undirected tree digraph with 9 vertices>
 gap> D := BananaTree(3, 3);
-<immutable connected symmetric digraph with 10 vertices, 18 edges>
+<immutable undirected tree digraph with 10 vertices>
 gap> D := BananaTree(5, 2);
-<immutable connected symmetric digraph with 11 vertices, 20 edges>
+<immutable undirected tree digraph with 11 vertices>
 gap> D := BananaTree(3, 4);
-<immutable connected symmetric digraph with 13 vertices, 24 edges>
+<immutable undirected tree digraph with 13 vertices>
 ]]></Example>
   </Description>
 </ManSection>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1436,7 +1436,7 @@ false
 gap> DigraphShortestPathSpanningTree(D, 1);
 fail
 gap> tree := DigraphShortestPathSpanningTree(D, 5);
-<immutable digraph with 5 vertices, 4 edges>
+<immutable directed tree digraph with 5 vertices>
 gap> OutNeighbours(tree);
 [ [  ], [ 3 ], [  ], [ 1 ], [ 2, 4 ] ]
 gap> ForAll(DigraphVertices(D), v ->

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2093,6 +2093,7 @@ InstallMethod(UndirectedSpanningTree, "for an immutable digraph",
 InstallMethod(UndirectedSpanningTreeAttr, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
+  local out;
   if DigraphNrVertices(D) = 0
       or not IsStronglyConnectedDigraph(D)
       or (HasMaximalSymmetricSubdigraphAttr(D)
@@ -2101,7 +2102,9 @@ function(D)
           <> 2 * (DigraphNrVertices(D) - 1)) then
     return fail;
   fi;
-  return UndirectedSpanningForest(D);
+  out := UndirectedSpanningForest(D);
+  SetIsUndirectedTree(out, true);
+  return out;
 end);
 
 InstallMethod(DigraphMycielskian, "for a digraph",

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -479,6 +479,14 @@ function(D)
       Append(str, "join semilattice ");
     elif HasIsMeetSemilatticeDigraph(D) and IsMeetSemilatticeDigraph(D) then
       Append(str, "meet semilattice ");
+    elif HasIsUndirectedTree(D) and IsUndirectedTree(D) then
+      Append(str, "undirected tree ");
+      display_nredges := false;
+    elif HasIsUndirectedForest(D) and IsUndirectedForest(D) then
+      Append(str, "undirected forest ");
+    elif HasIsDirectedTree(D) and IsDirectedTree(D) then
+      Append(str, "directed tree ");
+      display_nredges := false;
     else
       if HasIsEulerianDigraph(D) and IsEulerianDigraph(D) then
         Append(str, "Eulerian ");

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -70,6 +70,7 @@ InstallTrueMethod(IsAcyclicDigraph, IsTournament and IsTransitiveDigraph);
 InstallTrueMethod(IsAntisymmetricDigraph, IsAcyclicDigraph);
 InstallTrueMethod(IsAntisymmetricDigraph, IsTournament);
 InstallTrueMethod(IsBipartiteDigraph, IsCompleteBipartiteDigraph);
+InstallTrueMethod(IsBipartiteDigraph, IsUndirectedForest);
 InstallTrueMethod(IsCompleteMultipartiteDigraph, IsCompleteBipartiteDigraph);
 InstallTrueMethod(IsConnectedDigraph, IsBiconnectedDigraph);
 InstallTrueMethod(IsConnectedDigraph, IsStronglyConnectedDigraph);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1631,7 +1631,7 @@ true
 gap> D := DigraphFromDigraph6String("&I~~~~^Znn~|~~x^|v{");
 <immutable digraph with 10 vertices, 89 edges>
 gap> tree := UndirectedSpanningTree(D);
-<immutable symmetric digraph with 10 vertices, 18 edges>
+<immutable undirected tree digraph with 10 vertices>
 gap> IsUndirectedSpanningTree(D, tree);
 true
 gap> tree := UndirectedSpanningTree(DigraphMutableCopy(D));

--- a/tst/standard/examples.tst
+++ b/tst/standard/examples.tst
@@ -336,13 +336,13 @@ true
 
 # BananaTree
 gap> D := BananaTree(2, 4);
-<immutable connected symmetric digraph with 9 vertices, 16 edges>
+<immutable undirected tree digraph with 9 vertices>
 gap> D := BananaTree(3, 3);
-<immutable connected symmetric digraph with 10 vertices, 18 edges>
+<immutable undirected tree digraph with 10 vertices>
 gap> D := BananaTree(5, 2);
-<immutable connected symmetric digraph with 11 vertices, 20 edges>
+<immutable undirected tree digraph with 11 vertices>
 gap> D := BananaTree(3, 4);
-<immutable connected symmetric digraph with 13 vertices, 24 edges>
+<immutable undirected tree digraph with 13 vertices>
 gap> D := BananaTree(0, 0);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `BananaTree' on 2 arguments


### PR DESCRIPTION
I realised that undirected trees and forests didn't know that they were bipartite, so I've added this implication via an `InstallTrueMethod`. `UndirectedSpanningTree`s also didn't know that they were undirected trees, so I've added this too.

It then became a bit weird that these digraphs would be shown as `<immutable bipartite symmetric connected  digraph...>` or something like that.

The `ViewString`s now say "...forest digraph..." and "...tree digraph..." - should I drop the 'digraph'? I thought it best to keep it in, so that it's clear to a user that these are digraph objects, but I'm not strongly of that opinion.