### PR TITLE
Add Zykov and Christofides Algorithms for Chromatic Number

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1682,6 +1682,10 @@ gap> DigraphLoops(D);
       <Cite Key="Law1976"/></Item>
       <Item><C>byskov</C> - Byskov's Algorithm 
       <Cite Key="Bys2002"/></Item>
+      <Item><C>zykov</C> - Zykov's Algorithm 
+      <Cite Key="Corneil1973"/></Item>
+      <Item><C>christofides</C> - Christofides's Algorithm 
+      <Cite Key="Wang1974"/></Item>
     </List>
 
     <Example><![CDATA[

--- a/doc/digraphs.bib
+++ b/doc/digraphs.bib
@@ -193,3 +193,35 @@
     pages="313--324",
     isbn="978-3-319-11812-3"
 }
+
+@article{Corneil1973,
+    author = {Corneil, D. G. and Graham, B.},
+    title = {An Algorithm for Determining the Chromatic Number of a Graph},
+    journal = {SIAM Journal on Computing},
+    volume = {2},
+    number = {4},
+    pages = {311-318},
+    year = {1973},
+    doi = {10.1137/0202026},
+    URL = {https://doi.org/10.1137/0202026},
+    eprint = {https://doi.org/10.1137/0202026}
+}
+
+@article{Wang1974,
+    author= {Wang, Chung C.},
+    title = {An Algorithm for the Chromatic Number of a Graph},
+    year = {1974},
+    issue_date = {July 1974},
+    publisher = {Association for Computing Machinery},
+    address = {New York, NY, USA},
+    volume = {21},
+    number = {3},
+    issn = {0004-5411},
+    url = {https://doi.org/10.1145/321832.321837},
+    doi = {10.1145/321832.321837},
+    abstract = {Christofides' algorithm for finding the chromatic number of a graph is improved both in speed and memory space by using a depth-first search rule to search for a shortest path in a reduced subgraph tree.},
+    journal = {J. ACM},
+    month = jul,
+    pages = {385–391},
+    numpages = {7}
+}

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -568,7 +568,8 @@ function(D)
       # into a single new vertex with the edges merged.
       # We merge y into x, keeping x.
 
-      # TODO Use DigraphContractEdge once it is implemented.
+      # We could potentially use quotient digraph here, but the increased
+      # generality might cause this to get slower.
       D_contract := DigraphMutableCopy(D);
       for v in vertices do
          # Iterate over all vertices that are not x or y

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -551,7 +551,8 @@ function(D)
         # Search for the first vertex not adjacent to all others
         # This is guaranteed to exist as D is not the complete graph.
         if OutDegreeOfVertex(D, x) < nr - 1 then
-          # Now search for a non-adjacent vertex, prioritising higher degree ones
+          # Now search for a non-adjacent vertex, prioritising higher degree
+          # ones
           for j in [i + 1 .. nr] do
             y := vertices[j];
             if not adjacent(x, y) then

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1823,6 +1823,118 @@ Error, the argument <D> must be a digraph with no loops,
 gap> DIGRAPHS_UnderThreeColourable(EmptyDigraph(0));
 0
 
+#  Test ChromaticNumber Zykov
+gap> ChromaticNumber(NullDigraph(10) : zykov);
+1
+gap> ChromaticNumber(CompleteDigraph(10) : zykov);
+10
+gap> ChromaticNumber(CompleteBipartiteDigraph(5, 5) : zykov);
+2
+gap> ChromaticNumber(DigraphRemoveEdge(CompleteDigraph(10), [1, 2]) : zykov);
+10
+gap> ChromaticNumber(Digraph([[4, 8], [6, 10], [9], [2, 3, 9], [],
+> [3], [4], [6], [], [5, 7]]) : zykov);
+3
+gap> ChromaticNumber(DigraphDisjointUnion(CompleteDigraph(1),
+> Digraph([[2], [4], [1, 2], [3]])) : zykov);
+3
+gap> ChromaticNumber(DigraphDisjointUnion(CompleteDigraph(1),
+> Digraph([[2], [4], [1, 2], [3], [1, 2, 3]])) : zykov);
+4
+gap> gr := Digraph([[2, 3, 4], [3], [], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> ChromaticNumber(gr : zykov);
+3
+gap> ChromaticNumber(EmptyDigraph(0) : zykov);
+0
+gap> gr := CompleteDigraph(4);;
+gap> gr := DigraphAddVertex(gr);;
+gap> ChromaticNumber(gr : zykov);
+4
+gap> gr := Digraph([[2, 4, 7, 3], [3, 5, 8, 1], [1, 6, 9, 2],
+> [5, 7, 1, 6], [6, 8, 2, 4], [4, 9, 3, 5], [8, 1, 4, 9], [9, 2, 5, 7],
+> [7, 3, 6, 8]]);;
+gap> ChromaticNumber(gr : zykov);
+3
+gap> gr := DigraphSymmetricClosure(ChainDigraph(5));
+<immutable symmetric digraph with 5 vertices, 8 edges>
+gap> ChromaticNumber(gr : zykov);
+2
+gap> gr := DigraphFromGraph6String("KmKk~K??G@_@");
+<immutable symmetric digraph with 12 vertices, 42 edges>
+gap> ChromaticNumber(gr : zykov);
+4
+gap> gr := CycleDigraph(7);
+<immutable cycle digraph with 7 vertices>
+gap> ChromaticNumber(gr : zykov);
+3
+gap> ChromaticNumber(gr : zykov);
+3
+gap> ChromaticNumber(gr : zykov);
+3
+gap> a := DigraphRemoveEdges(CompleteDigraph(50), [[1, 2], [2, 1]]);;
+gap> b := DigraphAddVertex(a);;
+gap> ChromaticNumber(a : zykov);
+49
+gap> ChromaticNumber(b : zykov);
+49
+
+#  Test ChromaticNumber Christofides
+gap> ChromaticNumber(NullDigraph(10) : christofides);
+1
+gap> ChromaticNumber(CompleteDigraph(10) : christofides);
+10
+gap> ChromaticNumber(CompleteBipartiteDigraph(5, 5) : christofides);
+2
+gap> ChromaticNumber(DigraphRemoveEdge(CompleteDigraph(10), [1, 2]) : christofides);
+10
+gap> ChromaticNumber(Digraph([[4, 8], [6, 10], [9], [2, 3, 9], [],
+> [3], [4], [6], [], [5, 7]]) : christofides);
+3
+gap> ChromaticNumber(DigraphDisjointUnion(CompleteDigraph(1),
+> Digraph([[2], [4], [1, 2], [3]])) : christofides);
+3
+gap> ChromaticNumber(DigraphDisjointUnion(CompleteDigraph(1),
+> Digraph([[2], [4], [1, 2], [3], [1, 2, 3]])) : christofides);
+4
+gap> gr := Digraph([[2, 3, 4], [3], [], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> ChromaticNumber(gr : christofides);
+3
+gap> ChromaticNumber(EmptyDigraph(0) : christofides);
+0
+gap> gr := CompleteDigraph(4);;
+gap> gr := DigraphAddVertex(gr);;
+gap> ChromaticNumber(gr : christofides);
+4
+gap> gr := Digraph([[2, 4, 7, 3], [3, 5, 8, 1], [1, 6, 9, 2],
+> [5, 7, 1, 6], [6, 8, 2, 4], [4, 9, 3, 5], [8, 1, 4, 9], [9, 2, 5, 7],
+> [7, 3, 6, 8]]);;
+gap> ChromaticNumber(gr : christofides);
+3
+gap> gr := DigraphSymmetricClosure(ChainDigraph(5));
+<immutable symmetric digraph with 5 vertices, 8 edges>
+gap> ChromaticNumber(gr : christofides);
+2
+gap> gr := DigraphFromGraph6String("KmKk~K??G@_@");
+<immutable symmetric digraph with 12 vertices, 42 edges>
+gap> ChromaticNumber(gr : christofides);
+4
+gap> gr := CycleDigraph(7);
+<immutable cycle digraph with 7 vertices>
+gap> ChromaticNumber(gr : christofides);
+3
+gap> ChromaticNumber(gr : christofides);
+3
+gap> ChromaticNumber(gr : christofides);
+3
+gap> a := DigraphRemoveEdges(CompleteDigraph(50), [[1, 2], [2, 1]]);;
+gap> b := DigraphAddVertex(a);;
+gap> ChromaticNumber(a : christofides);
+49
+gap> ChromaticNumber(b : christofides);
+49
+
 #  DegreeMatrix
 gap> gr := Digraph([[2, 3, 4], [2, 5], [1, 5, 4], [1], [1, 1, 2, 4]]);;
 gap> DegreeMatrix(gr);


### PR DESCRIPTION
Add Zykov and Christofides Algorithms for Chromatic Number. This builds on the previous pull request #382 to add two additional algorithms for calculating the Chromatic Number. These use the same method selection as the existing implementations, and so are simply additional options to use.