### PR TITLE
Add more implications (including some implications of falsity)

### DIFF
--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -717,7 +717,8 @@ false
     <K>false</K> if it is not. A digraph is <E>empty</E> if it has no
     edges.<P/>
 
-    <C>IsNullDigraph</C> is a synonym for <C>IsEmptyDigraph</C>.
+    <Ref Prop="IsNullDigraph"/> is a synonym for <Ref Prop="IsEmptyDigraph"/>.
+    See also <Ref Prop="IsNonemptyDigraph"/>.
     <P/>
 
     &MUTABLE_RECOMPUTED_PROP;
@@ -734,6 +735,93 @@ gap> D := Digraph([[], [1]]);
 gap> IsEmptyDigraph(D);
 false
 gap> IsNullDigraph(D);
+false]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsNonemptyDigraph">
+<ManSection>
+  <Prop Name="IsNonemptyDigraph" Arg="digraph"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description>
+    Returns <K>true</K> if the digraph <A>digraph</A> is nonempty, and
+    <K>false</K> if it is not. A digraph is <E>nonempty</E> if it has at
+    least one edge.<P/>
+
+    See also <Ref Prop="IsEmptyDigraph"/>.
+    <P/>
+
+    &MUTABLE_RECOMPUTED_PROP;
+
+    <Example><![CDATA[
+gap> D := Digraph([[], []]);
+<immutable empty digraph with 2 vertices>
+gap> IsNonemptyDigraph(D);
+false
+gap> D := Digraph([[], [1]]);
+<immutable digraph with 2 vertices, 1 edge>
+gap> IsNonemptyDigraph(D);
+true]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DigraphHasAVertex">
+<ManSection>
+  <Prop Name="DigraphHasAVertex" Arg="digraph"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description>
+    Returns <K>true</K> if the digraph <A>digraph</A> has at least one vertex,
+    and <K>false</K> if it does not.<P/>
+
+    See also <Ref Prop="DigraphHasNoVertices"/>.
+    <P/>
+
+    &MUTABLE_RECOMPUTED_PROP;
+
+    <Example><![CDATA[
+gap> D := Digraph([]);
+<immutable empty digraph with 0 vertices>
+gap> DigraphHasAVertex(D);
+false
+gap> D := Digraph([[]]);
+<immutable empty digraph with 1 vertex>
+gap> DigraphHasAVertex(D);
+true
+gap> D := Digraph([[], [1]]);
+<immutable digraph with 2 vertices, 1 edge>
+gap> DigraphHasAVertex(D);
+true]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DigraphHasNoVertices">
+<ManSection>
+  <Prop Name="DigraphHasNoVertices" Arg="digraph"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description>
+    Returns <K>true</K> if the digraph <A>digraph</A> is the unique digraph
+    with zero vertices, and <K>false</K> otherwise.<P/>
+
+    See also <Ref Prop="DigraphHasAVertex"/>.
+    <P/>
+
+    &MUTABLE_RECOMPUTED_PROP;
+
+    <Example><![CDATA[
+gap> D := Digraph([]);
+<immutable empty digraph with 0 vertices>
+gap> DigraphHasNoVertices(D);
+true
+gap> D := Digraph([[]]);
+<immutable empty digraph with 1 vertex>
+gap> DigraphHasNoVertices(D);
+false
+gap> D := Digraph([[], [1]]);
+<immutable digraph with 2 vertices, 1 edge>
+gap> DigraphHasNoVertices(D);
 false]]></Example>
   </Description>
 </ManSection>

--- a/doc/z-chap5.xml
+++ b/doc/z-chap5.xml
@@ -1,5 +1,10 @@
 <Chapter Label="Properties of digraphs"><Heading>Properties of digraphs</Heading>
 
+  <Section><Heading>Vertex properties</Heading>
+    <#Include Label="DigraphHasAVertex">
+    <#Include Label="DigraphHasNoVertices">
+  </Section>
+
   <Section><Heading>Edge properties</Heading>
     <#Include Label="DigraphHasLoops">
     <#Include Label="IsAntisymmetricDigraph">
@@ -12,6 +17,7 @@
     <#Include Label="IsFunctionalDigraph">
     <#Include Label="IsPermutationDigraph">
     <#Include Label="IsMultiDigraph">
+    <#Include Label="IsNonemptyDigraph">
     <#Include Label="IsReflexiveDigraph">
     <#Include Label="IsSymmetricDigraph">
     <#Include Label="IsTournament">

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1080,7 +1080,7 @@ function(D)
   # alter the answer for the diameter/girth if necessary.  This function is
   # called, if appropriate, by DigraphDiameter and DigraphUndirectedGirth.
 
-  if DigraphNrVertices(D) = 0 and IsImmutableDigraph(D) then
+  if DigraphHasNoVertices(D) and IsImmutableDigraph(D) then
     SetDigraphDiameter(D, fail);
     SetDigraphUndirectedGirth(D, infinity);
     return rec(diameter := fail, girth := infinity);
@@ -1491,10 +1491,10 @@ end);
 
 InstallMethod(DegreeMatrix, "for a digraph", [IsDigraph],
 function(D)
-  if DigraphNrVertices(D) = 0 then
-    return [];
+  if DigraphHasAVertex(D) then
+    return DiagonalMat(OutDegrees(D));
   fi;
-  return DiagonalMat(OutDegrees(D));
+  return [];
 end);
 
 InstallMethod(LaplacianMatrix, "for a digraph", [IsDigraph],
@@ -1815,7 +1815,7 @@ function(D)
     SetDigraphAddAllLoopsAttr(D, C);
     SetIsReflexiveDigraph(C, true);
     SetIsMultiDigraph(C, ismulti);
-    SetDigraphHasLoops(C, DigraphNrVertices(C) > 0);
+    SetDigraphHasLoops(C, DigraphHasAVertex(C));
   fi;
   return C;
 end);
@@ -2264,7 +2264,7 @@ InstallMethod(UndirectedSpanningForest, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 function(D)
   local C;
-  if DigraphNrVertices(D) = 0 then
+  if DigraphHasNoVertices(D) then
     return fail;
   fi;
   C := MaximalSymmetricSubdigraph(D)!.OutNeighbours;
@@ -2293,9 +2293,9 @@ InstallMethod(UndirectedSpanningForestAttr, "for an immutable digraph",
 InstallMethod(UndirectedSpanningTree, "for a mutable digraph",
 [IsMutableDigraph],
 function(D)
-  if DigraphNrVertices(D) = 0
-      or not IsStronglyConnectedDigraph(D)
-      or not IsConnectedDigraph(UndirectedSpanningForest(DigraphMutableCopy(D)))
+  if not (DigraphHasAVertex(D)
+      and IsStronglyConnectedDigraph(D)
+      and IsConnectedDigraph(UndirectedSpanningForest(DigraphMutableCopy(D))))
       then
     return fail;
   fi;
@@ -2309,7 +2309,7 @@ InstallMethod(UndirectedSpanningTreeAttr, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   local out;
-  if DigraphNrVertices(D) = 0
+  if DigraphHasNoVertices(D)
       or not IsStronglyConnectedDigraph(D)
       or (HasMaximalSymmetricSubdigraphAttr(D)
           and not IsStronglyConnectedDigraph(MaximalSymmetricSubdigraph(D)))

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1065,7 +1065,7 @@ p -> AsDigraph(AsTransformation(p)));
 InstallMethod(AsBinaryRelation, "for a digraph", [IsDigraphByOutNeighboursRep],
 function(D)
   local rel;
-  if DigraphNrVertices(D) = 0 then
+  if DigraphHasNoVertices(D) then
     ErrorNoReturn("the argument <D> must be a digraph with at least 1 ",
                   "vertex,");
   elif IsMultiDigraph(D) then

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -109,7 +109,7 @@ function(D, n)
 
   # Only the null D with 0 vertices can be coloured with 0 colours
   if n = 0 then
-    if DigraphNrVertices(D) = 0 then
+    if DigraphHasNoVertices(D) then
       return IdentityTransformation;
     fi;
     return fail;

--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -142,7 +142,7 @@ if DIGRAPHS_NautyAvailable then
                                                  colors);
       colors := NautyColorData(colors);
     fi;
-    if DigraphNrVertices(D) = 0 then
+    if DigraphHasNoVertices(D) then
       # This circumvents Issue #17 in NautyTracesInterface, whereby a graph
       # with 0 vertices causes a seg fault.
       return [Group(()), ()];

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -11,6 +11,9 @@
 # meaning it really has multiple edges!!
 DeclareProperty("IsMultiDigraph", IsDigraph);
 
+DeclareProperty("DigraphHasAVertex", IsDigraph);
+DeclareProperty("DigraphHasNoVertices", IsDigraph);
+
 DeclareProperty("DigraphHasLoops", IsDigraph);
 DeclareProperty("IsAcyclicDigraph", IsDigraph);
 DeclareProperty("IsAperiodicDigraph", IsDigraph);
@@ -32,6 +35,7 @@ DeclareProperty("IsUndirectedForest", IsDigraph);
 DeclareProperty("IsEdgeTransitive", IsDigraph);
 DeclareProperty("IsVertexTransitive", IsDigraph);
 DeclareProperty("IsEmptyDigraph", IsDigraph);
+DeclareProperty("IsNonemptyDigraph", IsDigraph);
 DeclareProperty("IsEulerianDigraph", IsDigraph);
 DeclareProperty("IsFunctionalDigraph", IsDigraph);
 DeclareProperty("IsHamiltonianDigraph", IsDigraph);
@@ -98,3 +102,8 @@ InstallTrueMethod(IsSymmetricDigraph, IsCompleteDigraph);
 InstallTrueMethod(IsSymmetricDigraph, IsDigraph and IsUndirectedForest);
 InstallTrueMethod(IsTransitiveDigraph, IsTournament and IsAcyclicDigraph);
 InstallTrueMethod(IsUndirectedForest, IsDigraph and IsUndirectedTree);
+
+InstallTrueMethod(IsNonemptyDigraph, IsDigraph and DigraphHasLoops);
+InstallTrueMethod(DigraphHasLoops, IsReflexiveDigraph and DigraphHasAVertex);
+InstallTrueMethod(DigraphHasAVertex, IsDigraph and IsNonemptyDigraph);
+InstallTrueMethod(DigraphHasAVertex, IsDigraph and IsDirectedTree);

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -107,3 +107,44 @@ InstallTrueMethod(IsNonemptyDigraph, IsDigraph and DigraphHasLoops);
 InstallTrueMethod(DigraphHasLoops, IsReflexiveDigraph and DigraphHasAVertex);
 InstallTrueMethod(DigraphHasAVertex, IsDigraph and IsNonemptyDigraph);
 InstallTrueMethod(DigraphHasAVertex, IsDigraph and IsDirectedTree);
+
+# Implications that something is false
+
+InstallTrueMethod(HasDigraphHasLoops, IsAcyclicDigraph);
+InstallTrueMethod(HasDigraphHasLoops, IsTournament);
+InstallTrueMethod(HasDigraphHasLoops, IsUndirectedForest);
+InstallTrueMethod(HasDigraphHasLoops, IsDirectedTree);
+InstallTrueMethod(HasDigraphHasLoops, IsEmptyDigraph);
+InstallTrueMethod(HasDigraphHasLoops, IsCompleteDigraph and IsNonemptyDigraph);
+InstallTrueMethod(HasDigraphHasLoops, IsBipartiteDigraph);
+
+InstallTrueMethod(HasIsNonemptyDigraph, IsEmptyDigraph);
+InstallTrueMethod(HasIsEmptyDigraph, IsNonemptyDigraph);
+InstallTrueMethod(HasDigraphHasAVertex, DigraphHasNoVertices);
+InstallTrueMethod(HasDigraphHasNoVertices, DigraphHasAVertex);
+
+InstallTrueMethod(HasIsAcyclicDigraph, IsCompleteDigraph and IsNonemptyDigraph);
+InstallTrueMethod(HasIsAcyclicDigraph, IsDigraph and DigraphHasLoops);
+InstallTrueMethod(HasIsAcyclicDigraph,
+                  IsStronglyConnectedDigraph and IsNonemptyDigraph);
+InstallTrueMethod(HasIsAntisymmetricDigraph,
+                  IsCompleteDigraph and IsNonemptyDigraph);
+InstallTrueMethod(HasIsChainDigraph, IsDigraph and DigraphHasLoops);
+InstallTrueMethod(HasIsChainDigraph, IsSymmetricDigraph and IsNonemptyDigraph);
+InstallTrueMethod(HasIsCompleteDigraph, IsDigraph and DigraphHasLoops);
+InstallTrueMethod(HasIsReflexiveDigraph,
+                  IsAcyclicDigraph and DigraphHasAVertex);
+
+InstallTrueMethod(HasIsSymmetricDigraph, IsDirectedTree and IsNonemptyDigraph);
+InstallTrueMethod(HasIsSymmetricDigraph, IsTournament and IsNonemptyDigraph);
+InstallTrueMethod(HasIsSymmetricDigraph,
+                  IsAcyclicDigraph and IsNonemptyDigraph);
+
+InstallTrueMethod(HasIsMultiDigraph, IsChainDigraph);
+InstallTrueMethod(HasIsMultiDigraph, IsCompleteDigraph);
+InstallTrueMethod(HasIsMultiDigraph, IsCompleteMultipartiteDigraph);
+InstallTrueMethod(HasIsMultiDigraph, IsCycleDigraph);
+InstallTrueMethod(HasIsMultiDigraph, IsEmptyDigraph);
+InstallTrueMethod(HasIsMultiDigraph, IsFunctionalDigraph);
+InstallTrueMethod(HasIsMultiDigraph, IsTournament);
+InstallTrueMethod(HasIsMultiDigraph, IsUndirectedForest);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  prop.gi
-##  Copyright (C) 2014-19                                James D. Mitchell
+##  Copyright (C) 2014-21                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -12,6 +12,15 @@
 InstallMethod(IsMultiDigraph, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 IS_MULTI_DIGRAPH);
+
+InstallMethod(DigraphHasNoVertices, "for a digraph", [IsDigraph],
+D -> not DigraphHasAVertex(D));
+
+InstallMethod(DigraphHasAVertex, "for a digraph", [IsDigraph],
+D -> DigraphNrVertices(D) > 0);
+
+InstallMethod(IsNonemptyDigraph, "for a digraph", [IsDigraph],
+D -> not IsEmptyDigraph(D));
 
 InstallMethod(IsChainDigraph, "for a digraph", [IsDigraph],
 D -> IsDirectedTree(D) and IsSubset([0, 1], OutDegreeSet(D)));

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -27,7 +27,7 @@ D -> IsDirectedTree(D) and IsSubset([0, 1], OutDegreeSet(D)));
 
 InstallMethod(IsCycleDigraph, "for a digraph", [IsDigraph],
 function(D)
-  return DigraphNrVertices(D) > 0
+  return DigraphHasAVertex(D)
      and DigraphNrEdges(D) = DigraphNrVertices(D)
      and IsStronglyConnectedDigraph(D);
 end);
@@ -393,8 +393,8 @@ D -> DigraphNrEdges(D) = 2 * (DigraphNrVertices(D) - 1)
 
 InstallMethod(IsUndirectedForest, "for a digraph", [IsDigraph],
 function(D)
-  if not IsSymmetricDigraph(D) or DigraphNrVertices(D) = 0
-      or IsMultiDigraph(D) then
+  if DigraphHasNoVertices(D) or not IsSymmetricDigraph(D) or IsMultiDigraph(D)
+      then
     return false;
   fi;
   return ForAll(DigraphConnectedComponents(D).comps,

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  standard/prop.tst
-#Y  Copyright (C) 2014-17                                James D. Mitchell
+#Y  Copyright (C) 2014-21                                James D. Mitchell
 ##                                                          Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
@@ -139,7 +139,7 @@ gap> gr := Digraph([[1]]);;
 gap> DigraphHasLoops(gr);
 true
 gap> HasIsAcyclicDigraph(gr);
-false
+true
 gap> IsAcyclicDigraph(gr);
 false
 gap> gr := Digraph([[2], []]);
@@ -1570,6 +1570,196 @@ gap> ForAny([0 .. 10], i -> IsNonemptyDigraph(Digraph(
 > ListWithIdenticalEntries(i, []))));
 false
 gap> IsNonemptyDigraph(Digraph([[], [3], []]));
+true
+
+# Implications that something is false
+# DigraphHasLoops
+gap> D := Digraph([[2], [], [2]]);;
+gap> SetIsAcyclicDigraph(D, true);
+gap> HasDigraphHasLoops(D) and not DigraphHasLoops(D);
+true
+
+#
+gap> D := Digraph([[2], []]);;
+gap> SetIsTournament(D, true);
+gap> HasDigraphHasLoops(D) and not DigraphHasLoops(D);
+true
+
+#
+gap> D := Digraph([[2], [1, 3, 4], [2], [2], [6], [5]]);;
+gap> SetIsUndirectedForest(D, true);
+gap> HasDigraphHasLoops(D) and not DigraphHasLoops(D);
+true
+
+#
+gap> D := Digraph([[3], [1, 4], [], []]);;
+gap> SetIsDirectedTree(D, true);
+gap> HasDigraphHasLoops(D) and not DigraphHasLoops(D);
+true
+
+#
+gap> D := Digraph([[], []]);;
+gap> SetIsEmptyDigraph(D, true);
+gap> HasDigraphHasLoops(D) and not DigraphHasLoops(D);
+true
+
+#
+gap> D := Digraph([[2, 3], [1, 3], [1, 2]]);;
+gap> SetIsCompleteDigraph(D, true);
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasDigraphHasLoops(D) and not DigraphHasLoops(D);
+true
+
+#
+gap> D := Digraph([[2], []]);;
+gap> SetIsBipartiteDigraph(D, true);
+gap> HasDigraphHasLoops(D) and not DigraphHasLoops(D);
+true
+
+# IsAcyclicDigraph
+gap> D := Digraph([[2], [1]]);;
+gap> SetIsCompleteDigraph(D, true);
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasIsAcyclicDigraph(D) and not IsAcyclicDigraph(D);
+true
+
+#
+gap> D := Digraph([[2, 3], [2], [2]]);;
+gap> SetDigraphHasLoops(D, true);
+gap> HasIsAcyclicDigraph(D) and not IsAcyclicDigraph(D);
+true
+
+#
+gap> D := Digraph([[3], [1], [2]]);;
+gap> SetIsStronglyConnectedDigraph(D, true);
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasIsAcyclicDigraph(D) and not IsAcyclicDigraph(D);
+true
+
+# Other
+gap> D := Digraph([[], []]);;
+gap> SetIsEmptyDigraph(D, true);
+gap> HasIsNonemptyDigraph(D) and not IsNonemptyDigraph(D);
+true
+
+#
+gap> D := Digraph([[], [1]]);;
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasIsEmptyDigraph(D) and not IsEmptyDigraph(D);
+true
+
+#
+gap> D := Digraph([]);;
+gap> SetDigraphHasNoVertices(D, true);
+gap> HasDigraphHasAVertex(D) and not DigraphHasAVertex(D);
+true
+
+#
+gap> D := Digraph([[]]);;
+gap> SetDigraphHasAVertex(D, true);
+gap> HasDigraphHasNoVertices(D) and not DigraphHasNoVertices(D);
+true
+
+#
+gap> D := Digraph([[2], [1]]);;
+gap> SetIsCompleteDigraph(D, true);
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasIsAntisymmetricDigraph(D) and not IsAntisymmetricDigraph(D);
+true
+
+#
+gap> D := Digraph([[2], [3], [3]]);;
+gap> SetDigraphHasLoops(D, true);
+gap> HasIsChainDigraph(D) and not IsChainDigraph(D);
+true
+
+#
+gap> D := Digraph([[2, 3], [1], [1, 4], [3]]);;
+gap> SetIsSymmetricDigraph(D, true);
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasIsChainDigraph(D) and not IsChainDigraph(D);
+true
+
+#
+gap> D := Digraph([[2], [3], [3]]);;
+gap> SetDigraphHasLoops(D, true);
+gap> HasIsCompleteDigraph(D) and not IsCompleteDigraph(D);
+true
+
+#
+gap> D := Digraph([[2], [5], [], [5], [6], []]);;
+gap> SetIsAcyclicDigraph(D, true);
+gap> SetDigraphHasAVertex(D, true);
+gap> HasIsReflexiveDigraph(D) and not IsReflexiveDigraph(D);
+true
+
+# IsSymmetricDigraph
+gap> D := Digraph([[3], [], [2]]);;
+gap> SetIsAcyclicDigraph(D, true);
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasIsSymmetricDigraph(D) and not IsSymmetricDigraph(D);
+true
+
+#
+gap> D := Digraph([[3], [], [2]]);;
+gap> SetIsDirectedTree(D, true);
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasIsSymmetricDigraph(D) and not IsSymmetricDigraph(D);
+true
+
+#
+gap> D := Digraph([[3], [1], [2]]);;
+gap> SetIsTournament(D, true);
+gap> SetIsNonemptyDigraph(D, true);
+gap> HasIsSymmetricDigraph(D) and not IsSymmetricDigraph(D);
+true
+
+# IsMultiDigraph
+gap> D := Digraph([[2], [3], [4], []]);;
+gap> SetIsChainDigraph(D, true);
+gap> HasIsMultiDigraph(D) and not IsMultiDigraph(D);
+true
+
+#
+gap> D := Digraph([[2, 3], [3, 1], [2, 1]]);;
+gap> SetIsCompleteDigraph(D, true);
+gap> HasIsMultiDigraph(D) and not IsMultiDigraph(D);
+true
+
+#
+gap> D := Digraph([[2, 3], [3, 1], [2, 1]]);;
+gap> SetIsCompleteMultipartiteDigraph(D, true);
+gap> HasIsMultiDigraph(D) and not IsMultiDigraph(D);
+true
+
+#
+gap> D := Digraph([[2], [1]]);;
+gap> SetIsCycleDigraph(D, true);
+gap> HasIsMultiDigraph(D) and not IsMultiDigraph(D);
+true
+
+#
+gap> D := Digraph([[], []]);;
+gap> SetIsEmptyDigraph(D, true);
+gap> HasIsMultiDigraph(D) and not IsMultiDigraph(D);
+true
+
+#
+gap> D := Digraph([[3], [2], [3], [1]]);;
+gap> SetIsFunctionalDigraph(D, true);
+gap> HasIsMultiDigraph(D) and not IsMultiDigraph(D);
+true
+
+#
+gap> D := Digraph([[3], [1], [2]]);;
+gap> SetIsTournament(D, true);
+gap> HasIsMultiDigraph(D) and not IsMultiDigraph(D);
+true
+
+#
+gap> D := Digraph([[2], [1, 3, 4], [2], [2], [6], [5]]);;
+gap> SetIsUndirectedForest(D, true);
+gap> HasIsMultiDigraph(D) and not IsMultiDigraph(D);
 true
 
 #  DIGRAPHS_UnbindVariables

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1549,6 +1549,29 @@ true
 gap> IsEdgeTransitive(Digraph([[2], [3, 3, 3], []]));
 Error, the argument <D> must be a digraph with no multiple edges,
 
+# DigraphHasNoVertices and DigraphHasAVertex
+gap> List([0 .. 3], i -> DigraphHasAVertex(EmptyDigraph(i)));
+[ false, true, true, true ]
+gap> List([0 .. 3], i -> DigraphHasNoVertices(EmptyDigraph(i)));
+[ true, false, false, false ]
+gap> DigraphHasAVertex(Digraph([]));
+false
+gap> DigraphHasNoVertices(Digraph([]));
+true
+gap> DigraphHasAVertex(Digraph([[1]]));
+true
+gap> DigraphHasNoVertices(Digraph([[1]]));
+false
+
+# IsNonemptyDigraph
+gap> ForAny([0 .. 10], i -> IsNonemptyDigraph(EmptyDigraph(i)));
+false
+gap> ForAny([0 .. 10], i -> IsNonemptyDigraph(Digraph(
+> ListWithIdenticalEntries(i, []))));
+false
+gap> IsNonemptyDigraph(Digraph([[], [3], []]));
+true
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(circuit);


### PR DESCRIPTION
I learned recently (see the discussion starting https://github.com/gap-system/gap/pull/4546#discussion_r646906841) that you can use
```
InstallTrueMethod( HasIsX, IsY );
```
to, in practice, automatically set `IsX(D) = false` when `IsY(D) = true` becomes known. The only pitfall is that if `IsX(D)` is already (i.e. wrongly) set to `true`, then this true method doesn't do anything; in particular it doesn't complain. So this doesn't help us to catch bugs (where properties get set incorrectly), but we weren't catching them anyway, and it does offer useful functionality for storing learned information.

Therefore I have added some such '`InstallFalseMethod`'s to Digraphs. This was made easier with the addition of `DigraphHasVertices` and `DigraphHasEdges`, which allows me to easily exclude some trivial exceptions which would otherwise stop certain implications being added.

I also added immediate methods for these things so that they are set to true or false once the attributes `DigraphNrVertices` and `DigraphNrEdges` are known; similarly, I added immediate methods for `DigraphNrVertices` and `DigraphNrEdges` once the attributes `DigraphVertices` and `DigraphEdges` are known.

I still need to add documentation and tests, and possibly I'll come up with some more `InstallTrueMethod`s to add.