### PR TITLE
CI: refactor the CI a bit, and add a macOS job

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -1,4 +1,4 @@
-name: "Digraphs tests"
+name: "Tests"
 on:
   workflow_dispatch:
   pull_request:
@@ -7,15 +7,20 @@ on:
     # Every day at 3:30 AM UTC
     - cron: '30 3 * * *'
 
+env:
+  DIGRAPHS_LIB: digraphs-lib-0.6
+
 jobs:
   test:
-    name: "GAP ${{ matrix.gap-branch }}"
-    runs-on: ubuntu-latest
+    name: "${{ matrix.os }} / GAP ${{ matrix.gap-branch }}"
+    runs-on: "${{ matrix.os }}-latest"
     # Don't run this twice for PRs from branches in the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu
         gap-branch:
           - master
           - stable-4.11
@@ -25,37 +30,48 @@ jobs:
         include:
           - gap-branch: stable-4.10
             pkgs-to-clone: datastructures
+            os: ubuntu
 
     steps:
-      - name: "Check out the repository"
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: "Install TeX Live"
         if: ${{ matrix.gap-branch == 'master' }}
         run: |
+          packages=(
+            texlive-latex-base
+            texlive-latex-recommended
+            texlive-latex-extra
+            texlive-extra-utils
+            texlive-fonts-recommended
+            texlive-fonts-extra
+          )
           sudo apt-get update
-          sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra
-          sudo apt-get install texlive-extra-utils texlive-fonts-recommended texlive-fonts-extra
+          sudo apt-get install "${packages[@]}"
       - name: "Install GAP and clone/compile necessary packages"
-        uses: gap-actions/setup-gap-for-packages@v1
+        uses: gap-actions/setup-gap@v2
         with:
           GAP_PKGS_TO_CLONE: "${{ matrix.pkgs-to-clone }}"
           GAP_PKGS_TO_BUILD: "io orb profiling grape NautyTracesInterface datastructures"
           GAPBRANCH: ${{ matrix.gap-branch }}
+      - name: "Build Digraphs"
+        uses: gap-actions/build-pkg@v1
       - name: "Install digraphs-lib"
         run: |
-          DIGRAPHS_LIB="digraphs-lib-0.6"
-          curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${DIGRAPHS_LIB}.tar.gz"
-          tar xf "${DIGRAPHS_LIB}.tar.gz"
+          curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${{ env.DIGRAPHS_LIB }}.tar.gz"
+          tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
       - name: "Run tst/testall.g"
-        uses: gap-actions/run-test-for-packages@v1
-      - name: "Upload compiled manuals"
+        uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/build-pkg-docs@v1
         if: ${{ matrix.gap-branch == 'master' }}
+      - name: "Upload compiled manuals"
         uses: actions/upload-artifact@v2
+        if: ${{ matrix.gap-branch == 'master' }}
         with:
-          name: manual
+          name: "Digraphs manual"
           path: |
             doc/manual.pdf
             doc/*.html
             doc/*.css
             doc/*.js
-
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v1

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -34,19 +34,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: "Install TeX Live"
-        if: ${{ matrix.gap-branch == 'master' }}
-        run: |
-          packages=(
-            texlive-latex-base
-            texlive-latex-recommended
-            texlive-latex-extra
-            texlive-extra-utils
-            texlive-fonts-recommended
-            texlive-fonts-extra
-          )
-          sudo apt-get update
-          sudo apt-get install "${packages[@]}"
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
         with:
@@ -61,11 +48,33 @@ jobs:
           tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
       - name: "Run tst/testall.g"
         uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v1
+
+  manual:
+    name: "Compile and upload manual"
+    runs-on: ubuntu-latest
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Install TeX Live"
+        run: |
+          packages=(
+            texlive-latex-base
+            texlive-latex-recommended
+            texlive-latex-extra
+            texlive-extra-utils
+            texlive-fonts-recommended
+            texlive-fonts-extra
+          )
+          sudo apt-get update
+          sudo apt-get install "${packages[@]}"
+      - uses: gap-actions/setup-gap@v2
+        with:
+          GAP_PKGS_TO_BUILD: ''
       - uses: gap-actions/build-pkg-docs@v1
-        if: ${{ matrix.gap-branch == 'master' }}
       - name: "Upload compiled manuals"
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.gap-branch == 'master' }}
         with:
           name: "Digraphs manual"
           path: |
@@ -73,5 +82,3 @@ jobs:
             doc/*.html
             doc/*.css
             doc/*.js
-      - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v1

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -11,7 +11,7 @@ env:
   DIGRAPHS_LIB: digraphs-lib-0.6
 
 jobs:
-  test:
+  test-unix:
     name: "${{ matrix.os }} / GAP ${{ matrix.gap-branch }}"
     runs-on: "${{ matrix.os }}-latest"
     # Don't run this twice for PRs from branches in the same repository
@@ -31,9 +31,15 @@ jobs:
           - gap-branch: stable-4.10
             pkgs-to-clone: datastructures
             os: ubuntu
+          - gap-branch: master
+            pkgs-to-clone: "datastructures NautyTracesInterface"
+            os: macos
 
     steps:
       - uses: actions/checkout@v2
+      - name: "Install dependencies"
+        if: ${{ runner.os == 'macOS' }}
+        run: brew install automake
       - name: "Install GAP and clone/compile necessary packages"
         uses: gap-actions/setup-gap@v2
         with:


### PR DESCRIPTION
The motivation of the refactoring is to:
* Make it easier to add the macOS job
* Make it easier to make my Windows job work (see #464)
* To separate the manual-building job from the `master` job, which was already the longest job. Therefore things should be quicker overall.