### PR TITLE
Run GitHub Actions tests on a daily schedule, and allow jobs to be started manually too

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -1,5 +1,11 @@
 name: "Digraphs tests"
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+  schedule:
+    # Every day at 3:30 AM UTC
+    - cron: '30 3 * * *'
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,11 @@
 name: "linting"
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+  schedule:
+    # Every day at 3:30 AM UTC
+    - cron: '30 3 * * *'
 
 jobs:
   lint:


### PR DESCRIPTION
The GAP and linting jobs will run every morning at 3:30 GMT / 4:30 BST. Once this is merged into `master`, it will then be possible to go to https://github.com/digraphs/Digraphs/actions/workflows/gap.yml and https://github.com/digraphs/Digraphs/actions/workflows/lint.yml and choose to manually start a run of the corresponding tests on whichever branch you choose.