### PR TITLE
Split the four test functions into different steps in GitHub Actions

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -59,7 +59,27 @@ jobs:
         run: |
           curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${{ env.DIGRAPHS_LIB }}.tar.gz"
           tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
-      - name: "Run tst/testall.g"
+      - name: "Run DigraphsTestInstall"
+        if: ${{ always() }}
         uses: gap-actions/run-pkg-tests@v2
+        with:
+          GAP_TESTFILE: "tst/github_actions/install.g"
+      - name: "Run DigraphsTestStandard"
+        if: ${{ always() }}
+        uses: gap-actions/run-pkg-tests@v2
+        with:
+          GAP_TESTFILE: "tst/github_actions/standard.g"
+      - name: "Run DigraphsTestManualExamples"
+        if: ${{ always() }}
+        uses: gap-actions/run-pkg-tests@v2
+        with:
+          GAP_TESTFILE: "tst/github_actions/examples.g"
+      - name: "Run DigraphsTestExtreme"
+        if: ${{ always() }}
+        uses: gap-actions/run-pkg-tests@v2
+        with:
+          GAP_TESTFILE: "tst/github_actions/extreme.g"
       - uses: gap-actions/process-coverage@v2
+        if: ${{ always() }}
       - uses: codecov/codecov-action@v1
+        if: ${{ always() }}

--- a/tst/github_actions/examples.g
+++ b/tst/github_actions/examples.g
@@ -1,0 +1,7 @@
+LoadPackage("digraphs", false);;
+if DIGRAPHS_RunTest(DigraphsTestManualExamples) then
+  QUIT_GAP(0);
+else
+  QUIT_GAP(1);
+fi;
+FORCE_QUIT_GAP(1);

--- a/tst/github_actions/extreme.g
+++ b/tst/github_actions/extreme.g
@@ -1,0 +1,7 @@
+LoadPackage("digraphs", false);;
+if DigraphsTestExtreme(rec(earlyStop := false)) then
+  QUIT_GAP(0);
+else
+  QUIT_GAP(1);
+fi;
+FORCE_QUIT_GAP(1);

--- a/tst/github_actions/install.g
+++ b/tst/github_actions/install.g
@@ -1,0 +1,7 @@
+LoadPackage("digraphs", false);;
+if DigraphsTestInstall() then
+  QUIT_GAP(0);
+else
+  QUIT_GAP(1);
+fi;
+FORCE_QUIT_GAP(1);

--- a/tst/github_actions/standard.g
+++ b/tst/github_actions/standard.g
@@ -1,0 +1,7 @@
+LoadPackage("digraphs", false);;
+if DigraphsTestStandard(rec(earlyStop := false)) then
+  QUIT_GAP(0);
+else
+  QUIT_GAP(1);
+fi;
+FORCE_QUIT_GAP(1);


### PR DESCRIPTION
A small change that will make it quicker to see which bit of the test suite has failed. See https://github.com/wilfwilson/Digraphs/runs/2646648699?check_suite_focus=true for an example where `TestStandard` and `TestExtreme` both fail, but `TestInstall` and `TestManualExamples` both pass.

All of the testing functions are run even if one of them fails, and code coverage is uploaded even if one of them fails.