### PR TITLE
Add `tst/teststandard.g` and use it as the `PackageInfo.g` testfile

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -258,6 +258,6 @@ AvailabilityTest := function()
 end,
 
 Autoload := false,
-TestFile := "tst/testinstall.tst",
+TestFile := "tst/teststandard.g",
 Keywords := []
 ));

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -1,0 +1,23 @@
+#############################################################################
+##
+#W  teststandard.g
+#Y  Copyright (C) 2021                                      Wilf A. Wilson
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+LoadPackage("digraphs", false);;
+# These "{No} errors detected" lines currently have to be printed in this way
+# to satisfy the automated GAP testing system that runs on Jenkins.
+# This requirement will hopefully go soon.
+if DigraphsTestInstall()
+    and DigraphsTestStandard()
+    and DIGRAPHS_RunTest(DigraphsTestManualExamples) then
+  Print("#I  No errors detected while testing\n\n");
+  QUIT_GAP(0);
+else
+  Print("#I  Errors detected while testing\n\n");
+  QUIT_GAP(1);
+fi;
+FORCE_QUIT_GAP(1); # if we ever get here, there was an error


### PR DESCRIPTION
The `TestFile` component of the `PackageInfo` record is used by the GAP testing setup to do automated tests of packages (Jenkins; plus publicly available setup that used to be on Travis, and will hopefully be soon replicated on GitHub Actions).

The test file that's pointed to is supposed to finish quite quickly. Currently we use `tst/testinstall.tst` for this, which is certainly quick, but is not very thorough. I think that the standard test suite (plus manual examples) is quick enough to be included, and much more comprehensive.

This doesn't affect anything about how our CI own setup works.