### PR TITLE
Implement several new graph products

### DIFF
--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1932,7 +1932,7 @@ gap> DigraphDijkstra(D, 1, 2);
   <Description>
   If <A>D1</A> and <A>D2</A> are digraphs without multiple edges, then
   <C>ModularProduct</C> calculates the <E>modular product digraph</E>
-  (<C>MPD</C>) of <A>D1</A>and <A>D2</A>.
+  (<C>MPD</C>) of <A>D1</A> and <A>D2</A>.
 
   <C>MPD</C> has vertex set <C>V1 x V2</C> where <C>V1</C> is the vertex set of
   <A>D1</A> and <C>V2</C> is the vertex set of <A>D2</A> (a vertex
@@ -1958,7 +1958,8 @@ gap> ModularProduct(Digraph([[1], [1, 2]]), Digraph([[], [2]]));
 <immutable digraph with 4 vertices, 4 edges>
 gap> OutNeighbours(last);
 [ [ 4 ], [ 2, 3 ], [  ], [ 4 ] ]
-gap> ModularProduct(PetersenGraph(), DigraphSymmetricClosure(CycleDigraph(5)));
+gap> ModularProduct(PetersenGraph(),
+> DigraphSymmetricClosure(CycleDigraph(5)));
 <immutable digraph with 50 vertices, 950 edges>
 gap> ModularProduct(NullDigraph(0), CompleteDigraph(10));
 <immutable empty digraph with 0 vertices>
@@ -1966,6 +1967,164 @@ gap> ModularProduct(NullDigraph(0), CompleteDigraph(10));
 </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="StrongProduct">
+<ManSection>
+  <Oper Name="StrongProduct" Arg="D1, D2"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+  If <A>D1</A> and <A>D2</A> are digraphs without multiple edges,
+  then <C>StrongProduct</C> calculates the <E>strong product digraph</E>
+  (<C>SPD</C>) of <A>D1</A> and <A>D2</A>.
+
+  <C>SPD</C> has vertex set <C>V1 x V2</C> where <C>V1</C> is the vertex set of
+  <A>D1</A> and <C>V2</C> is the vertex set of <A>D2</A> (a vertex
+  <C>[a, b]</C> has label <C>(a - 1) * |V2| + b</C> in the  output). There is
+  an edge from <C>[a, b]</C> to <C>[c, d]</C> when at least one of the
+  following three conditions are satisfied:
+  <List>
+    <Item>
+      The vertices <C>a</C> and <C>c</C> of <A>D1</A> are equal and there is
+      an edge from <C>b</C> to <C>d</C> in <A>D2</A>.
+    </Item>
+    <Item>
+      The vertices <C>b</C> and <C>d</C> of <A>D2</A> are equal and there is
+      an edge from <C>a</C> to <C>c</C> in <A>D1</A>.
+    </Item>
+    <Item>
+      There is an edge from <C>a</C> to <C>c</C> in <A>D1</A> and there is
+      an edge from <C>b</C> to <C>d</C> in <A>D2</A>.
+    </Item>
+  </List>
+
+  The SPD of two paths of lengths <C>m</C> and <C>n</C> is also the king's graph
+  for an <C>m</C> by <C>n</C> board. 
+
+  <Example><![CDATA[
+gap> D1 := Digraph([[2], [1, 3, 4], [2, 5], [2, 5], [3, 4]]);
+<immutable digraph with 5 vertices, 10 edges>
+gap> D2 := Digraph([[2], [1, 3, 4], [2], [2]]);
+<immutable digraph with 4 vertices, 6 edges>
+gap> StrongProduct(D1, D2);
+<immutable digraph with 20 vertices, 130 edges>
+gap> StrongProduct(DigraphSymmetricClosure(ChainDigraph(3)),
+> DigraphSymmetricClosure(ChainDigraph(4)));
+<immutable digraph with 12 vertices, 58 edges>
+]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="ConormalProduct">
+<ManSection>
+  <Oper Name="ConormalProduct" Arg="D1, D2"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+  If <A>D1</A> and <A>D2</A> are digraphs without multiple edges,
+  then <C>ConormalProduct</C> calculates the <E>co-normal product digraph</E>
+  (<C>CNPD</C>) of <A>D1</A> and <A>D2</A>.
+
+  <C>CNPD</C> has vertex set <C>V1 x V2</C> where <C>V1</C> is the vertex set of
+  <A>D1</A> and <C>V2</C> is the vertex set of <A>D2</A> (a vertex
+  <C>[a, b]</C> has label <C>(a - 1) * |V2| + b</C> in the  output). There is
+  an edge from <C>[a, b]</C> to <C>[c, d]</C> when at least one of the
+  following two conditions are satisfied:
+  <List>
+    <Item>
+      There is an edge from <C>a</C> to <C>c</C> in <A>D1</A>.
+    </Item>
+    <Item>
+      There is an edge from <C>b</C> to <C>d</C> in <A>D2</A>.
+    </Item>
+  </List>
+
+  <Example><![CDATA[
+gap> ConormalProduct(DigraphSymmetricClosure(CycleDigraph(7)),
+> DigraphSymmetricClosure(CycleDigraph(4)));
+<immutable digraph with 28 vertices, 504 edges>
+gap> ConormalProduct(NullDigraph(0), CompleteDigraph(10));
+<immutable empty digraph with 0 vertices>
+]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="HomomorphicProduct">
+<ManSection>
+  <Oper Name="HomomorphicProduct" Arg="D1, D2"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+  If <A>D1</A> and <A>D2</A> are digraphs without multiple edges,
+  then <C>HomomorphicProduct</C> calculates the <E>homomorphic product digraph</E>
+  (<C>HPD</C>) of <A>D1</A> and <A>D2</A>.
+
+  <C>HPD</C> has vertex set <C>V1 x V2</C> where <C>V1</C> is the vertex set of
+  <A>D1</A> and <C>V2</C> is the vertex set of <A>D2</A> (a vertex
+  <C>[a, b]</C> has label <C>(a - 1) * |V2| + b</C> in the  output). There is
+  an edge from <C>[a, b]</C> to <C>[c, d]</C> when at least one of the
+  following two conditions are satisfied:
+  <List>
+    <Item>
+      The vertices <C>a</C> and <C>c</C> of <A>D1</A> are equal.
+    </Item>
+    <Item>
+      There is an edge from <C>a</C> to <C>c</C> in <A>D1</A> and no edge from
+      <C>b</C> to <C>d</C> in <A>D2</A>.
+    </Item>
+  </List>
+
+  <Example><![CDATA[
+gap> HomomorphicProduct(PetersenGraph(),
+> DigraphSymmetricClosure(ChainDigraph(4)));
+<immutable digraph with 40 vertices, 460 edges>
+gap> D1 := Digraph([[2], [1, 3, 4], [2, 5], [2, 5], [3, 4]]);
+<immutable digraph with 5 vertices, 10 edges>
+gap> D2 := Digraph([[2], [1, 3], [2, 4], [3]]);
+<immutable digraph with 4 vertices, 6 edges>
+gap> HomomorphicProduct(D1, D2);
+<immutable digraph with 20 vertices, 180 edges>
+]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="LexicographicProduct">
+<ManSection>
+  <Oper Name="LexicographicProduct" Arg="D1, D2"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+  If <A>D1</A> and <A>D2</A> are digraphs without multiple edges,
+  then <C>LexicographicProduct</C> calculates the <E>lexicographic product digraph</E>
+  (<C>LPD</C>) of <A>D1</A> and <A>D2</A>.
+
+  <C>LPD</C> has vertex set <C>V1 x V2</C> where <C>V1</C> is the vertex set of
+  <A>D1</A> and <C>V2</C> is the vertex set of <A>D2</A> (a vertex
+  <C>[a, b]</C> has label <C>(a - 1) * |V2| + b</C> in the  output). There is
+  an edge from <C>[a, b]</C> to <C>[c, d]</C> when at least one of the
+  following two conditions are satisfied:
+  <List>
+    <Item>
+      There is an edge from <C>a</C> to <C>c</C> in <A>D1</A>.
+    </Item>
+    <Item>
+      The vertices <C>a</C> and <C>c</C> of <A>D1</A> are equal and there is
+      an edge from <C>b</C> to <C>d</C> in <A>D2</A>.
+    </Item>
+  </List>
+
+  <Example><![CDATA[
+gap> LexicographicProduct(DigraphSymmetricClosure(CycleDigraph(3)),
+> DigraphSymmetricClosure(ChainDigraph(2)));
+<immutable digraph with 6 vertices, 30 edges>
+gap> OutNeighbours(last);
+[ [ 2, 3, 4, 5, 6 ], [ 1, 3, 4, 5, 6 ], [ 1, 2, 4, 5, 6 ], 
+  [ 1, 2, 3, 5, 6 ], [ 1, 2, 3, 4, 6 ], [ 1, 2, 3, 4, 5 ] ]
+gap> LexicographicProduct(NullDigraph(0), CompleteDigraph(10));
+<immutable empty digraph with 0 vertices>
+]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>  
 
 <#GAPDoc Label="NewDFSRecord">
 <ManSection>

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -59,6 +59,11 @@
     <#Include Label="DigraphJoin">
     <#Include Label="DigraphCartesianProduct">
     <#Include Label="DigraphDirectProduct">
+    <#Include Label="ConormalProduct">
+    <#Include Label="HomomorphicProduct">
+    <#Include Label="LexicographicProduct">
+    <#Include Label="ModularProduct">
+    <#Include Label="StrongProduct">
     <#Include Label="DigraphCartesianProductProjections">
     <#Include Label="DigraphDirectProductProjections">
     <#Include Label="LineDigraph">

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -42,8 +42,19 @@ DeclareGlobalFunction("DigraphEdgeUnion");
 DeclareGlobalFunction("DigraphCartesianProduct");
 DeclareGlobalFunction("DigraphDirectProduct");
 DeclareOperation("ModularProduct", [IsDigraph, IsDigraph]);
+DeclareOperation("StrongProduct", [IsDigraph, IsDigraph]);
+DeclareOperation("ConormalProduct", [IsDigraph, IsDigraph]);
+DeclareOperation("HomomorphicProduct", [IsDigraph, IsDigraph]);
+DeclareOperation("LexicographicProduct", [IsDigraph, IsDigraph]);
+
+DeclareSynonym("DigraphModularProduct", ModularProduct);
+DeclareSynonym("DigraphStrongProduct", StrongProduct);
+DeclareSynonym("DigraphConormalProduct", ConormalProduct);
+DeclareSynonym("DigraphHomomorphicProduct", HomomorphicProduct);
+DeclareSynonym("DigraphLexicographicProduct", LexicographicProduct);
 
 DeclareGlobalFunction("DIGRAPHS_CombinationOperProcessArgs");
+DeclareOperation("DIGRAPHS_GraphProduct", [IsDigraph, IsDigraph, IsFunction]);
 
 # 4. Actions . . .
 DeclareOperation("OnDigraphs", [IsDigraph, IsPerm]);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2494,9 +2494,9 @@ gap> MinimalCommonSuperdigraph(PetersenGraph(),
 [ <immutable digraph with 10 vertices, 30 edges>, IdentityTransformation, 
   IdentityTransformation ]
 gap> MaximalCommonSubdigraph(Digraph([[1, 1]]), Digraph([[1]]));
-Error, ModularProduct does not support multidigraphs,
+Error, the 1st argument (a digraph) must not satisfy IsMultiDigraph
 gap> MinimalCommonSuperdigraph(Digraph([[1, 1]]), Digraph([[1]]));
-Error, ModularProduct does not support multidigraphs,
+Error, the 1st argument (a digraph) must not satisfy IsMultiDigraph
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -2302,6 +2302,137 @@ gap> OutNeighbours(last);
   [ 23, 25, 33, 35, 38, 40, 1, 2, 6, 7, 11, 12, 16, 17, 26, 27, 41, 42, 49 ], 
   [ 21, 24, 31, 34, 36, 39, 2, 3, 7, 8, 12, 13, 17, 18, 27, 28, 42, 43, 50 ] ]
 
+#StrongProduct
+gap> D := Digraph([[2, 2], [1, 1, 3], [2]]);
+<immutable multidigraph with 3 vertices, 6 edges>
+gap> StrongProduct(D, D);
+Error, the 1st argument (a digraph) must not satisfy IsMultiDigraph
+gap> DigraphSymmetricClosure(ChainDigraph(6));
+<immutable symmetric digraph with 6 vertices, 10 edges>
+gap> StrongProduct(DigraphSymmetricClosure(ChainDigraph(10)), last);
+<immutable digraph with 60 vertices, 388 edges>
+gap> StrongProduct(NullDigraph(0), CompleteDigraph(5));
+<immutable empty digraph with 0 vertices>
+gap>  DigraphSymmetricClosure(CycleDigraph(4));
+<immutable symmetric digraph with 4 vertices, 8 edges>
+gap> StrongProduct(DigraphSymmetricClosure(ChainDigraph(3)), last);
+<immutable digraph with 12 vertices, 72 edges>
+gap> OutNeighbours(last);
+[ [ 2, 4, 5, 6, 8 ], [ 1, 3, 5, 6, 7 ], [ 2, 4, 6, 7, 8 ], [ 1, 3, 5, 7, 8 ], 
+  [ 1, 2, 4, 6, 8, 9, 10, 12 ], [ 1, 2, 3, 5, 7, 9, 10, 11 ], 
+  [ 2, 3, 4, 6, 8, 10, 11, 12 ], [ 1, 3, 4, 5, 7, 9, 11, 12 ], 
+  [ 5, 6, 8, 10, 12 ], [ 5, 6, 7, 9, 11 ], [ 6, 7, 8, 10, 12 ], 
+  [ 5, 7, 8, 9, 11 ] ]
+gap> StrongProduct(ChainDigraph(2), ChainDigraph(8));
+<immutable digraph with 16 vertices, 29 edges>
+
+#ConormalProduct
+gap> D := Digraph([[2, 4, 4], [1, 3], [2, 4], [1, 1, 3]]);
+<immutable multidigraph with 4 vertices, 10 edges>
+gap> ConormalProduct(D, D);
+Error, the 1st argument (a digraph) must not satisfy IsMultiDigraph
+gap> ConormalProduct(NullDigraph(10), CompleteDigraph(10));
+<immutable digraph with 100 vertices, 9000 edges>
+gap> ConormalProduct(PetersenGraph(), PetersenGraph());
+<immutable digraph with 100 vertices, 5100 edges>
+gap> DigraphSymmetricClosure(CycleDigraph(3));
+<immutable symmetric digraph with 3 vertices, 6 edges>
+gap> ConormalProduct(last, last);
+<immutable digraph with 9 vertices, 72 edges>
+gap> ConormalProduct(CycleDigraph(2), CycleDigraph(8));
+<immutable digraph with 16 vertices, 144 edges>
+
+#HomomorphicProduct
+gap> D := Digraph([[2, 3], [1, 3, 3], [1, 2, 2]]);
+<immutable multidigraph with 3 vertices, 8 edges>
+gap> HomomorphicProduct(D, D);                    
+Error, the 1st argument (a digraph) must not satisfy IsMultiDigraph
+gap> DigraphSymmetricClosure(CycleDigraph(6)); 
+<immutable symmetric digraph with 6 vertices, 12 edges>
+gap> HomomorphicProduct(PetersenGraph(), last);
+<immutable digraph with 60 vertices, 1080 edges>
+gap> HomomorphicProduct(NullDigraph(0), CompleteDigraph(11));
+<immutable empty digraph with 0 vertices>
+gap> DigraphSymmetricClosure(CycleDigraph(8));
+<immutable symmetric digraph with 8 vertices, 16 edges>
+gap> HomomorphicProduct(NullDigraph(10), last);
+<immutable digraph with 80 vertices, 640 edges>
+gap> OutNeighbours(last);
+[ [ 1, 2, 3, 4, 5, 6, 7, 8 ], [ 1, 2, 3, 4, 5, 6, 7, 8 ], 
+  [ 1, 2, 3, 4, 5, 6, 7, 8 ], [ 1, 2, 3, 4, 5, 6, 7, 8 ], 
+  [ 1, 2, 3, 4, 5, 6, 7, 8 ], [ 1, 2, 3, 4, 5, 6, 7, 8 ], 
+  [ 1, 2, 3, 4, 5, 6, 7, 8 ], [ 1, 2, 3, 4, 5, 6, 7, 8 ], 
+  [ 9, 10, 11, 12, 13, 14, 15, 16 ], [ 9, 10, 11, 12, 13, 14, 15, 16 ], 
+  [ 9, 10, 11, 12, 13, 14, 15, 16 ], [ 9, 10, 11, 12, 13, 14, 15, 16 ], 
+  [ 9, 10, 11, 12, 13, 14, 15, 16 ], [ 9, 10, 11, 12, 13, 14, 15, 16 ], 
+  [ 9, 10, 11, 12, 13, 14, 15, 16 ], [ 9, 10, 11, 12, 13, 14, 15, 16 ], 
+  [ 17, 18, 19, 20, 21, 22, 23, 24 ], [ 17, 18, 19, 20, 21, 22, 23, 24 ], 
+  [ 17, 18, 19, 20, 21, 22, 23, 24 ], [ 17, 18, 19, 20, 21, 22, 23, 24 ], 
+  [ 17, 18, 19, 20, 21, 22, 23, 24 ], [ 17, 18, 19, 20, 21, 22, 23, 24 ], 
+  [ 17, 18, 19, 20, 21, 22, 23, 24 ], [ 17, 18, 19, 20, 21, 22, 23, 24 ], 
+  [ 25, 26, 27, 28, 29, 30, 31, 32 ], [ 25, 26, 27, 28, 29, 30, 31, 32 ], 
+  [ 25, 26, 27, 28, 29, 30, 31, 32 ], [ 25, 26, 27, 28, 29, 30, 31, 32 ], 
+  [ 25, 26, 27, 28, 29, 30, 31, 32 ], [ 25, 26, 27, 28, 29, 30, 31, 32 ], 
+  [ 25, 26, 27, 28, 29, 30, 31, 32 ], [ 25, 26, 27, 28, 29, 30, 31, 32 ], 
+  [ 33, 34, 35, 36, 37, 38, 39, 40 ], [ 33, 34, 35, 36, 37, 38, 39, 40 ], 
+  [ 33, 34, 35, 36, 37, 38, 39, 40 ], [ 33, 34, 35, 36, 37, 38, 39, 40 ], 
+  [ 33, 34, 35, 36, 37, 38, 39, 40 ], [ 33, 34, 35, 36, 37, 38, 39, 40 ], 
+  [ 33, 34, 35, 36, 37, 38, 39, 40 ], [ 33, 34, 35, 36, 37, 38, 39, 40 ], 
+  [ 41, 42, 43, 44, 45, 46, 47, 48 ], [ 41, 42, 43, 44, 45, 46, 47, 48 ], 
+  [ 41, 42, 43, 44, 45, 46, 47, 48 ], [ 41, 42, 43, 44, 45, 46, 47, 48 ], 
+  [ 41, 42, 43, 44, 45, 46, 47, 48 ], [ 41, 42, 43, 44, 45, 46, 47, 48 ], 
+  [ 41, 42, 43, 44, 45, 46, 47, 48 ], [ 41, 42, 43, 44, 45, 46, 47, 48 ], 
+  [ 49, 50, 51, 52, 53, 54, 55, 56 ], [ 49, 50, 51, 52, 53, 54, 55, 56 ], 
+  [ 49, 50, 51, 52, 53, 54, 55, 56 ], [ 49, 50, 51, 52, 53, 54, 55, 56 ], 
+  [ 49, 50, 51, 52, 53, 54, 55, 56 ], [ 49, 50, 51, 52, 53, 54, 55, 56 ], 
+  [ 49, 50, 51, 52, 53, 54, 55, 56 ], [ 49, 50, 51, 52, 53, 54, 55, 56 ], 
+  [ 57, 58, 59, 60, 61, 62, 63, 64 ], [ 57, 58, 59, 60, 61, 62, 63, 64 ], 
+  [ 57, 58, 59, 60, 61, 62, 63, 64 ], [ 57, 58, 59, 60, 61, 62, 63, 64 ], 
+  [ 57, 58, 59, 60, 61, 62, 63, 64 ], [ 57, 58, 59, 60, 61, 62, 63, 64 ], 
+  [ 57, 58, 59, 60, 61, 62, 63, 64 ], [ 57, 58, 59, 60, 61, 62, 63, 64 ], 
+  [ 65, 66, 67, 68, 69, 70, 71, 72 ], [ 65, 66, 67, 68, 69, 70, 71, 72 ], 
+  [ 65, 66, 67, 68, 69, 70, 71, 72 ], [ 65, 66, 67, 68, 69, 70, 71, 72 ], 
+  [ 65, 66, 67, 68, 69, 70, 71, 72 ], [ 65, 66, 67, 68, 69, 70, 71, 72 ], 
+  [ 65, 66, 67, 68, 69, 70, 71, 72 ], [ 65, 66, 67, 68, 69, 70, 71, 72 ], 
+  [ 73, 74, 75, 76, 77, 78, 79, 80 ], [ 73, 74, 75, 76, 77, 78, 79, 80 ], 
+  [ 73, 74, 75, 76, 77, 78, 79, 80 ], [ 73, 74, 75, 76, 77, 78, 79, 80 ], 
+  [ 73, 74, 75, 76, 77, 78, 79, 80 ], [ 73, 74, 75, 76, 77, 78, 79, 80 ], 
+  [ 73, 74, 75, 76, 77, 78, 79, 80 ], [ 73, 74, 75, 76, 77, 78, 79, 80 ] ]
+gap> HomomorphicProduct(CompleteDigraph(8), CycleDigraph(8));
+<immutable digraph with 64 vertices, 3648 edges>
+
+#LexicographicProduct
+gap> D := Digraph([[2, 2, 2], [1, 1, 1]]);
+<immutable multidigraph with 2 vertices, 6 edges>
+gap> LexicographicProduct(CompleteDigraph(3), D);
+Error, the 2nd argument (a digraph) must not satisfy IsMultiDigraph
+gap> StrongProduct(NullDigraph(0), CompleteDigraph(3));
+<immutable empty digraph with 0 vertices>
+gap> D1 := Digraph([[2], [1, 3, 4], [2, 5], [2, 5], [3, 4]]);
+<immutable digraph with 5 vertices, 10 edges>
+gap> D2 := Digraph([[2], [1, 3, 4], [2], [2]]);              
+<immutable digraph with 4 vertices, 6 edges>
+gap> LexicographicProduct(D1, D2);
+<immutable digraph with 20 vertices, 190 edges>
+gap> OutNeighbours(last);
+[ [ 2, 5, 6, 7, 8 ], [ 1, 3, 4, 5, 6, 7, 8 ], [ 2, 5, 6, 7, 8 ], 
+  [ 2, 5, 6, 7, 8 ], [ 1, 2, 3, 4, 6, 9, 10, 11, 12, 13, 14, 15, 16 ], 
+  [ 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ], 
+  [ 1, 2, 3, 4, 6, 9, 10, 11, 12, 13, 14, 15, 16 ], 
+  [ 1, 2, 3, 4, 6, 9, 10, 11, 12, 13, 14, 15, 16 ], 
+  [ 5, 6, 7, 8, 10, 17, 18, 19, 20 ], 
+  [ 5, 6, 7, 8, 9, 11, 12, 17, 18, 19, 20 ], 
+  [ 5, 6, 7, 8, 10, 17, 18, 19, 20 ], [ 5, 6, 7, 8, 10, 17, 18, 19, 20 ], 
+  [ 5, 6, 7, 8, 14, 17, 18, 19, 20 ], 
+  [ 5, 6, 7, 8, 13, 15, 16, 17, 18, 19, 20 ], 
+  [ 5, 6, 7, 8, 14, 17, 18, 19, 20 ], [ 5, 6, 7, 8, 14, 17, 18, 19, 20 ], 
+  [ 9, 10, 11, 12, 13, 14, 15, 16, 18 ], 
+  [ 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20 ], 
+  [ 9, 10, 11, 12, 13, 14, 15, 16, 18 ], 
+  [ 9, 10, 11, 12, 13, 14, 15, 16, 18 ] ]
+gap> LexicographicProduct(ChainDigraph(3), CycleDigraph(7));   
+<immutable digraph with 21 vertices, 119 edges>
+
 # DigraphShortestPathSpanningTree
 gap> D := Digraph([[2, 3, 4], [1, 3, 4, 5], [1, 2], [5], [4]]);
 <immutable digraph with 5 vertices, 11 edges>


### PR DESCRIPTION
This adds 4 additional graph product functions to the oper file. The graph products implemented are the [Strong Product](https://en.wikipedia.org/wiki/Strong_product_of_graphs), the [Co-normal Product](https://en.wikipedia.org/wiki/Graph_product), the [Homomorphic Product](https://en.wikipedia.org/wiki/Graph_product) and the [Lexicographic Product](https://en.wikipedia.org/wiki/Lexicographic_product_of_graphs). The function for the [Modular graph product](https://en.wikipedia.org/wiki/Modular_product_of_graphs) was also edited in order to reduce redundancies. 