### PR TITLE
Fix `DigraphMaximumMatching` for digraphs with custom vertex labels

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2373,6 +2373,9 @@ InstallMethod(DigraphMaximumMatching, "for a digraph", [IsDigraph],
 function(D)
   local mateG, mateD, G, M, i, lab;
   G     := DigraphImmutableCopy(D);
+  # Ensure that InducedSubdigraph is given a digraph with vertex labels equal
+  # to DigraphVertices(D).
+  SetDigraphVertexLabels(G, DigraphVertices(G));
   G     := InducedSubdigraph(G, Difference(DigraphVertices(G), DigraphLoops(G)));
   lab   := DigraphVertexLabels(G);
   G     := DigraphSymmetricClosure(G);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2541,6 +2541,14 @@ true
 gap> Length(M);
 111
 
+# DigraphMaximumMatching: Issue #461, reported by Leonard Soicher on 2021-05-06.
+# See https://github.com/digraphs/Digraphs/issues/461
+gap> D := DigraphFromGraph6String("Cr");
+<immutable symmetric digraph with 4 vertices, 8 edges>
+gap> SetDigraphVertexLabels(D, [[1, 1], [2, 1], [1, 2], [2, 2]]);
+gap> IsMaximumMatching(D, DigraphMaximumMatching(D));
+true
+
 # DigraphNrLoops
 gap> D := EmptyDigraph(5);
 <immutable empty digraph with 5 vertices>


### PR DESCRIPTION
This fixes a bug reported by @lhsoicher in #461.

There, he creates a digraph whose vertex labels are lists. However, `DigraphMaximumMatching` gives an error when run on this digraph, because the method makes invalid assumptions about the vertex labels.

Since the method for `DigraphMaximumMatching` works with a copy (this could perhaps be avoided to give a performance boost, but that's a separate issue...), then this can be easily fixed by setting the copy `D` to have vertex labels `DigraphVertices(D)`, i.e. `[1..n]` for `n := DigraphNrVertices(D)`.