### PR TITLE
Renamed three functions for consistency

### DIFF
--- a/doc/examples.xml
+++ b/doc/examples.xml
@@ -669,9 +669,9 @@ gap> D := BananaTree(3, 4);
 </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="TadpoleDigraph">
+<#GAPDoc Label="TadpoleGraph">
 <ManSection>
-  <Oper Name="TadpoleDigraph" Arg="[filt, ]m, n"/>
+  <Oper Name="TadpoleGraph" Arg="[filt, ]m, n"/>
   <Returns>A digraph.</Returns>
   <Description>
     The <E>Tadpole digraph</E> is the symmetric closure of the disjoint union
@@ -695,20 +695,20 @@ gap> D := BananaTree(3, 4);
       Filt="IsImmutableDigraph"/> is used by default.<P/>
 
     <Example><![CDATA[
-gap> TadpoleDigraph(10, 15);
+gap> TadpoleGraph(10, 15);
 <immutable symmetric digraph with 25 vertices, 50 edges>
-gap> TadpoleDigraph(IsMutableDigraph, 5, 6);
+gap> TadpoleGraph(IsMutableDigraph, 5, 6);
 <mutable digraph with 11 vertices, 22 edges>
-gap> IsSymmetricDigraph(TadpoleDigraph(3, 5));
+gap> IsSymmetricDigraph(TadpoleGraph(3, 5));
 true
 ]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="BookDigraph">
+<#GAPDoc Label="BookGraph">
 <ManSection>
-  <Oper Name="BookDigraph" Arg="[filt, ]m"/>
+  <Oper Name="BookGraph" Arg="[filt, ]m"/>
   <Returns>A digraph.</Returns>
   <Description>
     The <E>Book digraph</E> is the Cartesian product of a complete digraph with 2 vertices
@@ -727,17 +727,17 @@ true
       Filt="IsImmutableDigraph"/> is used by default.<P/>
 
     <Example><![CDATA[
-gap> BookDigraph(1);
+gap> BookGraph(1);
 <immutable bipartite symmetric digraph with bicomponent sizes 2 and 2>
-gap> BookDigraph(2);
+gap> BookGraph(2);
 <immutable bipartite symmetric digraph with bicomponent sizes 3 and 3>
-gap> BookDigraph(IsMutable, 12);
+gap> BookGraph(IsMutable, 12);
 <mutable digraph with 26 vertices, 74 edges>
-gap> BookDigraph(7);
+gap> BookGraph(7);
 <immutable bipartite symmetric digraph with bicomponent sizes 8 and 8>
-gap> IsSymmetricDigraph(BookDigraph(24));
+gap> IsSymmetricDigraph(BookGraph(24));
 true
-gap> IsBipartiteDigraph(BookDigraph(24));
+gap> IsBipartiteDigraph(BookGraph(24));
 true
 ]]></Example>
   </Description>

--- a/doc/examples.xml
+++ b/doc/examples.xml
@@ -493,9 +493,9 @@ gap> TriangularGridGraph(IsMutable, 3, 3);
 </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="StarDigraph">
+<#GAPDoc Label="StarGraph">
 <ManSection>
-  <Oper Name="StarDigraph" Arg="[filt, ]k"/>
+  <Oper Name="StarGraph" Arg="[filt, ]k"/>
   <Returns>A digraph.</Returns>
   <Description>
     If <A>k</A> is a positive integer, then this operation returns the
@@ -516,13 +516,13 @@ gap> TriangularGridGraph(IsMutable, 3, 3);
     If the optional first argument <A>filt</A> is not present, then <Ref
       Filt="IsImmutableDigraph"/> is used by default.<P/>
     <Example><![CDATA[
-gap> StarDigraph(IsMutable, 10);
+gap> StarGraph(IsMutable, 10);
 <mutable digraph with 10 vertices, 18 edges>
-gap> StarDigraph(5);
+gap> StarGraph(5);
 <immutable complete bipartite digraph with bicomponent sizes 1 and 4>
-gap> IsSymmetricDigraph(StarDigraph(3));
+gap> IsSymmetricDigraph(StarGraph(3));
 true
-gap> IsUndirectedTree(StarDigraph(3));
+gap> IsUndirectedTree(StarGraph(3));
 true
 ]]></Example>
   </Description>
@@ -654,7 +654,7 @@ ent sizes 5 and 5>
     If the optional first argument <A>filt</A> is not present, then <Ref
       Filt="IsImmutableDigraph"/> is used by default.<P/>
 
-    See also <Ref Oper="StarDigraph"/> and <Ref Prop="IsUndirectedTree"/>.
+    See also <Ref Oper="StarGraph"/> and <Ref Prop="IsUndirectedTree"/>.
 <Example><![CDATA[
 gap> D := BananaTree(2, 4);
 <immutable undirected tree digraph with 9 vertices>
@@ -716,7 +716,7 @@ true
     For more details on the Book digraph please refer to <URL>https://mathworld.wolfram.com/BookGraph.html</URL>.<P/>
 
     See <Ref Func="DigraphCartesianProduct" Label="for a positive number of digraphs"/>,
-    <Ref Oper="CompleteDigraph"/>, and <Ref Oper="StarDigraph"/>. <P/>
+    <Ref Oper="CompleteDigraph"/>, and <Ref Oper="StarGraph"/>. <P/>
 
     If the optional first argument <A>filt</A> is present, then this should
     specify the category or representation the digraph being created will

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -95,7 +95,7 @@
     <#Include Label="HaarGraph">
     <#Include Label="KingsGraph">
     <#Include Label="KnightsGraph">
-    <#Include Label="StarDigraph">
+    <#Include Label="StarGraph">
     <#Include Label="TadpoleDigraph">
     <#Include Label="BookDigraph">
   </Section>

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -96,8 +96,8 @@
     <#Include Label="KingsGraph">
     <#Include Label="KnightsGraph">
     <#Include Label="StarGraph">
-    <#Include Label="TadpoleDigraph">
-    <#Include Label="BookDigraph">
+    <#Include Label="TadpoleGraph">
+    <#Include Label="BookGraph">
   </Section>
 
 </Chapter>

--- a/gap/examples.gd
+++ b/gap/examples.gd
@@ -67,9 +67,9 @@ DeclareConstructor("TriangularGridGraphCons", [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("TriangularGridGraph", [IsPosInt, IsPosInt]);
 DeclareOperation("TriangularGridGraph", [IsFunction, IsPosInt, IsPosInt]);
 
-DeclareConstructor("StarDigraphCons", [IsDigraph, IsPosInt]);
-DeclareOperation("StarDigraph", [IsPosInt]);
-DeclareOperation("StarDigraph", [IsFunction, IsPosInt]);
+DeclareConstructor("StarGraphCons", [IsDigraph, IsPosInt]);
+DeclareOperation("StarGraph", [IsPosInt]);
+DeclareOperation("StarGraph", [IsFunction, IsPosInt]);
 
 DeclareConstructor("KnightsGraphCons", [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("KnightsGraph", [IsPosInt, IsPosInt]);

--- a/gap/examples.gd
+++ b/gap/examples.gd
@@ -83,10 +83,10 @@ DeclareConstructor("BananaTreeCons", [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("BananaTree", [IsPosInt, IsPosInt]);
 DeclareOperation("BananaTree", [IsFunction, IsPosInt, IsPosInt]);
 
-DeclareConstructor("TadpoleDigraphCons", [IsDigraph, IsPosInt, IsPosInt]);
-DeclareOperation("TadpoleDigraph", [IsInt, IsPosInt]);
-DeclareOperation("TadpoleDigraph", [IsFunction, IsPosInt, IsPosInt]);
+DeclareConstructor("TadpoleGraphCons", [IsDigraph, IsPosInt, IsPosInt]);
+DeclareOperation("TadpoleGraph", [IsInt, IsPosInt]);
+DeclareOperation("TadpoleGraph", [IsFunction, IsPosInt, IsPosInt]);
 
-DeclareConstructor("BookDigraphCons", [IsDigraph, IsPosInt]);
-DeclareOperation("BookDigraph", [IsPosInt]);
-DeclareOperation("BookDigraph", [IsFunction, IsPosInt]);
+DeclareConstructor("BookGraphCons", [IsDigraph, IsPosInt]);
+DeclareOperation("BookGraph", [IsPosInt]);
+DeclareOperation("BookGraph", [IsFunction, IsPosInt]);

--- a/gap/examples.gi
+++ b/gap/examples.gi
@@ -525,7 +525,7 @@ InstallMethod(TriangularGridGraph, "for two positive integers",
 [IsPosInt, IsPosInt],
 {n, k} -> TriangularGridGraphCons(IsImmutableDigraph, n, k));
 
-InstallMethod(StarDigraphCons, "for IsMutableDigraph and a positive integer",
+InstallMethod(StarGraphCons, "for IsMutableDigraph and a positive integer",
 [IsMutableDigraph, IsPosInt],
 function(filt, k)
   if k = 1 then
@@ -534,19 +534,19 @@ function(filt, k)
   return CompleteBipartiteDigraph(IsMutableDigraph, 1, k - 1);
 end);
 
-InstallMethod(StarDigraph, "for a function and a positive integer",
+InstallMethod(StarGraph, "for a function and a positive integer",
 [IsFunction, IsPosInt],
-StarDigraphCons);
+StarGraphCons);
 
-InstallMethod(StarDigraph, "for integer", [IsPosInt],
-{k} -> StarDigraphCons(IsImmutableDigraph, k));
+InstallMethod(StarGraph, "for integer", [IsPosInt],
+{k} -> StarGraphCons(IsImmutableDigraph, k));
 
-InstallMethod(StarDigraphCons,
+InstallMethod(StarGraphCons,
 "for IsImmutableDigraph and a positive integer",
 [IsImmutableDigraph, IsPosInt],
 function(filt, k)
   local D;
-  D := MakeImmutable(StarDigraph(IsMutableDigraph, k));
+  D := MakeImmutable(StarGraph(IsMutableDigraph, k));
   SetIsMultiDigraph(D, false);
   SetIsEmptyDigraph(D, k = 1);
   SetIsCompleteBipartiteDigraph(D, k > 1);
@@ -650,7 +650,7 @@ function(filt, m, n)
     " greater than one");
   fi;
   D := EmptyDigraph(IsMutable, 1);
-  list := Concatenation([D], ListWithIdenticalEntries(m, StarDigraph(n)));
+  list := Concatenation([D], ListWithIdenticalEntries(m, StarGraph(n)));
   DigraphDisjointUnion(list);  # changes <D> in place
   for j in [0 .. (m - 1)] do
     DigraphAddEdges(D, [[1, (j * n + 3)], [(j * n + 3), 1]]);
@@ -717,7 +717,7 @@ InstallMethod(BookDigraphCons,
 function(filt, m)
   local book;
   book := CompleteDigraph(IsMutable, 2);
-  return DigraphCartesianProduct(book, StarDigraph(IsMutable, m + 1));
+  return DigraphCartesianProduct(book, StarGraph(IsMutable, m + 1));
 end);
 
 InstallMethod(BookDigraph, "for a function and one positive integer",

--- a/gap/examples.gi
+++ b/gap/examples.gi
@@ -678,7 +678,7 @@ InstallMethod(BananaTree, "for a function and two positive integers",
 [IsFunction, IsPosInt, IsPosInt],
 {filt, m, n} -> BananaTreeCons(filt, m, n));
 
-InstallMethod(TadpoleDigraphCons,
+InstallMethod(TadpoleGraphCons,
 "for IsMutableDigraph and two positive integers",
 [IsMutableDigraph, IsPosInt, IsPosInt],
 function(filt, m, n)
@@ -693,25 +693,25 @@ function(filt, m, n)
   return graph;
 end);
 
-InstallMethod(TadpoleDigraph, "for a function and two positive integers",
+InstallMethod(TadpoleGraph, "for a function and two positive integers",
 [IsFunction, IsPosInt, IsPosInt],
-TadpoleDigraphCons);
+TadpoleGraphCons);
 
-InstallMethod(TadpoleDigraph, "for two positive integers", [IsPosInt, IsPosInt],
-{m, n} -> TadpoleDigraphCons(IsImmutableDigraph, m, n));
+InstallMethod(TadpoleGraph, "for two positive integers", [IsPosInt, IsPosInt],
+{m, n} -> TadpoleGraphCons(IsImmutableDigraph, m, n));
 
-InstallMethod(TadpoleDigraphCons,
+InstallMethod(TadpoleGraphCons,
 "for IsImmutableDigraph and two positive integers",
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(filt, m, n)
   local D;
-  D := MakeImmutable(TadpoleDigraph(IsMutableDigraph, m, n));
+  D := MakeImmutable(TadpoleGraph(IsMutableDigraph, m, n));
   SetIsMultiDigraph(D, false);
   SetIsSymmetricDigraph(D, true);
   return D;
 end);
 
-InstallMethod(BookDigraphCons,
+InstallMethod(BookGraphCons,
 "for IsMutableDigraph and one positive integer",
 [IsMutableDigraph, IsPosInt],
 function(filt, m)
@@ -720,19 +720,19 @@ function(filt, m)
   return DigraphCartesianProduct(book, StarGraph(IsMutable, m + 1));
 end);
 
-InstallMethod(BookDigraph, "for a function and one positive integer",
+InstallMethod(BookGraph, "for a function and one positive integer",
 [IsFunction, IsPosInt],
-BookDigraphCons);
+BookGraphCons);
 
-InstallMethod(BookDigraph, "for one positive integer", [IsPosInt],
-{m} -> BookDigraphCons(IsImmutableDigraph, m));
+InstallMethod(BookGraph, "for one positive integer", [IsPosInt],
+{m} -> BookGraphCons(IsImmutableDigraph, m));
 
-InstallMethod(BookDigraphCons,
+InstallMethod(BookGraphCons,
 "for IsImmutableDigraph and one positive integer",
 [IsImmutableDigraph, IsPosInt],
 function(filt, m)
   local D;
-  D := MakeImmutable(BookDigraph(IsMutableDigraph, m));
+  D := MakeImmutable(BookGraph(IsMutableDigraph, m));
   SetIsMultiDigraph(D, false);
   SetIsSymmetricDigraph(D, true);
   SetIsBipartiteDigraph(D, true);

--- a/tst/standard/examples.tst
+++ b/tst/standard/examples.tst
@@ -288,18 +288,18 @@ gap> TriangularGridGraph(3, 1);
 <immutable connected bipartite symmetric digraph with bicomponent sizes 2 and \
 1>
 
-# StarDigraph
-gap> StarDigraph(IsMutable, 10);
+# StarGraph
+gap> StarGraph(IsMutable, 10);
 <mutable digraph with 10 vertices, 18 edges>
-gap> StarDigraph(IsImmutableDigraph, 10);
+gap> StarGraph(IsImmutableDigraph, 10);
 <immutable complete bipartite digraph with bicomponent sizes 1 and 9>
-gap> StarDigraph(3);
+gap> StarGraph(3);
 <immutable complete bipartite digraph with bicomponent sizes 1 and 2>
-gap> StarDigraph(1);
+gap> StarGraph(1);
 <immutable empty digraph with 1 vertex>
-gap> IsSymmetricDigraph(StarDigraph(3));
+gap> IsSymmetricDigraph(StarGraph(3));
 true
-gap> IsMultiDigraph(StarDigraph(3));
+gap> IsMultiDigraph(StarGraph(3));
 false
 
 #  Knight's Graph

--- a/tst/standard/examples.tst
+++ b/tst/standard/examples.tst
@@ -353,32 +353,32 @@ gap> D := BananaTree(IsMutableDigraph, 5, 3);
 gap> BananaTree(3, 1);
 Error, The second argument must be an integer greater than one
 
-# TadPoleDigraph
-gap> TadpoleDigraph(2, 2);
+# TadpoleGraph
+gap> TadpoleGraph(2, 2);
 Error, the first argument <m> must be an integer greater than 2
-gap> TadpoleDigraph(10, 15);
+gap> TadpoleGraph(10, 15);
 <immutable symmetric digraph with 25 vertices, 50 edges>
-gap> TadpoleDigraph(IsMutableDigraph, 5, 6);
+gap> TadpoleGraph(IsMutableDigraph, 5, 6);
 <mutable digraph with 11 vertices, 22 edges>
-gap> IsSymmetricDigraph(TadpoleDigraph(3, 5));
+gap> IsSymmetricDigraph(TadpoleGraph(3, 5));
 true
-gap> TadpoleDigraph(3, 1);
+gap> TadpoleGraph(3, 1);
 <immutable symmetric digraph with 4 vertices, 8 edges>
 
-# BookDigraph
-gap> BookDigraph(1);
+# BookGraph
+gap> BookGraph(1);
 <immutable bipartite symmetric digraph with bicomponent sizes 2 and 2>
-gap> BookDigraph(2);
+gap> BookGraph(2);
 <immutable bipartite symmetric digraph with bicomponent sizes 3 and 3>
-gap> BookDigraph(7);
+gap> BookGraph(7);
 <immutable bipartite symmetric digraph with bicomponent sizes 8 and 8>
-gap> BookDigraph(12);
+gap> BookGraph(12);
 <immutable bipartite symmetric digraph with bicomponent sizes 13 and 13>
-gap> BookDigraph(IsMutable, 12);
+gap> BookGraph(IsMutable, 12);
 <mutable digraph with 26 vertices, 74 edges>
-gap> IsSymmetricDigraph(BookDigraph(24));
+gap> IsSymmetricDigraph(BookGraph(24));
 true
-gap> IsBipartiteDigraph(BookDigraph(32));
+gap> IsBipartiteDigraph(BookGraph(32));
 true
 
 #


### PR DESCRIPTION
This fixes the issue raised in https://github.com/digraphs/Digraphs/issues/444

In this pull request:

- StarDigraph is changed to StarGraph
- TadpoleDigraph is changed to TadpoleGraph
- BookDigraph is changed to BookGraph
