### PR TITLE
More fixes for loading grape after digraphs

### DIFF
--- a/gap/grape.gi
+++ b/gap/grape.gi
@@ -132,7 +132,7 @@ function(D)
          "the Grape graph will have fewer\n#I  edges than the original,");
   fi;
 
-  if not DIGRAPHS_IsGrapeLoaded then
+  if not DIGRAPHS_IsGrapeLoaded() then
     Info(InfoWarning, 1, "Grape is not loaded,");
   fi;
 

--- a/init.g
+++ b/init.g
@@ -25,7 +25,7 @@ if not IsBound(DIGRAPH_OUT_NBS) and
 fi;
 
 BindGlobal("DIGRAPHS_IsGrapeLoaded",
-           IsPackageMarkedForLoading("grape", "4.8.1"));
+           {} -> IsPackageMarkedForLoading("grape", "4.8.1"));
 
 # To avoid warnings when GRAPE is not loaded
 if not IsBound(IsGraph) then

--- a/read.g
+++ b/read.g
@@ -8,7 +8,7 @@
 #############################################################################
 ##
 
-if not DIGRAPHS_IsGrapeLoaded then
+if not DIGRAPHS_IsGrapeLoaded() then
   Add(DIGRAPHS_OmitFromTests, "Graph(");
 fi;
 

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -211,7 +211,7 @@ gap> DigraphRange(gr);
 [ 2, 3, 2 ]
 gap> gr;
 <immutable digraph with 3 vertices, 3 edges>
-gap> if DIGRAPHS_IsGrapeLoaded then
+gap> if DIGRAPHS_IsGrapeLoaded() then
 >   g := Graph(gr);
 >   if not Digraph(g) = gr then
 >     Print("fail");
@@ -1627,7 +1627,7 @@ gap> MakeImmutable(D);
 # 
 gap> D := NullDigraph(10);
 <immutable empty digraph with 10 vertices>
-gap> if DIGRAPHS_IsGrapeLoaded then
+gap> if DIGRAPHS_IsGrapeLoaded() then
 >   D := Graph(D);
 >   if D <> rec(
 >       adjacencies := [[]],

--- a/tst/standard/grape.tst
+++ b/tst/standard/grape.tst
@@ -129,7 +129,7 @@ rec( adjacencies := [ [ 2, 4 ] ], group := Group([ (1,3), (1,2)(3,4) ]),
   schreierVector := [ -1, 2, 1, 2 ] )
 
 #  Digraph: copying group from Grape
-gap> if DIGRAPHS_IsGrapeLoaded then
+gap> if DIGRAPHS_IsGrapeLoaded() then
 >   gr := Digraph(JohnsonGraph(5, 3));
 > else
 >   gr := JohnsonDigraph(5, 3);
@@ -140,7 +140,7 @@ gap> HasDigraphGroup(gr);
 true
 gap> DigraphGroup(gr);
 Group([ (1,7,10,6,3)(2,8,4,9,5), (4,7)(5,8)(6,9) ])
-gap> if DIGRAPHS_IsGrapeLoaded then
+gap> if DIGRAPHS_IsGrapeLoaded() then
 >   gr := Digraph(CompleteGraph(Group((1, 2, 3), (1, 2))));
 > else
 >   gr := Digraph([[2, 3], [1, 3], [1, 2]]);
@@ -150,7 +150,7 @@ gap> HasDigraphGroup(gr);
 true
 gap> DigraphGroup(gr);
 Group([ (1,2,3), (1,2) ])
-gap> if DIGRAPHS_IsGrapeLoaded then
+gap> if DIGRAPHS_IsGrapeLoaded() then
 >   gr := Digraph(Graph(Group([()]),
 >                       [1, 2, 3],
 >                       OnPoints,
@@ -252,7 +252,7 @@ true
 #  Graph
 gap> gr := Digraph([[2, 2], []]);
 <immutable multidigraph with 2 vertices, 2 edges>
-gap> if DIGRAPHS_IsGrapeLoaded then
+gap> if DIGRAPHS_IsGrapeLoaded() then
 >   Graph(gr);
 > fi;
 

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -23,11 +23,11 @@ gap> OutNeighbours(gr);
 [ [ 8 ], [ 4, 5, 6, 8, 9 ], [ 2, 4, 5, 7, 10 ], [ 9 ], [ 1, 4, 6, 7, 9 ], 
   [ 2, 3, 6, 7, 10 ], [ 3, 4, 5, 8, 9 ], [ 3, 4, 9, 10 ], 
   [ 1, 2, 3, 5, 6, 9, 10 ], [ 2, 4, 5, 6, 9 ] ]
-gap> not DIGRAPHS_IsGrapeLoaded
-> or (DIGRAPHS_IsGrapeLoaded and Digraph(Graph(gr)) = gr);
+gap> not DIGRAPHS_IsGrapeLoaded()
+> or (DIGRAPHS_IsGrapeLoaded() and Digraph(Graph(gr)) = gr);
 true
-gap> not DIGRAPHS_IsGrapeLoaded
-> or (DIGRAPHS_IsGrapeLoaded and Graph(Digraph(Graph(gr))).adjacencies =
+gap> not DIGRAPHS_IsGrapeLoaded()
+> or (DIGRAPHS_IsGrapeLoaded() and Graph(Digraph(Graph(gr))).adjacencies =
 >     Graph(gr).adjacencies);
 true
 gap> adj := [
@@ -38,8 +38,8 @@ gap> adj := [
 > [1, 6, 8, 9, 11, 12, 13, 14], [2, 4, 7, 9, 10, 11, 13, 15, 16]];;
 gap> func := function(x, y) return y in adj[x]; end;
 function( x, y ) ... end
-gap> not DIGRAPHS_IsGrapeLoaded or
-> (DIGRAPHS_IsGrapeLoaded and
+gap> not DIGRAPHS_IsGrapeLoaded() or
+> (DIGRAPHS_IsGrapeLoaded() and
 >  Digraph(Graph(Group(()), [1 .. 20], OnPoints, func, true)) = Digraph(adj));
 true
 


### PR DESCRIPTION
When loading digraphs before grape, then some code kept printing a warning
saying "Grape is not loaded", even though grape was loaded. This patch fixes
that.

Sorry, I didn't notice this one before. 

Note that even with this patch, it will skip some test if one now tries to run the Digraphs test suite, That's because `DIGRAPHS_OmitFromTests` is initialized once and then not updated. This could be fixed, e.g. by removing `DIGRAPHS_OmitFromTests` and modifying the code which currently uses it to directly use `DIGRAPHS_IsGrapeLoaded()` -- the code would arguably be simpler, too. But I don't know if you have plans to use `DIGRAPHS_OmitFromTests` more or have other needs for it, so I didn't do that in this PR.