### PR TITLE
Use macros to reduce amounts of repeated text in the manual

### DIFF
--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -368,11 +368,12 @@ gap> DigraphByEdges(IsMutableDigraph,
   <C>[1 .. Length(<A>list</A>)]</C>, then this function returns the
   digraph with vertices <M>E^0=</M><C>[1 .. Length(<A>list</A>)]</C>, and
   edges corresponding to the entries of <A>list</A>. More precisely, there is an
-  edge with source vertex <C>i</C> and range vertex <C>j</C> if <C>i</C> is list
-  <C><A>list</A>[j]</C>. <P/>
+  edge with source vertex <C>i</C> and range vertex <C>j</C> if <C>i</C> is
+  in the list <C><A>list</A>[j]</C>. <P/>
 
-  If <C>i</C> occurs list <C><A>list</A>[j]</C> with multiplicity <C>k</C>,
-  then there are <C>k</C> multiple edges from <C>i</C> to <C>j</C>. <P/>
+  If <C>i</C> occurs in the list <C><A>list</A>[j]</C> with multiplicity
+  <C>k</C>, then there are <C>k</C> multiple edges from <C>i</C> to <C>j</C>.
+  <P/>
 
   See <Ref Attr="InNeighbours"/>.
 

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  digraph.xml
-#Y  Copyright (C) 2014-19                               James D. Mitchell
+#Y  Copyright (C) 2014-21                               James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -114,13 +114,8 @@
     Label = "for a group, list, function, and function"/>
   <Returns>A digraph.</Returns>
   <Description>
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-    Filt="IsImmutableDigraph"/> is used by default.
+    &STANDARD_FILT_TEXT;
+
     <List>
       <Mark>for a list (i.e. an adjacency list)</Mark>
       <Item>
@@ -289,13 +284,7 @@ gap> digraph := Digraph(group, List(f), act, adj);
   <Oper Name="DigraphByAdjacencyMatrix" Arg="[filt, ]list"/>
   <Returns>A digraph.</Returns>
   <Description>
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-    Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
     If <A>list</A> is the adjacency matrix of a digraph in the sense of
     <Ref Attr="AdjacencyMatrix"/>, then this operation returns the digraph
@@ -336,13 +325,7 @@ gap> D := DigraphByAdjacencyMatrix(IsMutableDigraph,
   <Oper Name="DigraphByEdges" Arg="[filt, ]list[, n]"/>
   <Returns>A digraph.</Returns>
   <Description>
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-    Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
     If <A>list</A> is list of pairs of positive integers, then this function
     returns the digraph with the minimum number of vertices <C>m</C> such that
@@ -379,13 +362,7 @@ gap> DigraphByEdges(IsMutableDigraph,
   <Oper Name="DigraphByInNeighbors" Arg="[filt, ]list"/>
   <Returns>A digraph.</Returns>
   <Description>
-  If the optional first argument <A>filt</A> is present, then this should
-  specify the category or representation the digraph being created will
-  belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-  then the digraph being created will be mutable, if <A>filt</A> is <Ref
-  Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-  If the optional first argument <A>filt</A> is not present, then <Ref
-  Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
   If <A>list</A> is a list of lists of positive integers list the range
   <C>[1 .. Length(<A>list</A>)]</C>, then this function returns the
@@ -469,16 +446,10 @@ gap> D := DigraphByInNeighbours(IsMutableDigraph,
     returns <K>fail</K>.
     <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.
+    See also <Ref Attr="AsTransformation"/>.
     <P/>
 
-    See also <Ref Attr="AsTransformation"/>.
+    &STANDARD_FILT_TEXT;
 
     <Example><![CDATA[
 gap> f := Transformation([4, 3, 3, 1, 7, 9, 10, 4, 2, 3]);
@@ -773,13 +744,7 @@ gap> List(D, x -> Size(x));
   <Oper Name="RandomDigraph" Arg="[filt, ]n[, p]"/>
   <Returns>A digraph.</Returns>
   <Description>
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
     If <A>n</A> is a positive integer, then this function returns a random
     digraph with <A>n</A> vertices and without multiple edges. The result
@@ -807,13 +772,7 @@ gap> RandomDigraph(IsMutableDigraph, 1000, 1 / 2);
   <Oper Name="RandomTournament" Arg="[filt, ]n"/>
   <Returns>A digraph.</Returns>
   <Description>
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
     If <A>n</A> is a non-negative integer, this function returns a random
     tournament with <A>n</A> vertices. See <Ref Prop="IsTournament"/>. <P/>
@@ -832,13 +791,7 @@ gap> RandomTournament(IsMutableDigraph, 10);
   <Oper Name="RandomLattice" Arg="n"/>
   <Returns>A digraph.</Returns>
   <Description>
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
     If <A>n</A> is a positive integer, this function return a random lattice
     with <C>m</C> vertices, where it is guaranteed that <C>m</C> is between

--- a/doc/examples.xml
+++ b/doc/examples.xml
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  examples.xml
-#Y  Copyright (C) 2019                              Murray T. Whyte
+#Y  Copyright (C) 2019-21                           Murray T. Whyte
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -16,18 +16,11 @@
   <Description>
     If <A>n</A> is a non-negative integer, this function returns the
     <E>empty</E> or <E>null</E> digraph with <A>n</A> vertices. An empty
-    digraph is one with no edges.
-    <P/>
-      
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    digraph is one with no edges. <P/>
 
-    <C>NullDigraph</C> is a synonym for <C>EmptyDigraph</C>.
+    <C>NullDigraph</C> is a synonym for <C>EmptyDigraph</C>. <P/>
+
+    &STANDARD_FILT_TEXT;
 
     <Example><![CDATA[
 gap> EmptyDigraph(20);
@@ -56,13 +49,7 @@ gap> EmptyDigraph(IsMutableDigraph, 10);
     <A>n</A> (containing the vertices <C>[m + 1 .. m + n]</C>).
     <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.
+    &STANDARD_FILT_TEXT;
 
     <Example><![CDATA[
 gap> CompleteBipartiteDigraph(2, 3);
@@ -86,13 +73,8 @@ gap> CompleteBipartiteDigraph(IsMutableDigraph, 3, 2);
       same independent set.
       <P/>
 
-      If the optional first argument <A>filt</A> is present, then this should
-      specify the category or representation the digraph being created will
-      belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-      then the digraph being created will be mutable, if <A>filt</A> is <Ref
-      Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-      If the optional first argument <A>filt</A> is not present, then <Ref
-        Filt="IsImmutableDigraph"/> is used by default.
+      &STANDARD_FILT_TEXT;
+
       <Example><![CDATA[
 gap> CompleteMultipartiteDigraph([5, 4, 2]);
 <immutable complete multipartite digraph with 11 vertices, 76 edges>
@@ -111,13 +93,8 @@ gap> CompleteMultipartiteDigraph(IsMutableDigraph, [5, 4, 2]);
     If <A>n</A> is a non-negative integer, this function returns the complete
     digraph with <A>n</A> vertices. See <Ref Prop="IsCompleteDigraph"/>. <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.
+    &STANDARD_FILT_TEXT;
+
     <Example><![CDATA[
 gap> CompleteDigraph(20);
 <immutable complete digraph with 20 vertices>
@@ -139,16 +116,11 @@ gap> CompleteDigraph(IsMutableDigraph, 10);
     for each vertex <C>i</C> (with <C>i</C> &lt; <C>n</C>), there is a directed
     edge with source <C>i</C> and range <C>i + 1</C>. <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
-
     The <Ref Oper="DigraphReflexiveTransitiveClosure"/> of a chain represents a
-    total order.
+    total order. <P/>
+
+    &STANDARD_FILT_TEXT;
+
     <Example><![CDATA[
 gap> ChainDigraph(42);
 <immutable chain digraph with 42 vertices>
@@ -171,14 +143,9 @@ gap> ChainDigraph(IsMutableDigraph, 10);
     edge with source <C>i</C> and range <C>i + 1</C>. In addition, there is
     an edge with source <C>n</C> and range <C>1</C>. <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-    Filt="IsImmutableDigraph"/> is used by default.
-  <Example><![CDATA[
+    &STANDARD_FILT_TEXT;
+
+    <Example><![CDATA[
 gap> CycleDigraph(1);
 <immutable digraph with 1 vertex, 1 edge>
 gap> CycleDigraph(123);
@@ -201,17 +168,12 @@ true
     returns a symmetric digraph which corresponds to the undirected <E>Johnson
     graph</E> <M>J(n, k)</M>. <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
-
     The <E>Johnson graph</E> <M>J(n, k)</M> has vertices given by all the
     <A>k</A>-subsets of the range <C>[1 .. <A>n</A>]</C>, and two vertices are
-      connected by an edge iff their intersection has size <M><A>k</A> - 1</M>.
+    connected by an edge if and only if their intersection has size
+    <M><A>k</A> - 1</M>. <P/>
+
+    &STANDARD_FILT_TEXT;
 
     <Example><![CDATA[
 gap> gr := JohnsonDigraph(3, 1);
@@ -245,18 +207,12 @@ gap> JohnsonDigraph(IsMutableDigraph, 1, 0);
     many problems in graph theory. The Petersen graph is named after Julius
     Petersen, who in 1898 constructed it to be the smallest bridgeless cubic
     graph with no three-edge-coloring.</Q><P/>
-    
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
 
-    See also <Ref Oper="GeneralisedPetersenGraph"/>.
+    See also <Ref Oper="GeneralisedPetersenGraph"/>. <P/>
 
-<Example><![CDATA[
+    &STANDARD_FILT_TEXT;
+
+    <Example><![CDATA[
 gap> ChromaticNumber(PetersenGraph());
 3
 gap> PetersenGraph(IsMutableDigraph);
@@ -287,15 +243,9 @@ gap> PetersenGraph(IsMutableDigraph);
     Coxeter and was given its name in 1969 by Mark Watkins.</Q>
     <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    See also <Ref Oper="PetersenGraph"/>. <P/>
 
-    See also <Ref Oper="PetersenGraph"/>.
+    &STANDARD_FILT_TEXT;
 
 <Example><![CDATA[
 gap> GeneralisedPetersenGraph(7, 2);
@@ -328,13 +278,7 @@ gap> GeneralisedPetersenGraph(IsMutableDigraph, 9, 4);
     connected by a bridge
     (the edge <C>[<A>m</A>, <A>m</A>+1]</C> and its reverse). <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable.
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.
+    &STANDARD_FILT_TEXT;
 
 <Example><![CDATA[
 gap> D := LollipopGraph(5, 3);
@@ -381,15 +325,9 @@ gap> LollipopGraph(IsMutableDigraph, 3, 8);
     
     See also <Ref Oper="SquareGridGraph"/> and
     <Ref Oper="TriangularGridGraph"/>. <P/>
-    
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable.
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
-    
+
+    &STANDARD_FILT_TEXT;
+
     <Example><![CDATA[
 gap> KingsGraph(8, 8);
 <immutable connected symmetric digraph with 64 vertices, 420 edges>
@@ -433,15 +371,9 @@ gap> OutNeighbors(D);
     See <URL>https://en.wikipedia.org/wiki/Lattice_graph</URL>
     for more information.  <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable.
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
-    
-<Example><![CDATA[
+    &STANDARD_FILT_TEXT;
+
+    <Example><![CDATA[
 gap> SquareGridGraph(5, 5);
 <immutable connected bipartite symmetric digraph with bicomponent size\
 s 13 and 12>
@@ -474,16 +406,10 @@ gap> GridGraph(IsMutable, 3, 4);
 
     See <URL>https://en.wikipedia.org/wiki/Lattice_graph#Other_kinds</URL>
     for more information.  <P/>
-    
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable.
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
 
-<Example><![CDATA[
+    &STANDARD_FILT_TEXT;
+
+    <Example><![CDATA[
 gap> TriangularGridGraph(3, 3);
 <immutable connected symmetric digraph with 9 vertices, 32 edges>
 gap> TriangularGridGraph(IsMutable, 3, 3);
@@ -508,13 +434,8 @@ gap> TriangularGridGraph(IsMutable, 3, 3);
     See <Ref Prop="IsUndirectedTree"/>, <Ref Prop="IsCompleteBipartiteDigraph"/>,
     and <Ref Attr="DigraphBicomponents"/>. <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
+
     <Example><![CDATA[
 gap> StarGraph(IsMutable, 10);
 <mutable digraph with 10 vertices, 18 edges>
@@ -549,13 +470,7 @@ true
     graph is a knight's graph of an <A>m</A> by <A>n</A> chessboard.</Q>
     <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable.
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
 <Example><![CDATA[
 gap> D := KnightsGraph(8, 8);
@@ -591,13 +506,7 @@ gap> KnightsGraph(IsMutable, 3, 9);
     the binary representation of <A>n</A> has a 1 in position
     (<M>j-i</M> modulo <M>m</M>) + 1 from the left. <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable.
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
 <Example><![CDATA[
 gap> HaarGraph(3);
@@ -636,17 +545,12 @@ ent sizes 5 and 5>
     <C>[((m - 1) * n) + 2 .. (m * n) + 1]</C>,
     with the first of these being the 'centre' of the star,
     and the second being the 'leaf' adjacent <C>1</C>. <P/>
-    
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable.
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
 
-    See also <Ref Oper="StarGraph"/> and <Ref Prop="IsUndirectedTree"/>.
-<Example><![CDATA[
+    See also <Ref Oper="StarGraph"/> and <Ref Prop="IsUndirectedTree"/>. <P/>
+
+    &STANDARD_FILT_TEXT;
+
+    <Example><![CDATA[
 gap> D := BananaTree(2, 4);
 <immutable undirected tree digraph with 9 vertices>
 gap> D := BananaTree(3, 3);
@@ -677,13 +581,7 @@ gap> D := BananaTree(3, 4);
     <Ref Func="DigraphDisjointUnion" Label="for a list of digraphs"/>,
     <Ref Oper="CycleDigraph"/>, and <Ref Oper="ChainDigraph"/>. <P/>
 
-    If the optional first argument <A>filt</A> is present, then this should
-    specify the category or representation the digraph being created will
-    belong to. For example, if <A>filt</A> is <Ref Filt="IsMutableDigraph"/>,
-    then the digraph being created will be mutable, if <A>filt</A> is <Ref
-    Filt="IsImmutableDigraph"/>, then the digraph will be immutable. 
-    If the optional first argument <A>filt</A> is not present, then <Ref
-      Filt="IsImmutableDigraph"/> is used by default.<P/>
+    &STANDARD_FILT_TEXT;
 
     <Example><![CDATA[
 gap> TadpoleGraph(10, 15);

--- a/doc/examples.xml
+++ b/doc/examples.xml
@@ -247,7 +247,7 @@ gap> PetersenGraph(IsMutableDigraph);
 
     &STANDARD_FILT_TEXT;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> GeneralisedPetersenGraph(7, 2);
 <immutable symmetric digraph with 14 vertices, 42 edges>
 gap> GeneralisedPetersenGraph(40, 1);
@@ -280,7 +280,7 @@ gap> GeneralisedPetersenGraph(IsMutableDigraph, 9, 4);
 
     &STANDARD_FILT_TEXT;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> D := LollipopGraph(5, 3);
 <immutable connected symmetric digraph with 8 vertices, 26 edges>
 gap> CliqueNumber(D);
@@ -316,13 +316,13 @@ gap> LollipopGraph(IsMutableDigraph, 3, 8);
     share an edge or a corner. It can also be constructed as the strong product 
     of two path graphs.</Q>
     <P/>
-    
+
     In particular, the <C><A>n</A> * <A>k</A></C>  vertices can be arranged
     into an <A>n</A> by <A>k</A> grid such that two vertices are adjacent in
     the digraph if and only if they are orthogonally or diagonally adjacent in the grid.
     The correspondence between vertices and grid positions is given by
     <Ref Oper="DigraphVertexLabels"/>.  <P/>
-    
+
     See also <Ref Oper="SquareGridGraph"/> and
     <Ref Oper="TriangularGridGraph"/>. <P/>
 
@@ -430,7 +430,7 @@ gap> TriangularGridGraph(IsMutable, 3, 3);
     vertices.  If <A>k</A> is at least <C>2</C>, then this is the complete
     bipartite digraph with bicomponents
     <C>[1]</C> and <C>[2 .. <A>k</A>]</C>. <P/>
-    
+
     See <Ref Prop="IsUndirectedTree"/>, <Ref Prop="IsCompleteBipartiteDigraph"/>,
     and <Ref Attr="DigraphBicomponents"/>. <P/>
 
@@ -472,7 +472,7 @@ true
 
     &STANDARD_FILT_TEXT;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> D := KnightsGraph(8, 8);
 <immutable connected symmetric digraph with 64 vertices, 336 edges>
 gap> IsConnectedDigraph(D);
@@ -508,7 +508,7 @@ gap> KnightsGraph(IsMutable, 3, 9);
 
     &STANDARD_FILT_TEXT;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> HaarGraph(3);
 <immutable bipartite vertex-transitive symmetric digraph with bicompon\
 ent sizes 2 and 2>
@@ -538,7 +538,7 @@ ent sizes 5 and 5>
     connecting one leaf of each of <A>n</A> copies of an <A>k</A>-star graph
     with a single root vertex that is distinct from all the stars.</Q>
     <P/>
-    
+
     Specifically, in the resulting digraph, vertex <C>1</C> is the 'root',
     and for each <C>m</C> in <C>[1 .. <A>k</A>]</C>,
     the <C>m</C>th star is on the vertices
@@ -678,7 +678,7 @@ true
     Note that <C>BinaryTree(<A>m</A>)</C> is the induced subdigraph of
     <C>BinaryTree(<A>m</A>+1)</C> on the vertices <C>[1..2^(<A>m</A>-1)]</C>.
     <P/>
-    
+
     &STANDARD_FILT_TEXT;
 
     <Example><![CDATA[

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -68,8 +68,7 @@
     See also <Ref Func="DigraphsUseBliss"/>, and <Ref Func="DigraphsUseNauty"/>.
     <P/>
 
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this attribute is recomputed every time it is called. 
+    &MUTABLE_RECOMPUTED_ATTR;
 
     <Example><![CDATA[
 gap> G := BlissAutomorphismGroup(JohnsonDigraph(5, 2));;
@@ -102,8 +101,7 @@ gap> Size(G);
     See also <Ref Func="DigraphsUseBliss"/>, and <Ref Func="DigraphsUseNauty"/>.
     <P/>
 
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this attribute is recomputed every time it is called. 
+    &MUTABLE_RECOMPUTED_ATTR;
 
     <Log><![CDATA[
 gap> NautyAutomorphismGroup(JohnsonDigraph(5, 2));
@@ -143,8 +141,7 @@ Group([ (3,4)(6,7)(8,9), (2,3)(5,6)(9,10), (2,5)(3,6)(4,7),
     and <Ref Func="DigraphsUseNauty"/>.
     <P/>
 
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this attribute is recomputed every time it is called. 
+    &MUTABLE_RECOMPUTED_ATTR;
 
     <Example><![CDATA[
 gap> johnson := DigraphFromGraph6String("E}lw");
@@ -735,8 +732,7 @@ fail]]></Example>
       Attr="NautyCanonicalLabelling" Label="for a digraph"/>.
     <P/>
 
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this attribute is recomputed every time it is called. 
+    &MUTABLE_RECOMPUTED_ATTR;
 
     <Example><![CDATA[
 gap> digraph := Digraph([[1], [2, 3], [3], [1, 2, 3]]);

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  isomorph.xml                                        James D. Mitchell
-#Y  Copyright (C) 2014-18                                  Wilf A. Wilson
+#Y  Copyright (C) 2014-21                                  Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -783,13 +783,13 @@ gap> OutNeighbours(canon);
     </List>
     See also <Ref Attr="AutomorphismGroup" Label="for a digraph"
       />.<P/>
-    
+
     If <A>col1</A> and <A>col2</A>, or <A>col</A>, are given, then they must
     represent vertex colourings; see 
     <Ref Oper="AutomorphismGroup" Label="for a digraph and a homogeneous list"/> 
     for details of the permissible values for
     these arguments. The homomorphism must then also have the property:
-  
+
     <List>
       <Item>
         <C>col1[i] = col2[i ^ x]</C> for all vertices <C>i</C> of <A>src</A>,

--- a/doc/main.xml
+++ b/doc/main.xml
@@ -26,6 +26,7 @@
    Only='Text'><Package>datastructures</Package></Alt>">
      <!ENTITY STANDARD_FILT_TEXT "If the optional first argument <A>filt</A> is present, then this should specify the category or representation the digraph being created will belong to. For example, if <A>filt</A> is <Ref Filt='IsMutableDigraph'/>, then the digraph being created will be mutable, if <A>filt</A> is <Ref Filt='IsImmutableDigraph'/>, then the digraph will be immutable.  If the optional first argument <A>filt</A> is not present, then <Ref Filt='IsImmutableDigraph'/> is used by default.<P/>">
      <!ENTITY MUTABLE_RECOMPUTED_PROP "If the argument <A>digraph</A> is mutable, then the return value of this property is recomputed every time it is called.<P/>">
+     <!ENTITY MUTABLE_RECOMPUTED_ATTR "If the argument <A>digraph</A> is mutable, then the return value of this attribute is recomputed every time it is called.<P/>">
      <#Include Label="PKGVERSIONDATA">
    ]>
 

--- a/doc/main.xml
+++ b/doc/main.xml
@@ -25,6 +25,7 @@
        Text='datastructures'>https://github.com/gap-packages/datastructures</URL></Alt><Alt
    Only='Text'><Package>datastructures</Package></Alt>">
      <!ENTITY STANDARD_FILT_TEXT "If the optional first argument <A>filt</A> is present, then this should specify the category or representation the digraph being created will belong to. For example, if <A>filt</A> is <Ref Filt='IsMutableDigraph'/>, then the digraph being created will be mutable, if <A>filt</A> is <Ref Filt='IsImmutableDigraph'/>, then the digraph will be immutable.  If the optional first argument <A>filt</A> is not present, then <Ref Filt='IsImmutableDigraph'/> is used by default.<P/>">
+     <!ENTITY MUTABLE_RECOMPUTED_PROP "If the argument <A>digraph</A> is mutable, then the return value of this property is recomputed every time it is called.<P/>">
      <#Include Label="PKGVERSIONDATA">
    ]>
 

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  prop.xml
-#Y  Copyright (C) 2014-19                               James D. Mitchell
+#Y  Copyright (C) 2014-21                               James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -54,7 +54,7 @@ true]]></Example>
 
     &MUTABLE_RECOMPUTED_PROP;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> D := Digraph([[1, 2], [2]]);
 <immutable digraph with 2 vertices, 3 edges>
 gap> DigraphEdges(D);
@@ -258,7 +258,7 @@ false]]></Example>
 
     &MUTABLE_RECOMPUTED_PROP;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> IsBiconnectedDigraph(Digraph([[1, 3], [2, 3], [3]]));
 false
 gap> IsBiconnectedDigraph(CycleDigraph(5));
@@ -468,7 +468,7 @@ false
 
     &MUTABLE_RECOMPUTED_PROP;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2, 3], [3]]);
 <immutable digraph with 3 vertices, 5 edges>
 gap> IsChainDigraph(D);
@@ -509,7 +509,7 @@ true]]></Example>
 
     &MUTABLE_RECOMPUTED_PROP;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2, 3], [3]]);
 <immutable digraph with 3 vertices, 5 edges>
 gap> IsCycleDigraph(D);
@@ -1203,7 +1203,7 @@ true
 
     &MUTABLE_RECOMPUTED_PROP;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> D := Digraph([[1], [2, 3], [2, 3]]);
 <immutable digraph with 3 vertices, 5 edges>
 gap> IsPreorderDigraph(D);
@@ -1240,7 +1240,7 @@ false
 
     &MUTABLE_RECOMPUTED_PROP;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2, 3], [3]]);
 <immutable digraph with 3 vertices, 5 edges>
 gap> IsPartialOrderDigraph(D);
@@ -1271,7 +1271,7 @@ true
 
     &MUTABLE_RECOMPUTED_PROP;
 
-<Example><![CDATA[
+    <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2], [1, 3]]);
 <immutable digraph with 3 vertices, 5 edges>
 gap> IsEquivalenceDigraph(D);

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -16,8 +16,7 @@
     A <E>multidigraph</E> is one that has at least two
     edges with equal source and range.<P/>
 
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := Digraph(["a", "b", "c"], ["a", "b", "b"], ["b", "c", "a"]);
@@ -52,9 +51,8 @@ true]]></Example>
     Returns <K>true</K> if the digraph <A>digraph</A> has loops, and
     <K>false</K> if it does not. A loop is an edge with equal source and range.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
 <Example><![CDATA[
 gap> D := Digraph([[1, 2], [2]]);
@@ -92,8 +90,7 @@ false]]></Example>
     <M>m</M> is the number of edges (counting multiple edges as one) and
     <M>n</M> is the number of vertices in the digraph. <P/>
 
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> Petersen := Graph(SymmetricGroup(5), [[1, 2]], OnSets,
@@ -130,9 +127,9 @@ false]]></Example>
     is aperiodic, i.e. if its <Ref Attr = "DigraphPeriod"/> is equal to 1.
     Otherwise, the property is <K>false</K>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> D := Digraph([[6], [1], [2], [3], [4, 4], [5]]);
 <immutable multidigraph with 6 vertices, 7 edges>
@@ -168,9 +165,8 @@ true]]></Example>
     the number of edges (counting multiple edges as one) and <M>n</M> is the
     number of vertices in the digraph.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := CycleDigraph(250000);
@@ -211,9 +207,8 @@ false
     <M>m</M> is the number of edges and
     <M>n</M> is the number of vertices of the digraph).
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := Digraph([[2], [3], []]);;
@@ -249,9 +244,6 @@ false]]></Example>
     <A>digraph</A> is biconnected, and <K>false</K> if it is not. In
     particular, <C>IsBiconnectedDigraph</C> returns <K>false</K> if
     <A>digraph</A> is not connected. <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. <P/>
 
     Multiple edges are ignored by this method. <P/>
 
@@ -263,7 +255,9 @@ false]]></Example>
     See also <Ref Attr="Bridges"/>, <Ref Attr="ArticulationPoints"/>, and 
     <Ref Prop="IsBridgelessDigraph"/>.
     <P/>
-      
+
+    &MUTABLE_RECOMPUTED_PROP;
+
 <Example><![CDATA[
 gap> IsBiconnectedDigraph(Digraph([[1, 3], [2, 3], [3]]));
 false
@@ -294,9 +288,9 @@ true]]></Example>
 
   See also <Ref Attr="DigraphBicomponents"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> D := ChainDigraph(4);
 <immutable chain digraph with 4 vertices>
@@ -334,9 +328,8 @@ true]]></Example>
 
     See also <Ref Oper="CompleteBipartiteDigraph"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := CycleDigraph(2);
@@ -370,9 +363,8 @@ true]]></Example>
     where every possible edge between these independent sets occurs in the
     digraph exactly once.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := CompleteMultipartiteDigraph([2, 4, 6]);
@@ -402,9 +394,8 @@ true]]></Example>
     Equivalently, a digraph with <M>n</M> vertices is complete precisely when
     it has <M>n(n - 1)</M> edges, no loops, and no multiple edges.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := Digraph([[2, 3], [1, 3], [1, 2]]);
@@ -435,9 +426,9 @@ false]]></Example>
     Specifically, a tournament is a digraph which has a unique directed edge
     (of some orientation) between any pair of distinct vertices, and no loops.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> D := Digraph([[2, 3, 4], [3, 4], [4], []]);
 <immutable digraph with 4 vertices, 6 edges>
@@ -474,9 +465,8 @@ false
     every vertex has out degree at most one; see <Ref Prop="IsDirectedTree"/>
     and <Ref Attr="OutDegrees"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
 <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2, 3], [3]]);
@@ -516,9 +506,8 @@ true]]></Example>
     A digraph is a <E>cycle</E> if and only if it is strongly connected and has
     the same number of edges as vertices. 
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
 <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2, 3], [3]]);
@@ -552,9 +541,8 @@ true]]></Example>
     to <C>A</C>. In other words, a digraph <C>D</C> is a core if and only if
     every endomorphism on <C>D</C> is an automorphism on <C>D</C>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := CompleteDigraph(6);
@@ -587,9 +575,8 @@ false
 
     See also <Ref Attr="DigraphSources"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := Digraph([[], [2]]);
@@ -642,9 +629,8 @@ true
     Please note that the digraph with zero vertices is considered to be neither
     an undirected tree nor an undirected forest.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := Digraph([[3], [3], [1, 2]]);
@@ -683,9 +669,8 @@ false]]></Example>
     transitively on its edges (via the action
     <Ref Func="OnPairs" BookName="ref"/>).
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> IsEdgeTransitive(CompleteDigraph(2));
@@ -709,9 +694,8 @@ Error, the argument <D> must be a digraph with no multiple edges,
     otherwise. A digraph is <E>vertex transitive</E> if its automorphism group
     acts transitively on its vertices.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> IsVertexTransitive(CompleteDigraph(2));
@@ -735,9 +719,8 @@ false
 
     <C>IsNullDigraph</C> is a synonym for <C>IsEmptyDigraph</C>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := Digraph([[], []]);
@@ -770,9 +753,8 @@ false]]></Example>
     a directed circuit. Note that the empty digraph with at most one vertex is
     considered to be Eulerian.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := Digraph([[]]);
@@ -807,9 +789,9 @@ true
     A digraph is <E>functional</E> if every vertex is the source of a
     unique edge.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> gr1 := Digraph([[3], [2], [2], [1], [6], [5]]);
 <immutable digraph with 6 vertices, 6 edges>
@@ -845,9 +827,8 @@ true
     The method used in this operation has the worst case complexity as
     <Ref Oper="DigraphMonomorphism"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> g := Digraph([[]]);
@@ -885,9 +866,9 @@ true
     See also <Ref Prop="IsInRegularDigraph"/> and
     <Ref Prop="IsOutRegularDigraph"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> IsRegularDigraph(CompleteDigraph(4));
 true
@@ -910,9 +891,9 @@ false
     See also <Ref Prop="IsOutRegularDigraph"/> and
     <Ref Prop="IsRegularDigraph"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> IsInRegularDigraph(CompleteDigraph(4));
 true
@@ -936,9 +917,9 @@ false
     See also <Ref Prop="IsInRegularDigraph"/> and
     <Ref Prop="IsRegularDigraph"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> IsOutRegularDigraph(CompleteDigraph(4));
 true
@@ -973,9 +954,8 @@ false
     In the case where <A>digraph</A> is not symmetric or not connected, the
     property is <K>false</K>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := DigraphSymmetricClosure(ChainDigraph(5));;
@@ -999,9 +979,9 @@ true
     reflexive, and <K>false</K> if it is not.
     A digraph is <E>reflexive</E> if it has a loop at every vertex. <P/>
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> D := Digraph([[1, 2], [2]]);
 <immutable digraph with 2 vertices, 3 edges>
@@ -1031,9 +1011,9 @@ false
     edges with source <C>v</C> and range <C>u</C>.  In other words, a symmetric
     digraph has a symmetric adjacency matrix <Ref Attr="AdjacencyMatrix"/>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> gr1 := Digraph([[2], [1, 3], [2, 3]]);
 <immutable digraph with 3 vertices, 5 edges>
@@ -1078,9 +1058,8 @@ false
     <C>u</C> and range <C>v</C>, and an edge with source <C>v</C> and range
     <C>u</C>, then the vertices <C>u</C> and <C>v</C> are equal.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> gr1 := Digraph([[2], [1, 3], [2, 3]]);
@@ -1121,10 +1100,9 @@ gap> DigraphEdges(gr2);
     [<Ref Attr="DigraphTopologicalSort"/>], then methods with
     complexity <M>O(m + n + m \cdot n)</M> will be used when appropriate.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
-    <P/>
+
+    &MUTABLE_RECOMPUTED_PROP;
+
     <Example><![CDATA[
 gap> D := Digraph([[1, 2], [3], [3]]);
 <immutable digraph with 3 vertices, 4 edges>
@@ -1168,9 +1146,8 @@ true
     every pair of vertices has a least upper bound (join) with respect to
     the relation.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
     <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2, 3], [3]]);
@@ -1223,9 +1200,8 @@ true
     the preorder relation <M>\leq</M> defined by <M>x \leq y</M> if and only
     if <C>[x, y]</C> is an edge of <A>digraph</A>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
 <Example><![CDATA[
 gap> D := Digraph([[1], [2, 3], [2, 3]]);
@@ -1261,9 +1237,8 @@ false
     to the partial order relation <M>\leq</M> defined by <M>x \leq y</M> if and
     only if <C>[x, y]</C> is an edge of <A>digraph</A>.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
 <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2, 3], [3]]);
@@ -1293,9 +1268,8 @@ true
     <Ref Prop="IsSymmetricDigraph"/> and <Ref Prop="IsTransitiveDigraph"/>.
     A partial order <A>digraph</A> corresponds to an equivalence relation.
     <P/>
-      
-    If the argument <A>digraph</A> is mutable, then the return value of
-    this property is recomputed every time it is called. 
+
+    &MUTABLE_RECOMPUTED_PROP;
 
 <Example><![CDATA[
 gap> D := Digraph([[1, 3], [2], [1, 3]]);
@@ -1309,24 +1283,21 @@ true
 
 <#GAPDoc Label="IsBridgelessDigraph">
 <ManSection>
-  <Prop Name="IsBridgelessDigraph" Arg="D"/>
+  <Prop Name="IsBridgelessDigraph" Arg="digraph"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
     A connected digraph is <E>bridgeless</E> if it is still connected (in the
     sense of <Ref Prop="IsConnectedDigraph"/>) when any edge is removed. 
-    If <A>D</A> has at least 3 vertices, then <Ref
+    If <A>digraph</A> has at least 3 vertices, then <Ref
     Prop="IsBiconnectedDigraph"/> implies <C>IsBridgelessDigraph</C>;
     see <Ref Attr="ArticulationPoints"/> or <Ref Attr="Bridges"/> for a more
     detailed explanation.
     <P/>
 
     <C>IsBridgelessDigraph</C> returns <K>true</K> if the digraph
-    <A>D</A> is bridgeless, and <K>false</K> if it is not. In
+    <A>digraph</A> is bridgeless, and <K>false</K> if it is not. In
     particular, <C>IsBridgelessDigraph</C> returns <K>false</K> if
-    <A>D</A> is not connected. <P/>
-      
-    If the argument <A>D</A> is mutable, then the return value of
-    this property is recomputed every time it is called. <P/>
+    <A>digraph</A> is not connected. <P/>
 
     Multiple edges are ignored by this method. <P/>
 
@@ -1336,9 +1307,11 @@ true
     <P/>
 
     See also <Ref Attr="Bridges"/>, <Ref Attr="ArticulationPoints"/>, and 
-    <Ref Prop="IsBiconnectedDigraph"/>.
-      
-<Example><![CDATA[
+    <Ref Prop="IsBiconnectedDigraph"/>. <P/>
+
+    &MUTABLE_RECOMPUTED_PROP;
+
+    <Example><![CDATA[
 gap> IsBridgelessDigraph(Digraph([[1, 3], [2, 3], [3]]));
 false
 gap> IsBridgelessDigraph(CycleDigraph(5));


### PR DESCRIPTION
Specifically:
* &STANDARD_FILT_TEXT;
* &MUTABLE_RECOMPUTED_PROP;
* &MUTABLE_RECOMPUTED_ATTR;

Also fixes some typos in `DigraphByInNeighbours` and adjusts some whitespace (😬).

These things are done in separate commits.

Resolves #478.