### PR TITLE
Clarify the wording of an edge case in the documentation of `IsDirectedTree`

### DIFF
--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -582,8 +582,8 @@ false
 
     A <E>directed tree</E> is an acyclic digraph with precisely 1 source,
     such that no two vertices share an out-neighbour.
-    Note the empty digraph is not considered a directed
-    tree as it has no source. <P/>
+    Note that the empty digraph with zero vertices is not considered
+    to be a directed tree, because it has no source. <P/>
 
     See also <Ref Attr="DigraphSources"/>.
     <P/>


### PR DESCRIPTION
There is no 'the empty digraph' in this package; we have an empty digraph for each number of vertices.