### PR TITLE
Add a `.release` helper script for the release system

### DIFF
--- a/.release
+++ b/.release
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script is intended to be run by the release-gap-package script which is
+# part of the the ReleaseTools for GAP:
+#
+# https://github.com/gap-system/ReleaseTools
+
+set -e
+
+# ensure we are in the same directory as this script
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+notice_it() {
+    printf '\033[93m%s\033[0m\n' "$*"
+}
+
+notice_it "Deleting additional unnecessary files"
+rm -f  .covignore .gaplint.yml .mailmap Dockerfile
+rm -rf ci etc scripts


### PR DESCRIPTION
So far, we only need to remove some additional files. I accidentally included some of these in the release of Digraphs v1.4.1.

This assumes that you're using the latest version of ReleaseTools.