### PR TITLE
Improve ViewStrings/TrueMethods for tournaments/cycle digraphs

### DIFF
--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -562,7 +562,8 @@ function(D)
     Append(str, "multi");
   fi;
 
-  if HasIsTournament(D) and IsTournament(D) and n > 1 then
+  if not (HasIsCycleDigraph(D) and IsCycleDigraph(D))
+      and HasIsTournament(D) and IsTournament(D) and n > 1 then
     Append(str, "tournament ");
     display_nredges := false;
   else

--- a/gap/examples.gi
+++ b/gap/examples.gi
@@ -243,21 +243,19 @@ InstallMethod(CycleDigraphCons,
 function(filt, n)
   local D;
   D := MakeImmutable(CycleDigraphCons(IsMutableDigraph, n));
-  if n = 1 then
-    SetIsTransitiveDigraph(D, true);
-    SetDigraphHasLoops(D, true);
-  else
-    SetIsTransitiveDigraph(D, false);
-    SetDigraphHasLoops(D, false);
-  fi;
   SetIsAcyclicDigraph(D, false);
   SetIsCycleDigraph(D, true);
   SetIsEmptyDigraph(D, false);
   SetIsMultiDigraph(D, false);
   SetDigraphNrEdges(D, n);
-  SetIsFunctionalDigraph(D, true);
-  SetIsStronglyConnectedDigraph(D, true);
+  SetIsTournament(D, n = 3);
+  SetIsTransitiveDigraph(D, n = 1);
   SetAutomorphismGroup(D, CyclicGroup(IsPermGroup, n));
+  SetDigraphHasLoops(D, n = 1);
+  SetIsBipartiteDigraph(D, n mod 2 = 0);
+  if n > 1 then
+    SetChromaticNumber(D, 2 + (n mod 2));
+  fi;
   return D;
 end);
 

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -74,6 +74,9 @@ InstallTrueMethod(IsBipartiteDigraph, IsUndirectedForest);
 InstallTrueMethod(IsCompleteMultipartiteDigraph, IsCompleteBipartiteDigraph);
 InstallTrueMethod(IsConnectedDigraph, IsBiconnectedDigraph);
 InstallTrueMethod(IsConnectedDigraph, IsStronglyConnectedDigraph);
+InstallTrueMethod(IsFunctionalDigraph, IsCycleDigraph);
+InstallTrueMethod(IsHamiltonianDigraph,
+                  IsTournament and IsStronglyConnectedDigraph);
 InstallTrueMethod(IsInRegularDigraph, IsRegularDigraph);
 InstallTrueMethod(IsOutRegularDigraph, IsRegularDigraph);
 InstallTrueMethod(IsPreorderDigraph, IsPartialOrderDigraph);
@@ -81,6 +84,7 @@ InstallTrueMethod(IsRegularDigraph, IsInRegularDigraph and IsOutRegularDigraph);
 InstallTrueMethod(IsRegularDigraph, IsVertexTransitive);
 InstallTrueMethod(IsStronglyConnectedDigraph,
                   IsConnectedDigraph and IsSymmetricDigraph);
+InstallTrueMethod(IsStronglyConnectedDigraph, IsCycleDigraph);
 InstallTrueMethod(IsStronglyConnectedDigraph, IsEulerianDigraph);
 InstallTrueMethod(IsStronglyConnectedDigraph, IsHamiltonianDigraph);
 InstallTrueMethod(IsStronglyConnectedDigraph, IsUndirectedTree);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -19,8 +19,8 @@ D -> IsDirectedTree(D) and IsSubset([0, 1], OutDegreeSet(D)));
 InstallMethod(IsCycleDigraph, "for a digraph", [IsDigraph],
 function(D)
   return DigraphNrVertices(D) > 0
-     and IsStronglyConnectedDigraph(D)
-     and DigraphNrEdges(D) = DigraphNrVertices(D);
+     and DigraphNrEdges(D) = DigraphNrVertices(D)
+     and IsStronglyConnectedDigraph(D);
 end);
 
 InstallMethod(IsBiconnectedDigraph, "for a digraph", [IsDigraph],


### PR DESCRIPTION
* Some properties were set to be true in the `CycleDigraph` creation function that should rather be `TrueMethods` for all things satisfying `IsCycleDigraph`.
* Strongly connected tournaments are Hamiltonian.
* Stop the `ViewString` '`<(im)mutable cycle tournament with 3 vertices>`' from happening: I think `<(im)mutable cycle digraph with 3 vertices>` is already specific enough, I think.
* Test the number of edges in `IsCycleDigraph` before testing strong connectivity, as it should be the cheaper test.