### PR TITLE
Add GitHub Actions Windows tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -83,3 +83,22 @@ jobs:
         if: ${{ always() }}
       - uses: codecov/codecov-action@v2
         if: ${{ always() }}
+
+  test-cygwin:
+    name: "cygwin / GAP master"
+    runs-on: windows-latest
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    env:
+      CHERE_INVOKING: 1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gap-actions/setup-cygwin@v1
+      - uses: gap-actions/setup-gap@cygwin-v2
+        with:
+          GAP_PKGS_TO_BUILD: "io orb profiling grape datastructures"
+      - uses: gap-actions/build-pkg@cygwin-v1
+      - name: "Install digraphs-lib"
+        run: |
+          curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${{ env.DIGRAPHS_LIB }}.tar.gz"
+          tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
+      - uses: gap-actions/run-pkg-tests@cygwin-v2


### PR DESCRIPTION
As discussed #464, the AppVeyor Windows tests broke and were therefore removed.

I think our philosophy with Windows tests should be to run them while it's convenient, but to spend as little effort as possible to maintain them.

The general-purpose CI setup for GAP packages that exists under the `gap-actions` organisation (which is what our GitHub Actions implementation already uses) current only works if you want to run tests on Ubuntu or macOS. I am working on making this work in Windows too, and I've got an initial version. I've not yet unified this with the existing Unix versions. Therefore I'm using my fork of several of the `gap-actions` repositories for now, which are specific to Windows.

Although this is not ideal, it's better than nothing, and if it stops working then we can scrap it. I hope to eventually unify my Windows fork with the main Unix versions, so that adding Windows tests just becomes a case of adding a line to the 'CI matrix' (rather than the 20 lines of mostly-duplicated code that it is now).