### PR TITLE
Avoid using SIZEOF_VOID_P, remove unsused SYS_IS_CYGWIN32

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,11 +57,6 @@ case $host_os in
          * ) CYGWIN=no;;
 esac
 AM_CONDITIONAL([SYS_IS_CYGWIN], [test "$CYGWIN" = "yes"])
-if test "$CYGWIN" = "yes"; then
-  AC_DEFINE(SYS_IS_CYGWIN32, 1, are we on CYGWIN?)
-else
-  AC_DEFINE(SYS_IS_CYGWIN32, 0, are we on CYGWIN?)
-fi
 
 dnl ## User setting: Debug mode (off by default)
 AC_ARG_ENABLE([debug],

--- a/src/bitarray.h
+++ b/src/bitarray.h
@@ -31,7 +31,7 @@ typedef UInt Block;
 #define MAXVERTS 512
 #endif
 
-#if SIZEOF_VOID_P == 8
+#if SYS_IS_64_BIT
 // To avoid division and mod
 static size_t const NR_BLOCKS_LOOKUP[MAXVERTS + 1] = {
     0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/src/homos.c
+++ b/src/homos.c
@@ -92,12 +92,8 @@
     }                                               \
   }
 
-#if SIZEOF_VOID_P == 4 && DIGRAPHS_HAVE___BUILTIN_CTZLL
-#undef DIGRAPHS_HAVE___BUILTIN_CTZLL
-#endif
-
 // The following macro is bitmap_decode_ctz_callpack from https://git.io/fho4p
-#ifdef DIGRAPHS_HAVE___BUILTIN_CTZLL
+#if SYS_IS_64_BIT && defined(DIGRAPHS_HAVE___BUILTIN_CTZLL)
 #define FOR_SET_BITS(__bit_array, __nr_bits, __variable)     \
   for (size_t k = 0; k < NR_BLOCKS_LOOKUP[__nr_bits]; ++k) { \
     Block block = __bit_array->blocks[k];                    \

--- a/src/perms.h
+++ b/src/perms.h
@@ -28,11 +28,8 @@
 #define MAXVERTS 512
 #define UNDEFINED MAXVERTS + 1
 
-#if SIZEOF_VOID_P == 8
-#define SMALLINTLIMIT 1152921504606846976
-#else
-#define SMALLINTLIMIT 268435456
-#endif
+// smallest positive integer that doesn't fit into a small integer object
+#define SMALLINTLIMIT (INT_INTOBJ_MAX + 1)
 
 typedef uint16_t* Perm;
 


### PR DESCRIPTION
This allows future GAP versions to drop SIZEOF_VOID_P (although 4.12
definitely will support it).