### PR TITLE
CI: use codecov-action@v2 instead of @v1

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -81,5 +81,5 @@ jobs:
           GAP_TESTFILE: "tst/github_actions/extreme.g"
       - uses: gap-actions/process-coverage@v2
         if: ${{ always() }}
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: ${{ always() }}


### PR DESCRIPTION
This should hopefully just work seamlessly. The `v1` version is [supposed to stop working at the end of the month](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1).