### PR TITLE
Improve ChromaticNumber with Brooks' theorem

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -178,7 +178,7 @@ InstallMethod(ChromaticNumber, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 function(D)
   local nr, comps, upper, chrom, tmp_comps, tmp_upper, n, comp, bound, clique,
-  c, i;
+  c, i, greedy_bound, brooks_bound;
   nr := DigraphNrVertices(D);
 
   if DigraphHasLoops(D) then
@@ -196,12 +196,17 @@ function(D)
   D := DigraphMutableCopy(D);
   D := DigraphRemoveAllMultipleEdges(D);
   D := DigraphSymmetricClosure(D);
+  MakeImmutable(D);
 
   if IsCompleteDigraph(D) then
     # chromatic number = nr iff <D> has >= 2 verts & this cond.
     return nr;
   elif nr = 4 then
     # if nr = 4, then 3 is only remaining possible chromatic number
+    return 3;
+  elif 2 * nr = DigraphNrEdges(D)
+      and IsRegularDigraph(D) and Length(OutNeighboursOfVertex(D, 1)) = 2 then
+    # <D> is an odd-length cycle graph
     return 3;
   fi;
 
@@ -215,7 +220,9 @@ function(D)
   # do not yet know.
   if IsConnectedDigraph(D) then
     comps := [D];
-    upper := [RankOfTransformation(DigraphGreedyColouring(D), nr)];
+    greedy_bound := RankOfTransformation(DigraphGreedyColouring(D), nr);
+    brooks_bound := Maximum(OutDegrees(D));  # Brooks' theorem
+    upper := [Minimum(greedy_bound, brooks_bound)];
     chrom := Maximum(CliqueNumber(D), chrom);
   else
     tmp_comps := [];
@@ -238,8 +245,12 @@ function(D)
           # If comp is bipartite, then its chromatic number is 2, and, since
           # the chromatic number of D is >= 3, this component can be
           # ignored.
-          bound := RankOfTransformation(DigraphGreedyColouring(comp),
-                                        DigraphNrVertices(comp));
+          greedy_bound := RankOfTransformation(DigraphGreedyColouring(comp),
+                                               DigraphNrVertices(comp));
+          # Don't need to take odd cycles into account for Brooks' theorem,
+          # since they are 3-colourable and the chromatic number of D is >= 3.
+          brooks_bound := Maximum(OutDegrees(comp));
+          bound := Minimum(greedy_bound, brooks_bound);
           if bound > chrom then
             # If bound <= chrom, then comp can be coloured by at most chrom
             # colours, and so we can ignore comp.

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1536,6 +1536,17 @@ gap> ChromaticNumber(a);
 49
 gap> ChromaticNumber(b);
 49
+gap> D := DigraphFromGraph6String("ElNG");
+<immutable digraph with 6 vertices, 18 edges>
+gap> ChromaticNumber(D);
+3
+gap> IsSymmetricDigraph(D) and IsRegularDigraph(D) and OutDegreeSet(D) = [3];
+true
+gap> IsBiconnectedDigraph(D);
+true
+gap> D := Digraph(OutNeighbours(CycleDigraph(13)));;
+gap> ChromaticNumber(D);
+3
 
 #  DegreeMatrix
 gap> gr := Digraph([[2, 3, 4], [2, 5], [1, 5, 4], [1], [1, 1, 2, 4]]);;


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Brooks'_theorem:
> For any connected undirected graph G with maximum degree Δ, the chromatic number of G is at most Δ, unless G is a complete graph or an odd cycle, in which case the chromatic number is Δ + 1

The greedy colouring algorithm can sometimes give Δ + 1 as an upper bound  (and maybe more?) when Brooks' theorem gives us just Δ. So let's take the minimum of the two in `ChromaticNumber`.