### PR TITLE
Enable the manual to be compiled without loading Digraphs

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -237,8 +237,9 @@ Dependencies := rec(
   GAP := ">=4.10.0",
   NeededOtherPackages := [["io", ">=4.5.1"],
                           ["orb", ">=4.8.2"],
+                          ["GAPDoc", ">=1.6.3"],
                           ["datastructures", ">=0.2.5"]],
-  SuggestedOtherPackages := [["gapdoc", ">=1.5.1"],
+  SuggestedOtherPackages := [
                              ["grape", ">=4.8.1"],
                              ["nautytracesinterface", ">=0.2"]],
   ExternalConditions := [],

--- a/ci/docker-test.sh
+++ b/ci/docker-test.sh
@@ -136,6 +136,10 @@ fi
 if [ "$SUITE" == "coverage" ]; then
   PKGS+=( "profiling" )
 fi
+# We now need a newer GAPDoc than the one included in the Docker container for GAP 4.10.2
+if [ "$GAP_VERSION" == "4.10.2" ]; then
+  PKGS+=( "GAPDoc" )
+fi
 
 for PKG in "${PKGS[@]}"; do
   cd $GAP_HOME/pkg
@@ -154,7 +158,12 @@ for PKG in "${PKGS[@]}"; do
     VERSION=${VERSION:1}
   fi
 
-  URL="https://github.com/gap-packages/$PKG/releases/download/v$VERSION/$PKG-$VERSION.tar.gz"
+  # This can be removed when there is no GAPDoc special case for GAP 4.10.2
+  if [ "$PKG" == "GAPDoc" ]; then
+    URL="http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-$VERSION.tar.gz"
+  else
+    URL="https://github.com/gap-packages/$PKG/releases/download/v$VERSION/$PKG-$VERSION.tar.gz"
+  fi
   bold "Downloading $PKG-$VERSION (${PACKAGES[0]} version), from URL:"
   bold "$URL"
   $CURL "$URL" -o $PKG-$VERSION.tar.gz

--- a/gap/doc.g
+++ b/gap/doc.g
@@ -1,0 +1,62 @@
+#############################################################################
+##
+##  doc.g
+##  Copyright (C) 2021                                   James D. Mitchell
+##                                                          Wilf A. Wilson
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+## This file contains the information required to build the Digraphs package
+## documentation, it is used by makedoc.g.
+
+BindGlobal("DIGRAPHS_DocXMLFiles",
+           ["../PackageInfo.g",
+            "attr.xml",
+            "cliques.xml",
+            "constructors.xml",
+            "digraph.xml",
+            "display.xml",
+            "examples.xml",
+            "grahom.xml",
+            "grape.xml",
+            "io.xml",
+            "isomorph.xml",
+            "labels.xml",
+            "oper.xml",
+            "orbits.xml",
+            "planar.xml",
+            "prop.xml",
+            "utils.xml"]);
+
+BindGlobal("DIGRAPHS_MakeDoc",
+function(pkgdir)
+  local PKG, temp, version, args;
+
+  PKG := "Digraphs";
+
+  # Get the GAP version from PackageInfo.g and write it to .VERSION
+  temp := SplitString(StringFile(Filename(pkgdir, "PackageInfo.g")), "\n");
+  version := SplitString(First(temp, x -> StartsWith(x, "Version")), "\"")[2];
+  PrintTo(Filename(pkgdir, ".VERSION"), version, "\n");
+
+  args := [Filename(pkgdir, "doc"),
+           "main.xml",
+           DIGRAPHS_DocXMLFiles,
+           PKG,
+           "MathJax",
+           "../../.."];
+  # If pdflatex is not available, but we call MakeGAPDocDoc implicitly asking
+  # for GAPDoc to compile a PDF version of the manual, then GAPDoc fails to
+  # create the doc/manual.six file, which we need later. This file however is
+  # still created if we explicitly say that we don't want a PDF
+  if Filename(DirectoriesSystemPrograms(), "pdflatex") = fail then
+    Add(args, "nopdf");
+  fi;
+  LoadPackage("GAPDoc");
+  SetGapDocLaTeXOptions("utf8");
+  CallFuncList(MakeGAPDocDoc, args);
+  CopyHTMLStyleFiles(Filename(pkgdir, "doc"));
+  GAPDocManualLabFromSixFile(PKG, Filename(pkgdir, "doc/manual.six"));
+end);

--- a/gap/utils.gi
+++ b/gap/utils.gi
@@ -13,24 +13,6 @@
 # Internal stuff
 #############################################################################
 
-BindGlobal("DIGRAPHS_DocXMLFiles", ["attr.xml",
-                                    "cliques.xml",
-                                    "constructors.xml",
-                                    "digraph.xml",
-                                    "display.xml",
-                                    "grahom.xml",
-                                    "grape.xml",
-                                    "io.xml",
-                                    "isomorph.xml",
-                                    "labels.xml",
-                                    "oper.xml",
-                                    "orbits.xml",
-                                    "planar.xml",
-                                    "prop.xml",
-                                    "utils.xml",
-                                    "examples.xml",
-                                    "../PackageInfo.g"]);
-
 BindGlobal("DIGRAPHS_TestRec", rec());
 MakeReadWriteGlobal("DIGRAPHS_TestRec");
 
@@ -207,11 +189,8 @@ end);
 
 InstallGlobalFunction(DigraphsMakeDoc,
 function()
-  MakeGAPDocDoc(Concatenation(PackageInfo("digraphs")[1]!.
-                              InstallationPath, "/doc"),
-                "main.xml", DIGRAPHS_DocXMLFiles, "Digraphs", "MathJax",
-                "../../..");
-  return;
+  # Compile the documentation of the currently-loaded version of Digraphs
+  DIGRAPHS_MakeDoc(DirectoriesPackageLibrary("Digraphs", ""));
 end);
 
 InstallGlobalFunction(DigraphsTestManualExamples,

--- a/makedoc.g
+++ b/makedoc.g
@@ -6,33 +6,20 @@
 ##      gap makedoc.g
 ##
 
-PACKAGE := "Digraphs";
-PrintTo(".VERSION", PackageInfo(PACKAGE)[1].Version, "\n");
-LoadPackage("GAPDoc");
-
-_DocXMLFiles := ["attr.xml",
-                 "cliques.xml",
-                 "constructors.xml",
-                 "digraph.xml",
-                 "display.xml",
-                 "examples.xml",
-                 "grahom.xml",
-                 "grape.xml",
-                 "io.xml",
-                 "isomorph.xml",
-                 "labels.xml",
-                 "oper.xml",
-                 "orbits.xml",
-                 "planar.xml",
-                 "prop.xml",
-                 "utils.xml",
-                 "../PackageInfo.g"];
-
-MakeGAPDocDoc(Concatenation(PackageInfo("digraphs")[1]!.
-                            InstallationPath, "/doc"),
-              "main.xml", _DocXMLFiles, "Digraphs", "MathJax",
-              "../../..");
-CopyHTMLStyleFiles("doc");
-GAPDocManualLab(PACKAGE);
-
-QUIT;
+if not IsDirectoryPath("gap")
+    or not "doc.g" in DirectoryContents("gap") then
+  Print("Error: GAP must be run from the package directory ",
+        "when reading makedoc.g\n");
+  FORCE_QUIT_GAP(1);
+fi;
+if IsBoundGlobal("DIGRAPHS_DocXMLFiles") then
+  MakeReadWriteGlobal("DIGRAPHS_DocXMLFiles");
+  UnbindGlobal("DIGRAPHS_DocXMLFiles");
+fi;
+if IsBoundGlobal("DIGRAPHS_MakeDoc") then
+  MakeReadWriteGlobal("DIGRAPHS_MakeDoc");
+  UnbindGlobal("DIGRAPHS_MakeDoc");
+fi;
+Read("gap/doc.g");
+DIGRAPHS_MakeDoc(DirectoryCurrent());
+FORCE_QUIT_GAP();

--- a/read.g
+++ b/read.g
@@ -22,6 +22,8 @@ BindGlobal("DIGRAPHS_NautyAvailable",
 
 Unbind(_NautyTracesInterfaceVersion);
 
+ReadPackage("digraphs", "gap/doc.g");
+
 ReadPackage("digraphs", "gap/utils.gi");
 ReadPackage("digraphs", "gap/digraph.gi");
 ReadPackage("digraphs", "gap/constructors.gi");

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,5 +1,10 @@
 LoadPackage("digraphs");
-if DigraphsTestInstall() and DigraphsTestAll() and DigraphsTestExtreme() then
+
+DigraphsMakeDoc();
+if DigraphsTestInstall()
+    and DigraphsTestStandard()
+    and DIGRAPHS_RunTest(DigraphsTestManualExamples)
+    and DigraphsTestExtreme() then
   FORCE_QUIT_GAP(0);
 fi;
 


### PR DESCRIPTION
This is the analogous change to https://github.com/semigroups/Semigroups/pull/748, for the same reasons.

Also it will be useful because I want to add to separate CI job to compile and upload the manuals, and this will mean that that job won't have to compile anything except for GAP itself (and so will be nice and quick).

In fact, this solution ended up being a bit more robust than the new Semigroups implementation, and it raised some issues with the Semigroups implementation. So I'll try to make the corresponding changes there.