### PR TITLE
Add `IsDistributiveLatticeDigraph` property

### DIFF
--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -1311,7 +1311,8 @@ true
     Equivalently, a <E>distributive lattice digraph</E> is a <E>lattice digraph</E>
     in which the <E>lattice digraphs</E> representing <M>M3</M> and <M>N5</M> are
     not embeddable as lattices
-    (see <URL>https://en.wikipedia.org/wiki/Distributive_lattice)</URL>.<P/>
+    (see <URL>https://en.wikipedia.org/wiki/Distributive_lattice</URL> and
+    <Ref Prop="IsLatticeEmbedding"/>).<P/>
 
     &MUTABLE_RECOMPUTED_PROP;
 

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -1295,6 +1295,44 @@ true
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="IsDistributiveLatticeDigraph">
+<ManSection>
+  <Prop Name="IsDistributiveLatticeDigraph" Arg="digraph"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description>
+    <C>IsDistributiveLatticeDigraph</C> returns <K>true</K> if the digraph
+    <A>digraph</A> is a <E>distributive lattice digraph</E>.<P/>
+
+    A <E>distributive lattice digraph</E> is a <E>lattice digraph</E>
+    (<Ref Prop="IsLatticeDigraph"/>) which is distributive. That is to say,
+    the functions <Ref Oper="PartialOrderDigraphMeetOfVertices"/> and
+    <Ref Oper="PartialOrderDigraphJoinOfVertices"/> distribute over each other.<P/>
+    
+    Equivalently, a <E>distributive lattice digraph</E> is a <E>lattice digraph</E>
+    in which the <E>lattice digraphs</E> representing <M>M3</M> and <M>N5</M> are
+    not embeddable as lattices
+    (see <URL>https://en.wikipedia.org/wiki/Distributive_lattice)</URL>.<P/>
+
+    &MUTABLE_RECOMPUTED_PROP;
+
+    <Example><![CDATA[
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> IsDistributiveLatticeDigraph(D);
+true
+gap> N5 := Digraph([[2, 4], [3], [5], [5], []]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> N5 := DigraphReflexiveTransitiveClosure(N5);
+<immutable preorder digraph with 5 vertices, 13 edges>
+gap> IsDistributiveLatticeDigraph(N5);
+false]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+
 <#GAPDoc Label="IsPreorderDigraph">
 <ManSection>
   <Prop Name="IsPreorderDigraph" Arg="digraph"/>

--- a/doc/z-chap5.xml
+++ b/doc/z-chap5.xml
@@ -30,6 +30,7 @@
     <#Include Label="IsMeetSemilatticeDigraph">
     <#Include Label="DigraphMeetTable">
     <#Include Label="IsUpperSemimodularDigraph">
+    <#Include Label="IsDistributiveLatticeDigraph">
   </Section>
 
   <Section><Heading>Regularity</Heading>

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -50,6 +50,7 @@ DeclareProperty("IsTransitiveDigraph", IsDigraph);
 DeclareProperty("IsJoinSemilatticeDigraph", IsDigraph);
 DeclareProperty("IsMeetSemilatticeDigraph", IsDigraph);
 DeclareProperty("IsPermutationDigraph", IsDigraph);
+DeclareProperty("IsDistributiveLatticeDigraph", IsDigraph);
 DeclareSynonymAttr("IsLatticeDigraph",
                    IsMeetSemilatticeDigraph and IsJoinSemilatticeDigraph);
 DeclareSynonymAttr("IsPreorderDigraph",

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -658,9 +658,6 @@ function(D)
 
   IsLatticeHomomorphism := function(map, L1, L2)
     local N, x, y;
-    if not IsLatticeDigraph(L1) or not IsLatticeDigraph(L2) then
-      return false;
-    fi;
     N := DigraphNrVertices(L1);
     for x in [1 .. N] do
       for y in [1 .. N] do

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -651,7 +651,7 @@ end);
 
 InstallMethod(IsDistributiveLatticeDigraph, "for a digraph", [IsDigraph],
 function(D)
-  local N5, M5, IsLatticeHomomorphism, IsSublattice;
+  local N5, M3, IsLatticeHomomorphism, IsSublattice;
   if not IsLatticeDigraph(D) then
     return false;
   fi;
@@ -682,8 +682,8 @@ function(D)
 
   N5 := DigraphReflexiveTransitiveClosure(
         Digraph([[2, 4], [3], [5], [5], []]));
-  M5 := DigraphReflexiveTransitiveClosure(
+  M3 := DigraphReflexiveTransitiveClosure(
         Digraph([[2, 3, 4], [5], [5], [5], []]));
 
-  return not (IsSublattice(N5, D) or IsSublattice(M5, D));
+  return not (IsSublattice(N5, D) or IsSublattice(M3, D));
 end);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -651,36 +651,19 @@ end);
 
 InstallMethod(IsDistributiveLatticeDigraph, "for a digraph", [IsDigraph],
 function(D)
-  local N5, M3, IsLatticeHomomorphism, IsSublattice;
+  local N5, M3;
   if not IsLatticeDigraph(D) then
     return false;
   fi;
-
-  IsLatticeHomomorphism := function(map, L1, L2)
-    local N, x, y;
-    N := DigraphNrVertices(L1);
-    for x in [1 .. N] do
-      for y in [1 .. N] do
-        if PartialOrderDigraphMeetOfVertices(L2, x ^ map, y ^ map) <>
-            PartialOrderDigraphMeetOfVertices(L1, x, y) ^ map
-            or PartialOrderDigraphJoinOfVertices(L2, x ^ map, y ^ map) <>
-               PartialOrderDigraphJoinOfVertices(L1, x, y) ^ map then
-          return false;
-        fi;
-      od;
-    od;
-    return true;
-  end;
-
-  IsSublattice := function(L1, L2)
-    return ForAny(EmbeddingsDigraphsRepresentatives(L1, L2),
-               x -> IsLatticeHomomorphism(x, L1, L2));
-  end;
 
   N5 := DigraphReflexiveTransitiveClosure(
         Digraph([[2, 4], [3], [5], [5], []]));
   M3 := DigraphReflexiveTransitiveClosure(
         Digraph([[2, 3, 4], [5], [5], [5], []]));
 
-  return not (IsSublattice(N5, D) or IsSublattice(M3, D));
+  if LatticeDigraphEmbedding(N5, D) <> fail or
+       LatticeDigraphEmbedding(M3, D) <> fail then
+    return false;
+  fi;
+  return true;
 end);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -648,3 +648,42 @@ function(D)
   fi;
   return IsTransitive(AutomorphismGroup(D), DigraphEdges(D), OnPairs);
 end);
+
+InstallMethod(IsDistributiveLatticeDigraph, "for a digraph", [IsDigraph],
+function(D)
+  local N5, M5, IsLatticeHomomorphism, IsSublattice;
+  if not IsLatticeDigraph(D) then
+    return false;
+  fi;
+
+  IsLatticeHomomorphism := function(map, L1, L2)
+    local N, x, y;
+    if not IsLatticeDigraph(L1) or not IsLatticeDigraph(L2) then
+      return false;
+    fi;
+    N := DigraphNrVertices(L1);
+    for x in [1 .. N] do
+      for y in [1 .. N] do
+        if PartialOrderDigraphMeetOfVertices(L2, x ^ map, y ^ map) <>
+            PartialOrderDigraphMeetOfVertices(L1, x, y) ^ map
+            or PartialOrderDigraphJoinOfVertices(L2, x ^ map, y ^ map) <>
+               PartialOrderDigraphJoinOfVertices(L1, x, y) ^ map then
+          return false;
+        fi;
+      od;
+    od;
+    return true;
+  end;
+
+  IsSublattice := function(L1, L2)
+    return ForAny(EmbeddingsDigraphsRepresentatives(L1, L2),
+               x -> IsLatticeHomomorphism(x, L1, L2));
+  end;
+
+  N5 := DigraphReflexiveTransitiveClosure(
+        Digraph([[2, 4], [3], [5], [5], []]));
+  M5 := DigraphReflexiveTransitiveClosure(
+        Digraph([[2, 3, 4], [5], [5], [5], []]));
+
+  return not (IsSublattice(N5, D) or IsSublattice(M5, D));
+end);

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1279,6 +1279,33 @@ false
 gap> IsLatticeDigraph(gr);
 false
 
+# IsDistributiveLatticeDigraph
+gap> D := Digraph([[11, 10], [], [2], [2], [3], [4, 3], [6, 5], [7], [7],
+>      [8], [9, 8]]);
+<immutable digraph with 11 vertices, 14 edges>
+gap> IsDistributiveLatticeDigraph(D);
+false
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 11 vertices, 60 edges>
+gap> IsDistributiveLatticeDigraph(D);
+true
+gap> D := DigraphReflexiveTransitiveClosure(CycleDigraph(5));
+<immutable preorder digraph with 5 vertices, 25 edges>
+gap> IsDistributiveLatticeDigraph(D);
+false
+gap> D := Digraph([[2, 4], [3, 5], [9], [5, 6], [7], [7, 8], [9], [9], []]);
+<immutable digraph with 9 vertices, 12 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 9 vertices, 34 edges>
+gap> IsDistributiveLatticeDigraph(D);
+false
+gap> N5 := DigraphReflexiveTransitiveClosure(Digraph([[2, 4], [3], [5], [5], []]));
+<immutable preorder digraph with 5 vertices, 13 edges>
+gap> M5 := DigraphReflexiveTransitiveClosure(Digraph([[2, 3, 4], [5], [5], [5], []]));
+<immutable preorder digraph with 5 vertices, 12 edges>
+gap> IsDistributiveLatticeDigraph(N5) or IsDistributiveLatticeDigraph(M5);
+false
+
 # IsPartialOrderDigraph
 gap> gr := NullDigraph(5);
 <immutable empty digraph with 5 vertices>

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1305,6 +1305,13 @@ gap> M5 := DigraphReflexiveTransitiveClosure(Digraph([[2, 3, 4], [5], [5], [5], 
 <immutable preorder digraph with 5 vertices, 12 edges>
 gap> IsDistributiveLatticeDigraph(N5) or IsDistributiveLatticeDigraph(M5);
 false
+gap> D := Digraph([[2, 4], [3, 4], [5], [5], []]);
+<immutable digraph with 5 vertices, 6 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 5 vertices, 14 edges>
+gap> IsDistributiveLatticeDigraph(D);
+true
+
 
 # IsPartialOrderDigraph
 gap> gr := NullDigraph(5);

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1312,7 +1312,6 @@ gap> D := DigraphReflexiveTransitiveClosure(D);
 gap> IsDistributiveLatticeDigraph(D);
 true
 
-
 # IsPartialOrderDigraph
 gap> gr := NullDigraph(5);
 <immutable empty digraph with 5 vertices>


### PR DESCRIPTION
**Note: This PR is on top of #538, which is in turn on top of #533.**

This PR adds the property `IsDistributiveLatticeDigraph`, which determines whether or not a digraph is a distributive lattice digraph. A digraph `D` is a distributive lattice digraph if it is a lattice digraph, and the operations `PartialOrderDigraphMeetOfVertices` and `PartialOrderDigraphJoinOfVertices` distributive over each other.


A lattice is distributive if and only if it the 'diamond' (`M3`) and 'pentagon' (`N5`) lattices described [here](https://en.wikipedia.org/wiki/Distributive_lattice#Characteristic_properties) are not sublattices. The method uses this characterisation.

Given a lattice digraph `D`, every lattice embedding from `M3` or `N5` into `D` is necessarily a digraph embedding of their corresponding partial order digraphs. The embeddings of `M3` and `N5` into `D` as digraphs are found, and it is determined whether or not they are lattice embeddings -- that is, the operations `PartialOrderDigraphMeetOfVertices` and `PartialOrderDigraphJoinOfVertices` are respected by the embeddings.

If it is found that one such digraph embedding is a lattice embedding, `IsDistributiveLatticeDigraph` returns `false`. Otherwise, it returns `true`.



I tested this approach against the simple approach of iterating through triplets of vertices, and found it to be faster. Producing 2500 random lattices with `RandomLattice(30)` (each call yields a random lattice on somewhere between 30 and 2*30 = 60 vertices), and comparing the runtimes for each method gives the following:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/42549861/152366337-ca233eea-be91-4544-a471-15e299446dc7.png">

Each point along the horizontal represents an individual lattice (the same being used for both methods). I'm referring to the lattice embedding method as the "homomorphism method". This axis is ordered by runtime for the trivial method (blue), and the garbage collection time is filtered out.

Comparing the methods on 1000 random lattices generated by `RandomLattice(n)` for `n` in the range `[9 .. 30]` gives the following:

<img width="762" alt="image" src="https://user-images.githubusercontent.com/42549861/152428324-d7a0d149-1e29-468e-8fa0-0523632dd981.png">

I've also compared the methods on all lattices on 11 and 12 points, and the homomorphism method was better on these. I'm working on a lattice-specific homomorphism finding algorithm, which should make this approach faster still.