### PR TITLE
Re-add PR #459: ExecuteDFS (generic depth first search)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,6 +26,7 @@ KEXT_SOURCES += src/perms.c
 KEXT_SOURCES += src/planar.c
 KEXT_SOURCES += src/schreier-sims.c
 KEXT_SOURCES += src/safemalloc.c
+KEXT_SOURCES += src/dfs.c
 
 ifdef WITH_INCLUDED_BLISS
   KEXT_SOURCES += extern/bliss-0.73/defs.cc

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1440,7 +1440,7 @@ gap> D := CompleteDigraph(5);
 gap> VerticesReachableFrom(D, 1);
 [ 1, 2, 3, 4, 5 ]
 gap> VerticesReachableFrom(D, 3);
-[ 1, 2, 3, 4, 5 ]
+[ 1, 3, 2, 4, 5 ]
 gap> D := EmptyDigraph(5);
 <immutable empty digraph with 5 vertices>
 gap> VerticesReachableFrom(D, 1);
@@ -2328,6 +2328,173 @@ gap> LexicographicProduct(NullDigraph(0), CompleteDigraph(10));
 </Description>
 </ManSection>
 <#/GAPDoc>  
+
+<#GAPDoc Label="NewDFSRecord">
+<ManSection>
+  <Oper Name="NewDFSRecord" Arg="digraph"/>
+  <Returns>A record.</Returns>
+  <Description>
+  This record contains three lists (parent, preorder and postorder) with their length
+  equal to the number of verticies in the <A>digraph</A>. Each index of the lists maps to the
+  vertex within the <A>digraph</A> equating to the vertex number. These lists store
+  the following:
+  <List>
+    <Mark>parent</Mark>
+    <Item>at each index, the parent of the vertex is stored</Item>
+    <Mark>preorder</Mark>
+    <Item>at each index, the preorder number (order in which the vertex is visited)
+          is stored</Item>
+    <Mark>postorder</Mark>
+    <Item>at each index, the postorder number (order in which the vertex is backtracked on)
+          is stored</Item>
+  </List>
+
+  The record also stores a further 4 attributes.
+  <List>
+    <Mark>current</Mark>
+    <Item>the current vertex that is being visited</Item>
+    <Mark>child</Mark>
+    <Item>the child of the current vertex</Item>
+    <Mark>graph</Mark>
+    <Item>the <A>digraph</A></Item>
+    <Mark>stop</Mark>
+    <Item>whether to stop the depth first search</Item>
+  </List>
+  
+  Initially, the <C>current</C> and <C>child</C> attributes will have <C>-1</C> values and the lists (<C>parent</C>,
+  <C>preorder</C> and <C>postorder</C>) will have <C>-1</C> values at all of their indicies as no vertex has 
+  been visited. The <C>stop</C> attribute will initially be <C>false</C>.
+  <E>This record should be passed into the <C>ExecuteDFS</C> function.</E>
+  See <Ref Oper="ExecuteDFS"/>.
+  <Example><![CDATA[
+gap> record := NewDFSRecord(CompleteDigraph(2));
+rec( child := -1, current := -1, 
+  graph := <immutable complete digraph with 2 vertices>, 
+  parent := [ -1, -1 ], postorder := [ -1, -1 ], 
+  preorder := [ -1, -1 ], stop := false )
+gap> record.preorder;
+[ -1, -1 ]
+gap> record.postorder;
+[ -1, -1 ]
+gap> record.stop;
+false
+gap> record.parent;
+[ -1, -1 ]
+gap> record.child;
+-1
+gap> record.current;
+-1
+gap> record.graph;
+<immutable complete digraph with 2 vertices>
+]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DFSDefault">
+<ManSection>
+  <Oper Name="DFSDefault" Arg="record, data"/>
+  <Description>
+  This is a default function to be passed into the <C>ExecuteDFS</C> function.
+  This does nothing and can be used in place of the <C>PreOrderFunc</C>, <C>PostOrderFunc</C>,
+  <C>AncestorFunc</C> and/or <C>CrossFunc</C> of the <C>ExecuteDFS</C> function.
+  See <Ref Oper="ExecuteDFS"/>.
+  <Example><![CDATA[
+gap> PreOrderFunc := function(record, data)
+>       data.num_vertices := data.num_vertices + 1;
+>    end;;
+gap> record := NewDFSRecord(CompleteDigraph(2));;
+gap> data := rec(num_vertices := 0);;
+gap> ExecuteDFS(record, data, 1, PreOrderFunc,
+>               DFSDefault, DFSDefault, DFSDefault);
+gap> data;
+rec( num_vertices := 2 )
+gap> record := NewDFSRecord(CompleteDigraph(2));;
+gap> ExecuteDFS(record, [], 1, DFSDefault,
+>               DFSDefault, DFSDefault, DFSDefault);
+gap> record;
+rec( child := 1, current := 1, 
+  graph := <immutable complete digraph with 2 vertices>, 
+  parent := [ 1, 1 ], postorder := [ 2, 1 ], preorder := [ 1, 2 ], 
+  stop := false )
+]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="ExecuteDFS">
+<ManSection>
+  <Oper Name="ExecuteDFS"
+    Arg="record, data, start, PreOrderFunc, PostOrderFunc, AncestorFunc, CrossFunc"/>
+  <Description>
+  This performs a full depth first search from the <A>start</A> vertex (where <A>start</A> is a vertex within the graph).
+  The depth first search can be terminated by changing the <A>record</A>.stop attribute to true in the
+  <A>PreOrderFunc</A>, <A>PostOrderFunc</A>, <A>AncestorFunc</A> or <A>CrossFunc</A> functions.
+  <C>ExecuteDFS</C> takes 7 arguments:
+  <List>
+    <Mark>record</Mark>
+    <Item>the depth first search record (created using NewDFSRecord)</Item>
+    <Mark>data</Mark>
+    <Item>an object that you want to manipulate in the functions passed.</Item>
+    <Mark>start</Mark>
+    <Item>the vertex where we begin the depth first search.</Item>
+    <Mark>PreOrderFunc</Mark>
+    <Item>this function is called when a vertex is first visited. This vertex
+    is stored in <A>record</A>.current</Item>
+    <Mark>PostOrderFunc</Mark>
+    <Item>this function is called when a vertex has no more unvisited children
+    causing us to backtrack. This vertex is stored in <A>record</A>.child and its parent is stored 
+    in <A>record</A>.current</Item>
+    <Mark>AncestorFunc</Mark>
+    <Item>this function is called when (<C><A>record</A>.current</C>,
+    <C><A>record</A>.child</C>) is an edge and <C><A>record</A>.child</C> is an ancestor of <C><A>record</A>.current</C>. An ancestor here means that
+    <C><A>record</A>.child</C> is on the same branch as <C><A>record</A>.current</C> but was visited prior to <C><A>record</A>.current</C></Item>
+    <Mark>CrossFunc</Mark>
+    <Item>this function is called when (<C><A>record</A>.current</C>,
+    <C><A>record</A>.child</C>) is an edge and <C><A>record</A>.child</C> has been visited before <C><A>record</A>.current</C>
+      and it is not an ancestor of <C><A>record</A>.current</C></Item>
+  </List>
+  Note that this function only performs a depth first search on the vertices reachable from <A>start</A>.
+  It is also important to note that all functions passed need to accept arguments <A>record</A> and <A>data</A>.
+  Finally, for the <A>start</A> vertex, its parent is itself and the <A>PreOrderFunc</A>
+  will be called on it.
+  See <Ref Oper="NewDFSRecord"/>.
+  <Example><![CDATA[
+gap> record := NewDFSRecord(CycleDigraph(10));;
+gap> ExecuteDFS(record, [], 1, DFSDefault,
+>               DFSDefault, DFSDefault, DFSDefault);
+gap> record.preorder;
+[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+gap> record := NewDFSRecord(CompleteDigraph(10));;
+gap> data := rec(cycle_vertex := 0);;
+gap> AncestorFunc := function(record, data)
+>       record.stop := true;
+>       data.cycle_vertex := record.child;
+>    end;;
+gap> ExecuteDFS(record, data, 1, DFSDefault,             
+>               DFSDefault, AncestorFunc, DFSDefault);
+gap> record.stop;
+true
+gap> data.cycle_vertex;
+1
+gap> record.preorder;
+[ 1, 2, 3, -1, -1, -1, -1, -1, -1, -1 ]
+gap> record := NewDFSRecord(Digraph([[2, 3], [4], [5], [], [4]]));;
+gap> CrossFunc := function(record, data)
+>       record.stop := true;
+>       Add(data, record.child);
+>    end;;
+gap> data := [];;
+gap> ExecuteDFS(record, data, 1, DFSDefault,                         
+>               DFSDefault, DFSDefault, CrossFunc);             
+gap> record.stop;
+true
+gap> data;
+[ 4 ]
+]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>
 
 <#GAPDoc Label="IsDigraphPath">
 <ManSection>

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -20,6 +20,9 @@
     <#Include Label="IsMatching">
     <#Include Label="DigraphMaximalMatching">
     <#Include Label="DigraphMaximumMatching">
+    <#Include Label="NewDFSRecord">
+    <#Include Label="DFSDefault">
+    <#Include Label="ExecuteDFS">
   </Section>
 
   <Section><Heading>Neighbours and degree</Heading>

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -237,7 +237,7 @@ end);
 
 # Finds a set S of homomorphism from gr1 to gr2 such that every homomorphism g
 # between the two graphs can expressed as a composition g = f * x of an element
-# f in S and an automorphism x of gr2
+# f in S and an automorphism x of gr2
 
 InstallMethod(HomomorphismsDigraphsRepresentatives,
 "for a digraph and a digraph",

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -157,3 +157,8 @@ DeclareOperation("PartialOrderDigraphJoinOfVertices",
                  [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("PartialOrderDigraphMeetOfVertices",
                  [IsDigraph, IsPosInt, IsPosInt]);
+
+# 11. DFS
+DeclareOperation("NewDFSRecord", [IsDigraph]);
+DeclareOperation("DFSDefault", [IsRecord, IsObject]);
+DeclareGlobalFunction("ExecuteDFS");

--- a/src/dfs.c
+++ b/src/dfs.c
@@ -1,0 +1,124 @@
+/*******************************************************************************
+**
+*A  dfs.c                  GAP package Digraphs               Lea Racine
+**                                                            James Mitchell
+**
+**  Copyright (C) 2014-21 - Julius Jonusas, James Mitchell, Michael Torpey,
+**  Wilf A. Wilson et al.
+**
+**  This file is free software, see the digraphs/LICENSE.
+**
+*******************************************************************************/
+
+#include "dfs.h"
+
+#include <stdbool.h>  // for false, true, bool
+#include <stdint.h>   // for uint64_t
+#include <stdlib.h>   // for NULL, free
+
+#include "digraphs-config.h"
+#include "digraphs-debug.h"
+#include "digraphs.h"
+
+// Extreme examples are on the pull request #459
+
+Obj ExecuteDFS(Obj self, Obj args) {
+  DIGRAPHS_ASSERT(LEN_PLIST(args) == 7);
+  Obj record        = ELM_PLIST(args, 1);
+  Obj data          = ELM_PLIST(args, 2);
+  Obj start         = ELM_PLIST(args, 3);
+  Obj PreorderFunc  = ELM_PLIST(args, 4);
+  Obj PostOrderFunc = ELM_PLIST(args, 5);
+  Obj AncestorFunc  = ELM_PLIST(args, 6);
+  Obj CrossFunc     = ELM_PLIST(args, 7);
+
+  DIGRAPHS_ASSERT(NARG_FUNC(PreorderFunc) == 2);
+  DIGRAPHS_ASSERT(IS_FUNC(AncestorFunc));
+  DIGRAPHS_ASSERT(NARG_FUNC(AncestorFunc) == 2);
+  DIGRAPHS_ASSERT(IS_FUNC(PostOrderFunc));
+  DIGRAPHS_ASSERT(NARG_FUNC(PostOrderFunc) == 2);
+  DIGRAPHS_ASSERT(IS_FUNC(PreorderFunc));
+  DIGRAPHS_ASSERT(IS_PREC(record));
+  DIGRAPHS_ASSERT(IS_INTOBJ(start));
+  DIGRAPHS_ASSERT(IS_FUNC(CrossFunc));
+  DIGRAPHS_ASSERT(NARG_FUNC(CrossFunc) == 2);
+
+  Obj D = ElmPRec(record, RNamName("graph"));
+  Int N = DigraphNrVertices(D);
+
+  if (INT_INTOBJ(start) > N) {
+    ErrorQuit(
+        "the third argument <start> must be a vertex in your graph,", 0L, 0L);
+  }
+  Int top   = 0;
+  Obj stack = NEW_PLIST(T_PLIST_CYC, N);
+  AssPlist(stack, ++top, start);
+
+  UInt preorder_num  = 0;
+  UInt postorder_num = 0;
+
+  Int current = 0;
+
+  Obj parent    = ElmPRec(record, RNamName("parent"));
+  Obj postorder = ElmPRec(record, RNamName("postorder"));
+  Obj preorder  = ElmPRec(record, RNamName("preorder"));
+
+  DIGRAPHS_ASSERT(LEN_PLIST(parent) == N);
+  DIGRAPHS_ASSERT(LEN_PLIST(postorder) == N);
+  DIGRAPHS_ASSERT(LEN_PLIST(preorder) == N);
+
+  SET_ELM_PLIST(parent, INT_INTOBJ(start), start);
+
+  Obj neighbors = FuncOutNeighbours(self, D);
+  DIGRAPHS_ASSERT(IS_PLIST(neighbors));
+
+  Int RNamChild   = RNamName("child");
+  Int RNamCurrent = RNamName("current");
+  Int RNamStop    = RNamName("stop");
+
+  while (top > 0) {
+    current = INT_INTOBJ(ELM_PLIST(stack, top--));
+    DIGRAPHS_ASSERT(current != 0);
+    if (current < 0) {
+      Int child = -1 * current;
+      AssPRec(record, RNamChild, INTOBJ_INT(child));
+      AssPRec(record, RNamCurrent, ELM_PLIST(parent, child));
+      CALL_2ARGS(PostOrderFunc, record, data);
+      SET_ELM_PLIST(postorder, child, INTOBJ_INT(++postorder_num));
+      CHANGED_BAG(record);
+      continue;
+    } else if (INT_INTOBJ(ELM_PLIST(preorder, current)) > 0) {
+      continue;
+    } else {
+      AssPRec(record, RNamCurrent, INTOBJ_INT(current));
+      CALL_2ARGS(PreorderFunc, record, data);
+      SET_ELM_PLIST(preorder, current, INTOBJ_INT(++preorder_num));
+      CHANGED_BAG(record);
+      AssPlist(stack, ++top, INTOBJ_INT(-1 * current));
+    }
+
+    if (ElmPRec(record, RNamStop) == True) {
+      break;
+    }
+
+    Obj succ = ELM_PLIST(neighbors, current);
+    for (UInt j = 0; j < LEN_LIST(succ); ++j) {
+      UInt v = INT_INTOBJ(ELM_LIST(succ, LEN_LIST(succ) - j));
+      AssPRec(record, RNamChild, INTOBJ_INT(v));
+      if (INT_INTOBJ(ELM_PLIST(preorder, v)) == -1) {
+        SET_ELM_PLIST(parent, v, INTOBJ_INT(current));
+        CHANGED_BAG(record);
+        AssPlist(stack, ++top, INTOBJ_INT(v));
+      } else if (INT_INTOBJ(ELM_PLIST(postorder, v)) == -1) {
+        CALL_2ARGS(AncestorFunc, record, data);
+      } else if (INT_INTOBJ(ELM_PLIST(preorder, v))
+                 < INT_INTOBJ(ELM_PLIST(preorder, current))) {
+        CALL_2ARGS(CrossFunc, record, data);
+      }
+      if (ElmPRec(record, RNamStop) == True) {
+        break;
+      }
+    }
+  }
+  return record;
+}

--- a/src/dfs.h
+++ b/src/dfs.h
@@ -1,0 +1,21 @@
+/*******************************************************************************
+**
+*A  dfs.h                  GAP package Digraphs               Lea Racine
+**                                                            James Mitchell
+**
+**  Copyright (C) 2014-21 - Julius Jonusas, James Mitchell, Michael Torpey,
+**  Wilf A. Wilson et al.
+**
+**  This file is free software, see the digraphs/LICENSE.
+**
+*******************************************************************************/
+
+#ifndef DIGRAPHS_SRC_DFS_H_
+#define DIGRAPHS_SRC_DFS_H_
+
+// GAP headers
+#include "compiled.h"  // for Obj, Int
+
+Obj ExecuteDFS(Obj self, Obj args);
+
+#endif  // DIGRAPHS_SRC_DFS_H_

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -21,6 +21,7 @@
 
 #include "bliss-includes.h"   // for bliss stuff
 #include "cliques.h"          // for FuncDIGRAPHS_FREE_CLIQUES_DATA
+#include "dfs.h"              // for FuncExecuteDFS
 #include "digraphs-config.h"  // for DIGRAPHS_WITH_INCLUDED_BLISS
 #include "digraphs-debug.h"   // for DIGRAPHS_ASSERT
 #include "homos.h"            // for FuncHomomorphismDigraphsFinder
@@ -2223,6 +2224,12 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(SUBGRAPH_HOMEOMORPHIC_TO_K4, 1, "digraph"),
     GVAR_FUNC(DIGRAPHS_FREE_HOMOS_DATA, 0, ""),
     GVAR_FUNC(DIGRAPHS_FREE_CLIQUES_DATA, 0, ""),
+
+    {"ExecuteDFS_C",
+     7,
+     "record, data, start, PreorderFunc, x, y, z",
+     ExecuteDFS,
+     "src/dfs.c:ExecuteDFS"},
 
     {0, 0, 0, 0, 0} /* Finish with an empty entry */
 };

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1360,6 +1360,16 @@ ent <D>,
 gap> DigraphPath(gr, 11, 11);
 Error, the 2nd and 3rd arguments <u> and <v> must be vertices of the 1st argum\
 ent <D>,
+gap> D := Digraph([[2], [3], [2, 3]]);
+<immutable digraph with 3 vertices, 4 edges>
+gap> DigraphPath(D, 1, 3);
+[ [ 1, 2, 3 ], [ 1, 1 ] ]
+gap> DigraphPath(D, 2, 1);
+fail
+gap> DigraphPath(D, 3, 3);
+[ [ 3, 3 ], [ 2 ] ]
+gap> DigraphPath(D, 1, 1);
+fail
 
 #  IteratorOfPaths
 gap> gr := CompleteDigraph(5);;
@@ -1966,7 +1976,7 @@ gap> D := CompleteDigraph(5);
 gap> VerticesReachableFrom(D, 1);
 [ 1, 2, 3, 4, 5 ]
 gap> VerticesReachableFrom(D, 3);
-[ 1, 2, 3, 4, 5 ]
+[ 1, 3, 2, 4, 5 ]
 gap> D := EmptyDigraph(5);
 <immutable empty digraph with 5 vertices>
 gap> VerticesReachableFrom(D, 1);
@@ -2014,7 +2024,7 @@ gap> VerticesReachableFrom(D, 1);
 gap> VerticesReachableFrom(D, 2);
 [ 4 ]
 gap> VerticesReachableFrom(D, 3);
-[ 1, 2, 3, 4, 5 ]
+[ 1, 3, 2, 4, 5 ]
 gap> VerticesReachableFrom(D, 4);
 [  ]
 gap> VerticesReachableFrom(D, 5);
@@ -2026,7 +2036,7 @@ gap> VerticesReachableFrom(D, 1);
 gap> VerticesReachableFrom(D, 2);
 [ 4 ]
 gap> VerticesReachableFrom(D, 3);
-[ 1, 2, 3, 4, 5 ]
+[ 1, 3, 2, 4, 5 ]
 gap> VerticesReachableFrom(D, 4);
 [  ]
 gap> VerticesReachableFrom(D, 5);
@@ -3313,6 +3323,120 @@ gap> Unbind(u1);
 gap> Unbind(u2);
 gap> Unbind(x);
 gap> Unbind(TestPartialOrderDigraph);
+
+# DFS
+
+# NewDFSRecord
+gap> NewDFSRecord(ChainDigraph(10));
+rec( child := -1, current := -1, 
+  graph := <immutable chain digraph with 10 vertices>, 
+  parent := [ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ], 
+  postorder := [ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ], 
+  preorder := [ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ], stop := false )
+gap> NewDFSRecord(CompleteDigraph(2));
+rec( child := -1, current := -1, 
+  graph := <immutable complete digraph with 2 vertices>, parent := [ -1, -1 ],
+  postorder := [ -1, -1 ], preorder := [ -1, -1 ], stop := false )
+gap> NewDFSRecord(Digraph([[1], [2], [1], [1], [2]]));
+rec( child := -1, current := -1, 
+  graph := <immutable digraph with 5 vertices, 5 edges>, 
+  parent := [ -1, -1, -1, -1, -1 ], postorder := [ -1, -1, -1, -1, -1 ], 
+  preorder := [ -1, -1, -1, -1, -1 ], stop := false )
+
+# DFSDefault
+gap> DFSDefault(rec(), []);
+gap> DFSDefault(rec(), rec());
+
+# ExecuteDFS
+gap> record := NewDFSRecord(CompleteDigraph(10));;
+gap> ExecuteDFS(record, [], 2, DFSDefault,
+>               DFSDefault, DFSDefault, DFSDefault);
+gap> record.preorder;
+[ 2, 1, 3, 4, 5, 6, 7, 8, 9, 10 ]
+gap> record := NewDFSRecord(CompleteDigraph(15));;
+gap> data := rec(cycle_vertex := 0);;
+gap> AncestorFunc := function(record, data)
+>       record.stop := true;
+>       data.cycle_vertex := record.child;
+>    end;;
+gap> ExecuteDFS(record, data, 1, DFSDefault,             
+>               DFSDefault, AncestorFunc, DFSDefault);
+gap> record.stop;
+true
+gap> data.cycle_vertex;
+1
+gap> record.preorder;
+[ 1, 2, 3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ]
+gap> record := NewDFSRecord(Digraph([[2, 3], [4], [5], [], [4]]));;
+gap> CrossFunc := function(record, data)
+>       record.stop := true;
+>       Add(data, record.child);
+>    end;;
+gap> data := [];;
+gap> ExecuteDFS(record, data, 1, DFSDefault,                         
+>               DFSDefault, DFSDefault, CrossFunc);             
+gap> record.stop;
+true
+gap> data;
+[ 4 ]
+gap> AncestorFunc := function(record, data)
+>      Add(data.cycle_vertex, record.child);
+>    end;;
+gap> CrossFunc := function(record, data)
+>      Add(data.cross_vertex, record.child);
+>    end;;
+gap> record := NewDFSRecord(Digraph([[2, 3, 3], [4, 4], [5, 1, 1], [], [4]]));;
+gap> data := rec(cycle_vertex := [], cross_vertex := []);;
+gap> ExecuteDFS(record, data, 1, DFSDefault,                         
+>               DFSDefault, AncestorFunc, CrossFunc);
+gap> data;
+rec( cross_vertex := [ 4 ], cycle_vertex := [ 1, 1 ] )
+gap> ExecuteDFS(rec(), data, 1, DFSDefault,                         
+>               DFSDefault, AncestorFunc, CrossFunc);
+Error, the 1st argument <record> must be created with NewDFSRecord,
+gap> D := ChainDigraph(1);;
+gap> ExecuteDFS(NewDFSRecord(D), [], 3, DFSDefault, DFSDefault, DFSDefault,
+> DFSDefault);
+Error, the third argument <start> must be a vertex in your graph,
+
+# IsDigraphPath
+gap> D := Digraph(IsMutableDigraph, Combinations([1 .. 5]), IsSubset);
+<mutable digraph with 32 vertices, 243 edges>
+gap> DigraphReflexiveTransitiveReduction(D);
+<mutable digraph with 32 vertices, 80 edges>
+gap> MakeImmutable(D);
+<immutable digraph with 32 vertices, 80 edges>
+gap> IsDigraphPath(D, [1, 2, 3], []);
+Error, the 2nd and 3rd arguments (lists) are incompatible, expected 3rd argume\
+nt of length 2, got 0
+gap> IsDigraphPath(D, [1], []);
+true
+gap> IsDigraphPath(D, [1, 2], [5]);
+false
+gap> IsDigraphPath(D, [32, 31, 33], [1, 1]);
+false
+gap> IsDigraphPath(D, [32, 33, 31], [1, 1]);
+false
+gap> IsDigraphPath(D, [6, 9, 16, 17], [3, 3, 2]);
+true
+gap> IsDigraphPath(D, [33, 9, 16, 17], [3, 3, 2]);
+false
+gap> IsDigraphPath(D, [6, 9, 18, 1], [9, 10, 2]);
+false
+
+# IsDigraphPath
+gap> D := Digraph(IsMutableDigraph, Combinations([1 .. 5]), IsSubset);
+<mutable digraph with 32 vertices, 243 edges>
+gap> DigraphReflexiveTransitiveReduction(D);
+<mutable digraph with 32 vertices, 80 edges>
+gap> MakeImmutable(D);
+<immutable digraph with 32 vertices, 80 edges>
+gap> IsDigraphPath(D, DigraphPath(D, 6, 1));
+true
+gap> ForAll(List(IteratorOfPaths(D, 6, 1)), x -> IsDigraphPath(D, x));
+true
+gap> IsDigraphPath(D, []);
+Error, the 2nd argument (a list) must have length 2, but found length 0
 
 #
 gap> DIGRAPHS_StopTest();

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -187,6 +187,14 @@ gap> HasIsAcyclicDigraph(gr);
 false
 gap> IsAcyclicDigraph(gr);
 false
+gap> gr := DigraphDisjointUnion(ChainDigraph(10), ChainDigraph(2));
+<immutable digraph with 12 vertices, 10 edges>
+gap> IsAcyclicDigraph(gr);
+true
+gap> gr := DigraphDisjointUnion(CompleteDigraph(5), ChainDigraph(2)); 
+<immutable digraph with 7 vertices, 21 edges>
+gap> IsAcyclicDigraph(gr);                                           
+false
 
 #  IsFunctionalDigraph
 gap> IsFunctionalDigraph(multiple);


### PR DESCRIPTION
This reverts #504, in other words, it adds again the code that was in #459.

Since the code in this PR is buggy (see #487), it was removed from the `main` branch. I do not imagine that this PR _itself_ will ever be merged (at least not as-is), but I have pushed this branch and opened this PR so that we do not lose track of this code.

@james-d-mitchell has started PR #499 to try to fix this, which I have taken the liberty of rebasing on top of this branch. When #499 is merged, this PR should then be closed, and the associated branch deleted.