### PR TITLE
digraph: add AsDigraph for partial perms and fix doc

### DIFF
--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -421,33 +421,52 @@ gap> D := DigraphByInNeighbours(IsMutableDigraph,
 
 <#GAPDoc Label="AsDigraph">
 <ManSection>
-  <Oper Name="AsDigraph" Arg="[filt, ]f[, n]"
-    Label="for a transformation or perm"/>
+  <Oper Name="AsDigraph" Arg="[filt, ]f[, n]" Label="for a binary relation"/>
   <Returns>A digraph, or <K>fail</K>.</Returns>
   <Description>
-    If <A>f</A> is a transformation or permutation,
-    and <A>n</A> is a non-negative integer
-    such that the restriction of <A>f</A> to <C>[1..<A>n</A>]</C> defines
-    a function of <C>[1..<A>n</A>]</C>, then <C>AsDigraph</C>
-    returns the functional digraph with <A>n</A> vertices defined by
-    <A>f</A>. See <Ref Prop="IsFunctionalDigraph"/>.
+
+      If <A>f</A> is a binary relation represented as one of the following in
+        &GAP;:
+      <List>
+        <Mark>
+          a transformation
+        </Mark>
+        <Item>
+          satisfying <Ref Filt="IsTransformation" BookName="ref"/>;
+        </Item>
+        <Mark>
+          a permutation
+        </Mark>
+        <Item>
+          satisfying <Ref Filt="IsPerm" BookName="ref"/>;
+        </Item>
+        <Mark>
+          a partial perm
+        </Mark>
+        <Item>
+          satisfying <Ref Filt="IsPartialPerm" BookName="ref"/>;
+        </Item>
+        <Mark>
+          a binary relation
+        </Mark>
+        <Item>
+          satisfying <Ref Filt="IsBinaryRelation" BookName="ref"/>;
+        </Item>
+      </List>
+      and <A>n</A> is a non-negative integer, then <C>AsDigraph</C> attempts
+      to construct a digraph with <A>n</A> vertices whose edges are determined
+      by <A>f</A>.<P/>
+
+    The digraph returned by <C>AsDigraph</C> has for each vertex
+    <C>v</C> in <C>[1 .. <A>n</A>]</C>, an edge with source <C>v</C> and range
+    <C>v ^ <A>f</A></C>.  If <C>v ^ <A>f</A></C> is greater than <A>n</A> for any
+    <C>v</C>, then <K>fail</K> is returned.
     <P/>
 
-    Specifically, the digraph returned by <C>AsDigraph</C> has  <A>n</A> edges:
-    for each vertex <C>v</C> in <C>[1..<A>n</A>]</C>, there is a unique edge
-    with source <C>v</C>; this edge has range <C>v^<A>f</A></C>.
-    <P/>
-
-    If the optional second argument <A>n</A> is not supplied, then
-    the degree of the transformation <A>f</A>,
-    or the largest moved point of the permutation <A>f</A>,
-    as applicable, is used by default.  If the restriction of
-    <A>f</A> to <C>[1..<A>n</A>]</C> does not define a function of
-    <C>[1..<A>n</A>]</C>, then <C>AsDigraph(<A>f</A>, <A>n</A>)</C>
-    returns <K>fail</K>.
-    <P/>
-
-    See also <Ref Attr="AsTransformation"/>.
+    If the optional second argument <A>n</A> is not supplied, then the degree
+    of the transformation <A>f</A>, the largest moved point of the permutation
+    <A>f</A>, the maximum of the degree and the codegree of the partial perm
+    <A>f</A>, or as applicable, is used by default.  
     <P/>
 
     &STANDARD_FILT_TEXT;

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -106,18 +106,24 @@ DeclareSynonym("DigraphByInNeighbors", DigraphByInNeighbours);
 DeclareConstructor("AsDigraphCons", [IsDigraph, IsBinaryRelation]);
 DeclareConstructor("AsDigraphCons", [IsDigraph, IsTransformation]);
 DeclareConstructor("AsDigraphCons", [IsDigraph, IsTransformation, IsInt]);
+DeclareConstructor("AsDigraphCons", [IsDigraph, IsPartialPerm]);
+DeclareConstructor("AsDigraphCons", [IsDigraph, IsPartialPerm, IsInt]);
 
 DeclareOperation("AsDigraph", [IsFunction, IsBinaryRelation]);
 DeclareOperation("AsDigraph", [IsFunction, IsTransformation]);
 DeclareOperation("AsDigraph", [IsFunction, IsTransformation, IsInt]);
 DeclareOperation("AsDigraph", [IsFunction, IsPerm]);
 DeclareOperation("AsDigraph", [IsFunction, IsPerm, IsInt]);
+DeclareOperation("AsDigraph", [IsFunction, IsPartialPerm]);
+DeclareOperation("AsDigraph", [IsFunction, IsPartialPerm, IsInt]);
 
 DeclareOperation("AsDigraph", [IsBinaryRelation]);
 DeclareOperation("AsDigraph", [IsTransformation]);
 DeclareOperation("AsDigraph", [IsTransformation, IsInt]);
 DeclareOperation("AsDigraph", [IsPerm]);
 DeclareOperation("AsDigraph", [IsPerm, IsInt]);
+DeclareOperation("AsDigraph", [IsPartialPerm]);
+DeclareOperation("AsDigraph", [IsPartialPerm, IsInt]);
 
 DeclareOperation("AsBinaryRelation", [IsDigraph]);
 DeclareOperation("AsSemigroup", [IsFunction, IsDigraph]);

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1062,6 +1062,58 @@ InstallMethod(AsDigraph, "for a function and a perm",
 InstallMethod(AsDigraph, "for a perm", [IsPerm],
 p -> AsDigraph(AsTransformation(p)));
 
+InstallMethod(AsDigraphCons,
+"for IsMutableDigraph, a partial perm, and an integer",
+[IsMutableDigraph, IsPartialPerm, IsInt],
+function(filt, f, n)
+  local list, x, i;
+  if n < 0 then
+    ErrorNoReturn("the 2nd argument <n> should be a non-negative integer,");
+  fi;
+
+  list := EmptyPlist(n);
+  for i in [1 .. n] do
+    x := i ^ f;
+    if x > n then
+      return fail;
+    elif x <> 0 then
+      list[i] := [x];
+    else
+      list[i] := [];
+    fi;
+  od;
+  return DigraphNC(IsMutableDigraph, list);
+end);
+
+InstallMethod(AsDigraphCons,
+"for IsImmutableDigraph, a partial perm, and an integer",
+[IsImmutableDigraph, IsPartialPerm, IsInt],
+function(filt, f, n)
+  local D;
+  D := AsDigraph(IsMutableDigraph, f, n);
+  if D <> fail then
+    D := MakeImmutable(D);
+    SetIsMultiDigraph(D, false);
+  fi;
+  return D;
+end);
+
+InstallMethod(AsDigraph, "for a function, a partial perm, and an integer",
+[IsFunction, IsPartialPerm, IsInt], AsDigraphCons);
+
+InstallMethod(AsDigraph, "for a partial perm and an integer",
+[IsPartialPerm, IsInt],
+{t, n} -> AsDigraphCons(IsImmutableDigraph, t, n));
+
+InstallMethod(AsDigraph, "for a function and a partial perm",
+[IsFunction, IsPartialPerm],
+{func, t} -> AsDigraphCons(func, t, Maximum(DegreeOfPartialPerm(t),
+                                            CodegreeOfPartialPerm(t))));
+
+InstallMethod(AsDigraph, "for a partial perm", [IsPartialPerm],
+t -> AsDigraphCons(IsImmutableDigraph, t, Maximum(DegreeOfPartialPerm(t),
+                                                  CodegreeOfPartialPerm(t))));
+
 InstallMethod(AsBinaryRelation, "for a digraph", [IsDigraphByOutNeighboursRep],
 function(D)
   local rel;

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -479,7 +479,8 @@ fail
 gap> f := ();;
 gap> D := AsDigraph(f);
 <immutable empty digraph with 0 vertices>
-gap> D = EmptyDigraph(0);;
+gap> D = EmptyDigraph(0);
+true
 gap> AsDigraph(f, 10);
 <immutable functional digraph with 10 vertices>
 gap> g := (1, 3, 7)(2, 6, 5, 8);;
@@ -510,6 +511,41 @@ gap> D := AsDigraph(IsMutableDigraph, h, 6);
 <mutable digraph with 6 vertices, 6 edges>
 gap> OutNeighbours(D);
 [ [ 1 ], [ 5 ], [ 2 ], [ 4 ], [ 3 ], [ 6 ] ]
+
+# AsDigraph for a partial perm
+gap> f := PartialPerm([]);;
+gap> D := AsDigraph(f);
+<immutable empty digraph with 0 vertices>
+gap> D = EmptyDigraph(0);
+true
+gap> AsDigraph(f, 10);
+<immutable empty digraph with 10 vertices>
+gap> x := AsPartialPerm((1, 3, 7)(2, 6, 5, 8));
+(1,3,7)(2,6,5,8)(4)
+gap> D := AsDigraph(x);
+<immutable digraph with 8 vertices, 8 edges>
+gap> AsDigraph(x, -1);
+Error, the 2nd argument <n> should be a non-negative integer,
+gap> AsDigraph(x, 0);
+<immutable empty digraph with 0 vertices>
+gap> D := AsDigraph(g, 10);
+<immutable functional digraph with 10 vertices>
+gap> AsDigraph(g, 7);
+fail
+gap> x := AsPartialPerm((2, 5, 3), 5);
+(1)(2,5,3)(4)
+gap> D := AsDigraph(IsMutableDigraph, x);
+<mutable digraph with 5 vertices, 5 edges>
+gap> AsDigraph(IsImmutableDigraph, x, 5);
+<immutable digraph with 5 vertices, 5 edges>
+gap> D = AsDigraph(IsImmutableDigraph, x, 5);
+true
+gap> D := AsDigraph(IsMutableDigraph, x, 6);
+<mutable digraph with 6 vertices, 5 edges>
+gap> OutNeighbours(D);
+[ [ 1 ], [ 5 ], [ 2 ], [ 4 ], [ 3 ], [  ] ]
+gap> AsDigraph(AsPartialPerm((2, 5, 3)), 2);
+fail
 
 #  RandomDigraph
 gap> IsImmutableDigraph(RandomDigraph(100, 0.2));


### PR DESCRIPTION
This PR adds an `AsDigraph` method for partial perms, and cleans up the documentation for `AsDigraph` as a bonus.