### PR TITLE
`DigraphAddEdge`: do not add an edge label if edge labels are not yet initialised

### DIFF
--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -184,7 +184,7 @@ function(D, src, ran)
                   "digraph <D> that is the 1st argument,");
   fi;
   Add(D!.OutNeighbours[src], ran);
-  if not IsMultiDigraph(D) then
+  if HaveEdgeLabelsBeenAssigned(D) and not IsMultiDigraph(D) then
     SetDigraphEdgeLabel(D, src, ran, 1);
   fi;
   return D;

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -575,6 +575,10 @@ gap> DigraphAddEdge(gr, [1, 2]);
 <immutable digraph with 2 vertices, 1 edge>
 gap> DigraphEdges(last);
 [ [ 1, 2 ] ]
+gap> n := 10 ^ 5;; D1 := EmptyDigraph(IsMutableDigraph, n);;
+gap> for i in [1 .. n - 1] do DigraphAddEdge(D1, i, i + 1); od;
+gap> D1 = ChainDigraph(n);
+true
 
 #  DigraphAddVertices
 gap> gr := Digraph([[1]]);;


### PR DESCRIPTION
This can significantly increase the performance of `DigraphAddEdge` for digraphs that do not have edge labels. See #500.