### PR TITLE
Fix compatibility with grape

### DIFF
--- a/init.g
+++ b/init.g
@@ -32,7 +32,7 @@ if not IsBound(IsGraph) then
   IsGraph := ReturnFalse;
 fi;
 if not IsBound(Vertices) then
-  Vertices := IdFunc;
+  DeclareOperation("Vertices", [IsRecord]);
 fi;
 if not IsBound(Adjacency) then
   Adjacency := IdFunc;


### PR DESCRIPTION
When starting GAP with `-A`, then first loading digraphs and afterwards
loading grape, the following error was produced:

    Error, variable `Vertices' is not bound to an operation at GAPROOT/lib/oper.g:940 called from
    <function "DeclareOperation">( <arguments> )
     called from read-eval loop at GAPROOT/pkg/grape-4.8.5/lib/grape.g:566
    you can 'quit;' to quit to outer loop, or
    you can 'return;' to continue