### PR TITLE
Add `LatticeDigraphEmbedding` method

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -2436,3 +2436,45 @@ fail
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="MeetSemilatticeDigraphMeetTable">
+<ManSection>
+  <Attr Name="MeetSemilatticeDigraphMeetTable" Arg="digraph"/>
+  <Attr Name="JoinSemilatticeDigraphJoinTable" Arg="digraph"/>
+  <Returns>A matrix or <K>fail</K>.</Returns>
+  <Description>
+    <C>MeetSemilatticeDigraphMeetTable</C> returns the <E>meet table</E> of
+    <A>digraph</A> if <A>digraph</A> is a meet semilattice digraph
+    <Ref Prop="IsMeetSemilatticeDigraph"/>. Similarly,
+    <C>JoinSemilatticeDigraphJoinTable</C> returns the <E>join table</E> of
+    <A>digraph</A> if <A>digraph</A> is a join semilattice digraph.
+    <Ref Prop="IsJoinSemilatticeDigraph"/>.<P/>
+
+    Where <A>digraph</A> is a meet semilattice digraph with <M>n</M> vertices,
+    the <E>meet table</E> of <A>digraph</A> is the matrix <M>A</M> such that
+    the <M>(i, j)</M> entry of <M>A</M> is equal to the meet of vertices
+    <M>i</M> and <M>j</M>.<P/>
+
+    Similarly, where <A>digraph</A> is a join semilattice digraph with <M>n</M>
+    vertices, the <E>join table</E> of <A>digraph</A> is the matrix <M>A</M>
+    such that the <M>(i, j)</M> entry of <M>A</M> is equal to the join of
+    vertices <M>i</M> and <M>j</M>.
+
+    <Example><![CDATA[
+gap> D := Digraph([[1, 2, 3, 4], [2, 4], [3, 4], [4]]);
+<immutable digraph with 4 vertices, 9 edges>
+gap> IsJoinSemilatticeDigraph(D);
+true
+gap> Display(JoinSemilatticeDigraphJoinTable(D));
+[ [  1,  2,  3,  4 ],
+  [  2,  2,  4,  4 ],
+  [  3,  4,  3,  4 ],
+  [  4,  4,  4,  4 ] ]
+gap> D := CycleDigraph(5);
+<immutable cycle digraph with 5 vertices>
+gap> JoinSemilatticeDigraphJoinTable(D);
+fail
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -2437,16 +2437,16 @@ fail
 </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="MeetSemilatticeDigraphMeetTable">
+<#GAPDoc Label="DigraphMeetTable">
 <ManSection>
-  <Attr Name="MeetSemilatticeDigraphMeetTable" Arg="digraph"/>
-  <Attr Name="JoinSemilatticeDigraphJoinTable" Arg="digraph"/>
+  <Attr Name="DigraphMeetTable" Arg="digraph"/>
+  <Attr Name="DigraphJoinTable" Arg="digraph"/>
   <Returns>A matrix or <K>fail</K>.</Returns>
   <Description>
-    <C>MeetSemilatticeDigraphMeetTable</C> returns the <E>meet table</E> of
+    <C>DigraphMeetTable</C> returns the <E>meet table</E> of
     <A>digraph</A> if <A>digraph</A> is a meet semilattice digraph
     <Ref Prop="IsMeetSemilatticeDigraph"/>. Similarly,
-    <C>JoinSemilatticeDigraphJoinTable</C> returns the <E>join table</E> of
+    <C>DigraphJoinTable</C> returns the <E>join table</E> of
     <A>digraph</A> if <A>digraph</A> is a join semilattice digraph.
     <Ref Prop="IsJoinSemilatticeDigraph"/>.<P/>
 
@@ -2465,14 +2465,14 @@ gap> D := Digraph([[1, 2, 3, 4], [2, 4], [3, 4], [4]]);
 <immutable digraph with 4 vertices, 9 edges>
 gap> IsJoinSemilatticeDigraph(D);
 true
-gap> Display(JoinSemilatticeDigraphJoinTable(D));
+gap> Display(DigraphJoinTable(D));
 [ [  1,  2,  3,  4 ],
   [  2,  2,  4,  4 ],
   [  3,  4,  3,  4 ],
   [  4,  4,  4,  4 ] ]
 gap> D := CycleDigraph(5);
 <immutable cycle digraph with 5 vertices>
-gap> JoinSemilatticeDigraphJoinTable(D);
+gap> DigraphJoinTable(D);
 fail
 ]]></Example>
   </Description>

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -2443,12 +2443,11 @@ fail
   <Attr Name="DigraphJoinTable" Arg="digraph"/>
   <Returns>A matrix or <K>fail</K>.</Returns>
   <Description>
-    <C>DigraphMeetTable</C> returns the <E>meet table</E> of
-    <A>digraph</A> if <A>digraph</A> is a meet semilattice digraph
-    <Ref Prop="IsMeetSemilatticeDigraph"/>. Similarly,
-    <C>DigraphJoinTable</C> returns the <E>join table</E> of
-    <A>digraph</A> if <A>digraph</A> is a join semilattice digraph.
-    <Ref Prop="IsJoinSemilatticeDigraph"/>.<P/>
+    <C>DigraphMeetTable</C> returns the <E>meet table</E> of the digraph
+    <A>digraph</A> if <A>digraph</A> is a meet semilattice digraph <Ref
+    Prop="IsMeetSemilatticeDigraph"/>. Similarly, <C>DigraphJoinTable</C>
+    returns the <E>join table</E> of <A>digraph</A> if <A>digraph</A> is a join
+    semilattice digraph. <Ref Prop="IsJoinSemilatticeDigraph"/>.<P/>
 
     Where <A>digraph</A> is a meet semilattice digraph with <M>n</M> vertices,
     the <E>meet table</E> of <A>digraph</A> is the matrix <M>A</M> such that

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -882,7 +882,7 @@ gap> L1 := DigraphReflexiveTransitiveClosure(ChainDigraph(5));
 gap> L2 := DigraphReflexiveTransitiveClosure(ChainDigraph(6));
 <immutable preorder digraph with 6 vertices, 21 edges>
 gap> LatticeDigraphEmbedding(L1, L2);
-[ 1, 2, 3, 4, 5 ]
+IdentityTransformation
 gap> LatticeDigraphEmbedding(L2, L1);
 fail
 ]]></Example>

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -869,7 +869,7 @@ gap> MinimalCommonSuperdigraph(NullDigraph(0), CompleteDigraph(10));
   <Description>
     <C>LatticeDigraphEmbedding</C> returns a single <E>injective</E> <Ref
       Oper="DigraphHomomorphism"/> between <A>L1</A> and <A>L2</A>, with
-      the the property that it is a <E>lattice homomorphism</E>. If one
+      the property that it is a <E>lattice homomorphism</E>. If one
       does not exist, <K>fail</K> is returned.<P/>
 
       A <E>lattice homomorphism</E> is a digraph homomorphism which
@@ -892,10 +892,11 @@ fail
 
 <#GAPDoc Label="IsLatticeHomomorphism">
 <ManSection>
-  <Oper Name="IsLatticeHomomorphism" Arg="L1, L2, map"/>
   <Oper Name="IsLatticeHomomorphism" Arg="L1, L2, map" 
         Label="for digraphs and a permutation or transformation"/>
   <Oper Name="IsLatticeEpimorphism" Arg="L1, L2, map"
+        Label="for digraphs and a permutation or transformation"/>
+  <Oper Name="IsLatticeEmbedding" Arg="L1, L2, map"
         Label="for digraphs and a permutation or transformation"/>
   <Oper Name="IsLatticeMonomorphism" Arg="L1, L2, map"
         Label="for digraphs and a permutation or transformation"/>
@@ -904,6 +905,11 @@ fail
   <Returns><K>true</K> or <K>false</K>.</Returns>
 
   <Description>
+    A transformation or permutation <A>map</A> is a <E>lattice homomorphism</E>
+    if <A>map</A> respects meets and joins of every pair of vertices, and
+    <A>map</A> fixes every <C>i</C> which is not a vertex of <A>L1</A>.
+    <P/>
+
     <C>IsLatticeHomomorphism</C> returns <K>true</K> if the permutation
     or transformation <A>map</A> is a lattice homomorphism from the lattice digraph
     <A>L1</A> to the lattice digraph <A>L2</A>.
@@ -931,10 +937,6 @@ fail
     <E>lattice homomorphism</E> from <A>L1</A> to <A>L2</A>, and <K>false</K>
     otherwise. If <A>L1</A> or <A>L2</A> is not a lattice, then <K>false</K>
     is returned.<P/>
-
-    A transformation or permutation <A>map</A> is a <E>lattice homomorphism</E>
-    if <A>map</A> respects meets and joins of every pair of vertices, and
-    <A>map</A> fixes every <C>i</C> which is not a vertex of <A>L1</A>.
     <Example><![CDATA[
 gap> G := Digraph([[2, 4], [3, 7], [6], [5, 7], [6], [], [6]]);
 <immutable digraph with 7 vertices, 9 edges>

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -889,3 +889,33 @@ fail
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="IsLatticeHomomorphism">
+<ManSection>
+  <Oper Name="IsLatticeHomomorphism" Arg="L1, L2, map"/>
+  <Returns>A boolean.</Returns>
+  <Description>
+    <C>IsLatticeHomomorphism</C> takes a pair of lattices <A>L1</A> and <A>L2</A>,
+       and a transformation <A>map</A>, returning <K>true</K> if <A>map</A> is a
+       <E>lattice homomorphism</E> from <A>L1</A> to <A>L2</A>, and <K>false</K>
+       otherwise.<P/>
+
+       A <E>lattice homomorphism</E> is a digraph homomorphism which
+       respects meets and joins of every pair of vertices.
+    <Example><![CDATA[
+gap> G := Digraph([[2, 4], [3, 7], [6], [5, 7], [6], [], [6]]);
+<immutable digraph with 7 vertices, 9 edges>
+gap> D := DigraphRemoveVertex(G, 7);
+<immutable digraph with 6 vertices, 6 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 7 vertices, 22 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 6 vertices, 17 edges>
+gap> IsDigraphEmbedding(D, G, IdentityTransformation);
+true
+gap> IsLatticeHomomorphism(D, G, IdentityTransformation);
+false
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -861,3 +861,31 @@ gap> MinimalCommonSuperdigraph(NullDigraph(0), CompleteDigraph(10));
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="LatticeDigraphEmbedding">
+<ManSection>
+  <Oper Name="LatticeDigraphEmbedding" Arg="L1, L2"/>
+  <Returns>A transformation, or <K>fail</K>.</Returns>
+  <Description>
+    <C>LatticeDigraphEmbedding</C> returns a single <E>injective</E> <Ref
+      Oper="DigraphHomomorphism"/> between <A>L1</A> and <A>L2</A>, with
+      the the property that it is a <E>lattice homomorphism</E>. If one
+      does not exist, <K>fail</K> is returned.<P/>
+
+      A <E>lattice homomorphism</E> is a digraph homomorphism which
+      respects meets and joins of every pair of vertices.
+    <Example><![CDATA[
+gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(5));
+<immutable preorder digraph with 5 vertices, 15 edges>
+gap> L1 := DigraphReflexiveTransitiveClosure(ChainDigraph(5));
+<immutable preorder digraph with 5 vertices, 15 edges>
+gap> L2 := DigraphReflexiveTransitiveClosure(ChainDigraph(6));
+<immutable preorder digraph with 6 vertices, 21 edges>
+gap> LatticeDigraphEmbedding(L1, L2);
+[ 1, 2, 3, 4, 5 ]
+gap> LatticeDigraphEmbedding(L2, L1);
+fail
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -893,15 +893,48 @@ fail
 <#GAPDoc Label="IsLatticeHomomorphism">
 <ManSection>
   <Oper Name="IsLatticeHomomorphism" Arg="L1, L2, map"/>
-  <Returns>A boolean.</Returns>
-  <Description>
-    <C>IsLatticeHomomorphism</C> takes a pair of lattices <A>L1</A> and <A>L2</A>,
-       and a transformation <A>map</A>, returning <K>true</K> if <A>map</A> is a
-       <E>lattice homomorphism</E> from <A>L1</A> to <A>L2</A>, and <K>false</K>
-       otherwise.<P/>
+  <Oper Name="IsLatticeHomomorphism" Arg="L1, L2, map" 
+        Label="for digraphs and a permutation or transformation"/>
+  <Oper Name="IsLatticeEpimorphism" Arg="L1, L2, map"
+        Label="for digraphs and a permutation or transformation"/>
+  <Oper Name="IsLatticeMonomorphism" Arg="L1, L2, map"
+        Label="for digraphs and a permutation or transformation"/>
+  <Oper Name="IsLatticeEndomorphism" Arg="L, map"
+        Label="for digraphs and a permutation or transformation"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
 
-       A <E>lattice homomorphism</E> is a digraph homomorphism which
-       respects meets and joins of every pair of vertices.
+  <Description>
+    <C>IsLatticeHomomorphism</C> returns <K>true</K> if the permutation
+    or transformation <A>map</A> is a lattice homomorphism from the lattice digraph
+    <A>L1</A> to the lattice digraph <A>L2</A>.
+    <P/>
+
+    <C>IsLatticeEpimorphism</C> returns <K>true</K> if the permutation
+    or transformation <A>map</A> is a surjective lattice homomorphism from
+    the lattice digraph <A>L1</A> to the lattice digraph <A>L2</A>.
+    <P/>
+
+    <C>IsLatticeEmbedding</C> returns <K>true</K> if the permutation
+    or transformation <A>map</A> is an injective lattice homomorphism from
+    the lattice digraph <A>L1</A> to the lattice digraph <A>L2</A>.
+    The function <C>IsLatticeMonomorphism</C> is a synonym of 
+    <C>IsLatticeEmbedding</C>.
+    <P/>
+
+    <C>IsLatticeEndomorphism</C> returns <K>true</K> if the permutation
+    or transformation <A>map</A> is an lattice endomorphism of the
+    lattice digraph <A>L</A>.
+    <P/>
+
+    <C>IsLatticeHomomorphism</C> takes a pair of digraphs <A>L1</A> and <A>L2</A>,
+    and a transformation <A>map</A>, returning <K>true</K> if <A>map</A> is a
+    <E>lattice homomorphism</E> from <A>L1</A> to <A>L2</A>, and <K>false</K>
+    otherwise. If <A>L1</A> or <A>L2</A> is not a lattice, then <K>false</K>
+    is returned.<P/>
+
+    A transformation or permutation <A>map</A> is a <E>lattice homomorphism</E>
+    if <A>map</A> respects meets and joins of every pair of vertices, and
+    <A>map</A> fixes every <C>i</C> which is not a vertex of <A>L1</A>.
     <Example><![CDATA[
 gap> G := Digraph([[2, 4], [3, 7], [6], [5, 7], [6], [], [6]]);
 <immutable digraph with 7 vertices, 9 edges>
@@ -915,6 +948,24 @@ gap> IsDigraphEmbedding(D, G, IdentityTransformation);
 true
 gap> IsLatticeHomomorphism(D, G, IdentityTransformation);
 false
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> G := Digraph([[2, 3], [4], [4], [5], []]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 5 vertices, 14 edges>
+gap> IsLatticeEmbedding(D, G, IdentityTransformation);
+true
+gap> IsLatticeMonomorphism(D, G, IdentityTransformation);
+true
+gap> f := Transformation([1, 2, 3, 4, 4]);
+Transformation( [ 1, 2, 3, 4, 4 ] )
+gap> IsLatticeEpimorphism(G, D, f);
+true
+gap> IsLatticeEndomorphism(D, (2, 3));
+true
 ]]></Example>
   </Description>
 </ManSection>

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -867,13 +867,18 @@ gap> MinimalCommonSuperdigraph(NullDigraph(0), CompleteDigraph(10));
   <Oper Name="LatticeDigraphEmbedding" Arg="L1, L2"/>
   <Returns>A transformation, or <K>fail</K>.</Returns>
   <Description>
+    If <A>L1</A> and <A>L2</A> are lattice digraphs (<Ref
+      Prop="IsLatticeDigraph"/> returns <K>true</K>, then 
     <C>LatticeDigraphEmbedding</C> returns a single <E>injective</E> <Ref
       Oper="DigraphHomomorphism"/> between <A>L1</A> and <A>L2</A>, with
-      the property that it is a <E>lattice homomorphism</E>. If one
-      does not exist, <K>fail</K> is returned.<P/>
+      the property that it is a <E>lattice homomorphism</E>. If no such
+      homomorphism exists, <K>fail</K> is returned.<P/>
 
-      A <E>lattice homomorphism</E> is a digraph homomorphism which
-      respects meets and joins of every pair of vertices.
+      A <E>lattice homomorphism</E> is a digraph homomorphism which respects
+      meets and joins of every pair of vertices. Note that every injective
+      lattice homomorphism <C>map</C> is an embedding, in the sense that
+      the inverse of <C>map</C> is a lattice homomorphism also.
+
     <Example><![CDATA[
 gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(5));
 <immutable preorder digraph with 5 vertices, 15 edges>
@@ -905,6 +910,13 @@ fail
   <Returns><K>true</K> or <K>false</K>.</Returns>
 
   <Description>
+    Each of the function described in this section (except
+    <C>IsLatticeEndomorphism</C>) takes a pair of digraphs <A>L1</A> and
+    <A>L2</A>, and a transformation <A>map</A>, returning <K>true</K> if
+    <A>map</A> is a <E>lattice homomorphism</E> from <A>L1</A> to <A>L2</A>,
+      and <K>false</K> otherwise. If <A>L1</A> or <A>L2</A> is not a lattice,
+      then <K>false</K> is returned.<P/>
+
     A transformation or permutation <A>map</A> is a <E>lattice homomorphism</E>
     if <A>map</A> respects meets and joins of every pair of vertices, and
     <A>map</A> fixes every <C>i</C> which is not a vertex of <A>L1</A>.
@@ -930,13 +942,7 @@ fail
     <C>IsLatticeEndomorphism</C> returns <K>true</K> if the permutation
     or transformation <A>map</A> is an lattice endomorphism of the
     lattice digraph <A>L</A>.
-    <P/>
 
-    <C>IsLatticeHomomorphism</C> takes a pair of digraphs <A>L1</A> and <A>L2</A>,
-    and a transformation <A>map</A>, returning <K>true</K> if <A>map</A> is a
-    <E>lattice homomorphism</E> from <A>L1</A> to <A>L2</A>, and <K>false</K>
-    otherwise. If <A>L1</A> or <A>L2</A> is not a lattice, then <K>false</K>
-    is returned.<P/>
     <Example><![CDATA[
 gap> G := Digraph([[2, 4], [3, 7], [6], [5, 7], [6], [], [6]]);
 <immutable digraph with 7 vertices, 9 edges>

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -1290,15 +1290,6 @@ gap> IsJoinSemilatticeDigraph(D);
 true
 gap> IsLatticeDigraph(D);
 true
-gap> D := Digraph([[1, 1, 1], [1, 1, 2, 2],
->                   [1, 3, 3], [1, 2, 3, 3, 4]]);
-<immutable multidigraph with 4 vertices, 15 edges>
-gap> IsMeetSemilatticeDigraph(D);
-true
-gap> IsJoinSemilatticeDigraph(D);
-true
-gap> IsLatticeDigraph(D);
-true
 ]]></Example>
   </Description>
 </ManSection>

--- a/doc/z-chap5.xml
+++ b/doc/z-chap5.xml
@@ -28,7 +28,7 @@
     <#Include Label="IsPreorderDigraph">
     <#Include Label="IsPartialOrderDigraph">
     <#Include Label="IsMeetSemilatticeDigraph">
-    <#Include Label="MeetSemilatticeDigraphMeetTable">
+    <#Include Label="DigraphMeetTable">
     <#Include Label="IsUpperSemimodularDigraph">
   </Section>
 

--- a/doc/z-chap5.xml
+++ b/doc/z-chap5.xml
@@ -28,6 +28,7 @@
     <#Include Label="IsPreorderDigraph">
     <#Include Label="IsPartialOrderDigraph">
     <#Include Label="IsMeetSemilatticeDigraph">
+    <#Include Label="MeetSemilatticeDigraphMeetTable">
     <#Include Label="IsUpperSemimodularDigraph">
   </Section>
 

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -73,6 +73,7 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
     <#Include Label="ChromaticNumber">
     <#Include Label="DigraphCore">
     <#Include Label="LatticeDigraphEmbedding">
+    <#Include Label="IsLatticeHomomorphism">
   </Section>
 
 </Chapter>

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -72,6 +72,7 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
     <#Include Label="DigraphWelshPowellOrder">
     <#Include Label="ChromaticNumber">
     <#Include Label="DigraphCore">
+    <#Include Label="LatticeDigraphEmbedding">
   </Section>
 
 </Chapter>

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -126,3 +126,6 @@ DeclareAttribute("NonLowerSemimodularPair", IsDigraph);
 
 DeclareProperty("IsUpperSemimodularDigraph", IsDigraph);
 DeclareProperty("IsLowerSemimodularDigraph", IsDigraph);
+
+DeclareProperty("JoinSemilatticeDigraphJoinTable", IsDigraph);
+DeclareProperty("MeetSemilatticeDigraphMeetTable", IsDigraph);

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -127,5 +127,5 @@ DeclareAttribute("NonLowerSemimodularPair", IsDigraph);
 DeclareProperty("IsUpperSemimodularDigraph", IsDigraph);
 DeclareProperty("IsLowerSemimodularDigraph", IsDigraph);
 
-DeclareProperty("JoinSemilatticeDigraphJoinTable", IsDigraph);
-DeclareProperty("MeetSemilatticeDigraphMeetTable", IsDigraph);
+DeclareAttribute("JoinSemilatticeDigraphJoinTable", IsDigraph);
+DeclareAttribute("MeetSemilatticeDigraphMeetTable", IsDigraph);

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -127,5 +127,5 @@ DeclareAttribute("NonLowerSemimodularPair", IsDigraph);
 DeclareProperty("IsUpperSemimodularDigraph", IsDigraph);
 DeclareProperty("IsLowerSemimodularDigraph", IsDigraph);
 
-DeclareAttribute("JoinSemilatticeDigraphJoinTable", IsDigraph);
-DeclareAttribute("MeetSemilatticeDigraphMeetTable", IsDigraph);
+DeclareAttribute("DigraphJoinTable", IsDigraph);
+DeclareAttribute("DigraphMeetTable", IsDigraph);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2672,24 +2672,8 @@ end);
 
 InstallMethod(JoinSemilatticeDigraphJoinTable, "for a digraph",
 [IsDigraph],
-function(D)
-  local out;
-  out := DIGRAPHS_IsMeetJoinSemilatticeDigraph(D, true);
-  if out = false then
-    SetIsJoinSemilatticeDigraph(D, false);
-    return fail;
-  fi;
-  return out;
-end);
+D -> DIGRAPHS_IsJoinSemilatticeAndJoinTable(D)[2]);
 
 InstallMethod(MeetSemilatticeDigraphMeetTable, "for a digraph",
 [IsDigraph],
-function(D)
-  local out;
-  out := DIGRAPHS_IsMeetJoinSemilatticeDigraph(D, false);
-  if out = false then
-    SetIsMeetSemilatticeDigraph(D, false);
-    return fail;
-  fi;
-  return out;
-end);
+D -> DIGRAPHS_IsMeetSemilatticeAndMeetTable(D)[2]);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2669,3 +2669,27 @@ function(D)
   D := DigraphReflexiveTransitiveReduction(DigraphMutableCopyIfMutable(D));
   return DIGRAPHS_NonSemimodularPair(InNeighbours(D)) = fail;
 end);
+
+InstallMethod(JoinSemilatticeDigraphJoinTable, "for a digraph",
+[IsDigraph],
+function(D)
+  local out;
+  out := DIGRAPHS_IsMeetJoinSemilatticeDigraph(D, true);
+  if out = false then
+    SetIsJoinSemilatticeDigraph(D, false);
+    return fail;
+  fi;
+  return out;
+end);
+
+InstallMethod(MeetSemilatticeDigraphMeetTable, "for a digraph",
+[IsDigraph],
+function(D)
+  local out;
+  out := DIGRAPHS_IsMeetJoinSemilatticeDigraph(D, false);
+  if out = false then
+    SetIsMeetSemilatticeDigraph(D, false);
+    return fail;
+  fi;
+  return out;
+end);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2670,10 +2670,10 @@ function(D)
   return DIGRAPHS_NonSemimodularPair(InNeighbours(D)) = fail;
 end);
 
-InstallMethod(JoinSemilatticeDigraphJoinTable, "for a digraph",
+InstallMethod(DigraphJoinTable, "for a digraph",
 [IsDigraph],
 D -> DIGRAPHS_IsJoinSemilatticeAndJoinTable(D)[2]);
 
-InstallMethod(MeetSemilatticeDigraphMeetTable, "for a digraph",
+InstallMethod(DigraphMeetTable, "for a digraph",
 [IsDigraph],
 D -> DIGRAPHS_IsMeetSemilatticeAndMeetTable(D)[2]);

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -97,12 +97,20 @@ DeclareOperation("MaximalCommonSubdigraph", [IsDigraph, IsDigraph]);
 DeclareOperation("MinimalCommonSuperdigraph", [IsDigraph, IsDigraph]);
 
 DeclareOperation("LatticeDigraphEmbedding", [IsDigraph, IsDigraph]);
+
 DeclareOperation("IsLatticeHomomorphism",
                  [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsLatticeHomomorphism",
+                 [IsDigraph, IsDigraph, IsPerm]);
 DeclareOperation("IsLatticeEndomorphism", [IsDigraph, IsTransformation]);
+DeclareOperation("IsLatticeEndomorphism", [IsDigraph, IsPerm]);
 DeclareOperation("IsLatticeEpimorphism",
                  [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsLatticeEpimorphism",
+                 [IsDigraph, IsDigraph, IsPerm]);
 DeclareOperation("IsLatticeEmbedding",
                  [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsLatticeEmbedding",
+                 [IsDigraph, IsDigraph, IsPerm]);
 DeclareSynonym("IsLatticeMonomorphism", IsLatticeEmbedding);
 

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -97,3 +97,4 @@ DeclareOperation("MaximalCommonSubdigraph", [IsDigraph, IsDigraph]);
 DeclareOperation("MinimalCommonSuperdigraph", [IsDigraph, IsDigraph]);
 
 DeclareOperation("LatticeDigraphEmbedding", [IsDigraph, IsDigraph]);
+DeclareOperation("IsLatticeHomomorphism", [IsDigraph, IsDigraph, IsTransformation]);

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -97,4 +97,12 @@ DeclareOperation("MaximalCommonSubdigraph", [IsDigraph, IsDigraph]);
 DeclareOperation("MinimalCommonSuperdigraph", [IsDigraph, IsDigraph]);
 
 DeclareOperation("LatticeDigraphEmbedding", [IsDigraph, IsDigraph]);
-DeclareOperation("IsLatticeHomomorphism", [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsLatticeHomomorphism",
+                 [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsLatticeEndomorphism", [IsDigraph, IsTransformation]);
+DeclareOperation("IsLatticeEpimorphism",
+                 [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsLatticeEmbedding",
+                 [IsDigraph, IsDigraph, IsTransformation]);
+DeclareSynonym("IsLatticeMonomorphism", IsLatticeEmbedding);
+

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -95,3 +95,5 @@ DeclareOperation("DigraphsRespectsColouring",
 
 DeclareOperation("MaximalCommonSubdigraph", [IsDigraph, IsDigraph]);
 DeclareOperation("MinimalCommonSuperdigraph", [IsDigraph, IsDigraph]);
+
+DeclareOperation("LatticeDigraphEmbedding", [IsDigraph, IsDigraph]);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -903,9 +903,15 @@ InstallMethod(IsLatticeHomomorphism,
 function(L1, L2, map)
   local N1, N2, x, y, meet1, meet2, join1, join2;
 
+  N1 := DigraphNrVertices(L1);
+  N2 := DigraphNrVertices(L2);
+
+  if LargestMovedPoint(map) > N1 then
+    return false;
+  fi;
+
   # We compute the join/meet table to avoid having to do this twice if L1 or L2
   # is mutable
-
   join1 := DigraphJoinTable(L1);
   meet1 := DigraphMeetTable(L1);
 
@@ -919,9 +925,6 @@ function(L1, L2, map)
   if join2 = fail or meet2 = fail then
     ErrorNoReturn("the 2nd argument (a digraph) must be a lattice digraph");
   fi;
-
-  N1 := DigraphNrVertices(L1);
-  N2 := DigraphNrVertices(L2);
 
   if Maximum(ImageSetOfTransformation(map, N1)) > N2 then
     return false;

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -762,7 +762,7 @@ function(L1, L2)
   in1, in2, mask, defined, not_in_image, FindNextAmong, Recurse;
 
   p := PermList(Reversed(DigraphWelshPowellOrder(L1)));
-  L1 := OnDigraphs(L1, p);
+  L1 := OnDigraphs(L1, p ^ -1);
 
   # We compute the join/meet table to avoid having to do this twice if L1 or L2
   # is mutable
@@ -890,7 +890,7 @@ function(L1, L2)
 
   if Recurse(1, 1, false) then
     Append(map, [N1 + 1 .. N2]);
-    return Transformation(map) ^ p;
+    return p ^-1  * Transformation(map);
   fi;
   return fail;
 end);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -925,3 +925,23 @@ function(L1, L2, map)
   od;
   return true;
 end);
+
+InstallMethod(IsLatticeEndomorphism, "for a digraph and a transformation",
+[IsDigraph, IsTransformation],
+{L, map} -> IsLatticeHomomorphism(L, L, map));
+
+InstallMethod(IsLatticeEpimorphism,
+"for a digraph, a digraph, and a transformation",
+[IsDigraph, IsDigraph, IsTransformation],
+function(L1, L2, map)
+  return IsLatticeHomomorphism(L1, L2, map)
+    and OnSets(DigraphVertices(L1), map) = DigraphVertices(L2);
+end);
+
+InstallMethod(IsLatticeEmbedding,
+"for a digraph, a digraph, and a transformation",
+[IsDigraph, IsDigraph, IsTransformation],
+function(L1, L2, map)
+  return IsLatticeHomomorphism(L1, L2, map)
+    and IsInjectiveListTrans(DigraphVertices(L1), map);
+end);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -844,8 +844,10 @@ function(L1, L2)
       # meets and joins map to meets and joins, respectively
       for prev in [1 .. N1] do
         if defined[prev] then
-          IntersectBlist(conditions[depth + 1][join1[prev][next]], mask[join2[map[prev]][map[next]]]);
-          IntersectBlist(conditions[depth + 1][meet1[prev][next]], mask[meet2[map[prev]][map[next]]]);
+          IntersectBlist(conditions[depth + 1][join1[prev][next]],
+                         mask[join2[map[prev]][map[next]]]);
+          IntersectBlist(conditions[depth + 1][meet1[prev][next]],
+                         mask[meet2[map[prev]][map[next]]]);
         fi;
       od;
 
@@ -890,7 +892,7 @@ function(L1, L2)
 
   if Recurse(1, 1, false) then
     Append(map, [N1 + 1 .. N2]);
-    return p ^-1  * Transformation(map);
+    return p ^ -1 * Transformation(map);
   fi;
   return fail;
 end);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -912,7 +912,8 @@ function(L1, L2, map)
   if Maximum(ImageSetOfTransformation(map, N1)) > N2 then
     return false;
   fi;
-  # The above checks if the <x ^ map> and <y ^ map> entries of meet2 and join2 exist
+  # The above checks if the <x ^ map> and <y ^ map> entries of
+  # meet2 and join2 exist
 
   for x in [1 .. N1] do
     for y in [1 .. N1] do

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -940,9 +940,18 @@ function(L1, L2, map)
   return true;
 end);
 
+InstallMethod(IsLatticeHomomorphism,
+"for a digraph, a digraph, and a permutation",
+[IsDigraph, IsDigraph, IsPerm],
+{L1, L2, perm} -> IsLatticeHomomorphism(L1, L2, AsTransformation(perm)));
+
 InstallMethod(IsLatticeEndomorphism, "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
 {L, map} -> IsLatticeHomomorphism(L, L, map));
+
+InstallMethod(IsLatticeEndomorphism, "for a digraph and a permutation",
+[IsDigraph, IsPerm],
+{L, perm} -> IsLatticeHomomorphism(L, L, AsTransformation(perm)));
 
 InstallMethod(IsLatticeEpimorphism,
 "for a digraph, a digraph, and a transformation",
@@ -952,6 +961,14 @@ function(L1, L2, map)
     and OnSets(DigraphVertices(L1), map) = DigraphVertices(L2);
 end);
 
+InstallMethod(IsLatticeEpimorphism,
+"for a digraph, a digraph, and a permutation",
+[IsDigraph, IsDigraph, IsPerm],
+function(L1, L2, perm)
+  return IsLatticeHomomorphism(L1, L2, AsTransformation(perm))
+    and OnSets(DigraphVertices(L1), perm) = DigraphVertices(L2);
+end);
+
 InstallMethod(IsLatticeEmbedding,
 "for a digraph, a digraph, and a transformation",
 [IsDigraph, IsDigraph, IsTransformation],
@@ -959,3 +976,8 @@ function(L1, L2, map)
   return IsLatticeHomomorphism(L1, L2, map)
     and IsInjectiveListTrans(DigraphVertices(L1), map);
 end);
+
+InstallMethod(IsLatticeEmbedding,
+"for a digraph, a digraph, and a permutation",
+[IsDigraph, IsDigraph, IsPerm],
+{L1, L2, perm} -> IsLatticeHomomorphism(L1, L2, AsTransformation(perm)));

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -767,9 +767,9 @@ function(L1, L2)
   meet2 := DigraphMeetTable(L2);
 
   if join1 = fail or meet1 = fail then
-    Error("the first argument must be a lattice digraph");
+    ErrorNoReturn("the first argument must be a lattice digraph,");
   elif join2 = fail or meet2 = fail then
-    Error("the second argument must be a lattice digraph");
+    ErrorNoReturn("the second argument must be a lattice digraph,");
   fi;
 
   N1         := DigraphNrVertices(L1);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -896,3 +896,31 @@ function(L1, L2)
   fi;
   return fail;
 end);
+
+InstallMethod(IsLatticeHomomorphism,
+"for a transformation and a pair of digraphs",
+[IsDigraph, IsDigraph, IsTransformation],
+function(L1, L2, map)
+  local N1, N2, x, y, meet1, meet2, join1, join2;
+  N1 := DigraphNrVertices(L1);
+  N2 := DigraphNrVertices(L2);
+  join1 := DigraphJoinTable(L1);
+  meet1 := DigraphMeetTable(L1);
+  join2 := DigraphJoinTable(L2);
+  meet2 := DigraphMeetTable(L2);
+
+  if Maximum(ImageSetOfTransformation(map, N1)) > N2 then
+    return false;
+  fi;
+  # The above checks if the <x ^ map> and <y ^ map> entries of meet2 and join2 exist
+
+  for x in [1 .. N1] do
+    for y in [1 .. N1] do
+      if meet2[x ^ map, y ^ map] <> meet1[x, y] ^ map
+          or join2[x ^ map, y ^ map] <> join1[x, y] ^ map then
+        return false;
+      fi;
+    od;
+  od;
+  return true;
+end);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -902,12 +902,26 @@ InstallMethod(IsLatticeHomomorphism,
 [IsDigraph, IsDigraph, IsTransformation],
 function(L1, L2, map)
   local N1, N2, x, y, meet1, meet2, join1, join2;
-  N1 := DigraphNrVertices(L1);
-  N2 := DigraphNrVertices(L2);
+
+  # We compute the join/meet table to avoid having to do this twice if L1 or L2
+  # is mutable
+
   join1 := DigraphJoinTable(L1);
   meet1 := DigraphMeetTable(L1);
+
+  if join1 = fail or meet1 = fail then
+    ErrorNoReturn("the 1st argument (a digraph) must be a lattice digraph");
+  fi;
+
   join2 := DigraphJoinTable(L2);
   meet2 := DigraphMeetTable(L2);
+
+  if join2 = fail or meet2 = fail then
+    ErrorNoReturn("the 2nd argument (a digraph) must be a lattice digraph");
+  fi;
+
+  N1 := DigraphNrVertices(L1);
+  N2 := DigraphNrVertices(L2);
 
   if Maximum(ImageSetOfTransformation(map, N1)) > N2 then
     return false;

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -839,6 +839,8 @@ function(L1, L2)
       map[next]             := value;
       defined[next]         := true;
       not_in_image[value]   := false;
+      # TODO(later): can we avoid copying the entire "conditions" here, like in
+      # the C-code?
       conditions[depth + 1] := StructuralCopy(conditions[depth]);
 
       # meets and joins map to meets and joins, respectively
@@ -932,6 +934,8 @@ function(L1, L2, map)
   # The above checks if the <x ^ map> and <y ^ map> entries of
   # meet2 and join2 exist
 
+  # TODO(later): can we avoid checking all joins and meets, i.e. by only
+  # checking the join-irreducible nodes or something?
   for x in [1 .. N1] do
     for y in [1 .. N1] do
       if meet2[x ^ map, y ^ map] <> meet1[x, y] ^ map

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -2194,7 +2194,12 @@ InstallMethod(PartialOrderDigraphJoinOfVertices,
 "for a digraph by out-neighbours and two positive integers",
 [IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, i, j)
-  local x, nbs, intr;
+  local x, nbs, intr, tab;
+
+  if HasJoinSemilatticeDigraphJoinTable(D) then
+    tab := JoinSemilatticeDigraphJoinTable(D);
+    return tab[i, j];
+  fi;
 
   if not IsPartialOrderDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must satisfy ",
@@ -2222,7 +2227,12 @@ InstallMethod(PartialOrderDigraphMeetOfVertices,
 "for a digraph and two positive integers",
 [IsDigraph, IsPosInt, IsPosInt],
 function(D, i, j)
-  local x, nbs, intr;
+  local x, nbs, intr, tab;
+
+  if HasMeetSemilatticeDigraphMeetTable(D) then
+    tab := MeetSemilatticeDigraphMeetTable(D);
+    return tab[i, j];
+  fi;
 
   if not IsPartialOrderDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must satisfy ",

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -2196,8 +2196,8 @@ InstallMethod(PartialOrderDigraphJoinOfVertices,
 function(D, i, j)
   local x, nbs, intr, tab;
 
-  if HasJoinSemilatticeDigraphJoinTable(D) then
-    tab := JoinSemilatticeDigraphJoinTable(D);
+  if HasDigraphJoinTable(D) then
+    tab := DigraphJoinTable(D);
     return tab[i, j];
   fi;
 
@@ -2229,8 +2229,8 @@ InstallMethod(PartialOrderDigraphMeetOfVertices,
 function(D, i, j)
   local x, nbs, intr, tab;
 
-  if HasMeetSemilatticeDigraphMeetTable(D) then
-    tab := MeetSemilatticeDigraphMeetTable(D);
+  if HasDigraphMeetTable(D) then
+    tab := DigraphMeetTable(D);
     return tab[i, j];
   fi;
 

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -2194,11 +2194,10 @@ InstallMethod(PartialOrderDigraphJoinOfVertices,
 "for a digraph by out-neighbours and two positive integers",
 [IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, i, j)
-  local x, nbs, intr, tab;
+  local x, nbs, intr;
 
   if HasDigraphJoinTable(D) then
-    tab := DigraphJoinTable(D);
-    return tab[i, j];
+    return DigraphJoinTable(D)[i, j];
   fi;
 
   if not IsPartialOrderDigraph(D) then
@@ -2227,11 +2226,10 @@ InstallMethod(PartialOrderDigraphMeetOfVertices,
 "for a digraph and two positive integers",
 [IsDigraph, IsPosInt, IsPosInt],
 function(D, i, j)
-  local x, nbs, intr, tab;
+  local x, nbs, intr;
 
   if HasDigraphMeetTable(D) then
-    tab := DigraphMeetTable(D);
-    return tab[i, j];
+    return DigraphMeetTable(D)[i, j];
   fi;
 
   if not IsPartialOrderDigraph(D) then

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -67,8 +67,9 @@ DeclareSynonymAttr("IsAntiSymmetricDigraph", IsAntisymmetricDigraph);
 DeclareSynonymAttr("IsNullDigraph", IsEmptyDigraph);
 DeclareSynonymAttr("IsQuasiorderDigraph", IsPreorderDigraph);
 
-DeclareOperation("DIGRAPHS_IsMeetJoinSemilatticeDigraph",
-                 [IsDigraph, IsBool]);
+DeclareOperation("DIGRAPHS_MeetJoinTable", [IsDigraph, IsList, IsList]);
+DeclareOperation("DIGRAPHS_IsJoinSemilatticeAndJoinTable", [IsDigraph]);
+DeclareOperation("DIGRAPHS_IsMeetSemilatticeAndMeetTable", [IsDigraph]);
 
 InstallTrueMethod(IsAcyclicDigraph, IsChainDigraph);
 InstallTrueMethod(IsAcyclicDigraph, IsDigraph and IsDirectedTree);

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -68,7 +68,7 @@ DeclareSynonymAttr("IsNullDigraph", IsEmptyDigraph);
 DeclareSynonymAttr("IsQuasiorderDigraph", IsPreorderDigraph);
 
 DeclareOperation("DIGRAPHS_IsMeetJoinSemilatticeDigraph",
-                 [IsHomogeneousList]);
+                 [IsDigraph, IsBool]);
 
 InstallTrueMethod(IsAcyclicDigraph, IsChainDigraph);
 InstallTrueMethod(IsAcyclicDigraph, IsDigraph and IsDirectedTree);

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -67,7 +67,7 @@ DeclareSynonymAttr("IsAntiSymmetricDigraph", IsAntisymmetricDigraph);
 DeclareSynonymAttr("IsNullDigraph", IsEmptyDigraph);
 DeclareSynonymAttr("IsQuasiorderDigraph", IsPreorderDigraph);
 
-DeclareOperation("DIGRAPHS_MeetJoinTable", [IsDigraph, IsList, IsList]);
+DeclareOperation("DIGRAPHS_MeetJoinTable", [IsDigraph, IsList, IsList, IsBool]);
 DeclareOperation("DIGRAPHS_IsJoinSemilatticeAndJoinTable", [IsDigraph]);
 DeclareOperation("DIGRAPHS_IsMeetSemilatticeAndMeetTable", [IsDigraph]);
 

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -43,7 +43,7 @@ D -> IsConnectedDigraph(D) and IsEmpty(Bridges(D)));
 InstallMethod(DIGRAPHS_IsMeetJoinSemilatticeDigraph, "for a digraph and a bool",
 [IsDigraph, IsBool],
 function(D, join)
-  local P, U, ord, tab, S, N, i, x, T, l, q, z, y, nbs;
+  local P, U, ord, tab, S, N, i, x, T, l, q, z, y;
 
   if not IsPartialOrderDigraph(D) then
     return false;
@@ -59,11 +59,9 @@ function(D, join)
   tab := List([1 .. N], x -> []);  # table of meets/joins
 
   if join then
-    nbs := OutNeighbours(D);
     P   := DigraphTopologicalSort(D);
     U   := OutNeighbours(DigraphReflexiveTransitiveReduction(D));
   else
-    nbs := InNeighbours(D);
     P   := Reversed(DigraphTopologicalSort(D));
     U   := InNeighbours(DigraphReflexiveTransitiveReduction(D));
   fi;
@@ -95,7 +93,9 @@ function(D, join)
         fi;
       od;
       for z in T do
-        if not z in nbs[q] then
+        if join and not IsDigraphEdge(D, q, z) then
+          return false;
+        elif not join and not IsDigraphEdge(D, z, q) then
           return false;
         fi;
       od;

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -97,19 +97,33 @@ function(D, join)
     od;
     Add(S, x);
   od;
-  return true;
+  return tab;
 end);
 
 InstallMethod(IsJoinSemilatticeDigraph, "for a digraph by out-neighbours",
 [IsDigraph],
 function(D)
-  return DIGRAPHS_IsMeetJoinSemilatticeDigraph(D, true);
+  local out;
+  out := DIGRAPHS_IsMeetJoinSemilatticeDigraph(D, true);
+  if out = false then
+    SetJoinSemilatticeDigraphJoinTable(D, fail);
+    return false;
+  fi;
+  SetJoinSemilatticeDigraphJoinTable(D, out);
+  return true;
 end);
 
 InstallMethod(IsMeetSemilatticeDigraph, "for a digraph",
 [IsDigraph],
 function(D)
-  return DIGRAPHS_IsMeetJoinSemilatticeDigraph(D, false);
+  local out;
+  out := DIGRAPHS_IsMeetJoinSemilatticeDigraph(D, false);
+  if out = false then
+    SetMeetSemilatticeDigraphMeetTable(D, fail);
+    return false;
+  fi;
+  SetMeetSemilatticeDigraphMeetTable(D, out);
+  return true;
 end);
 
 InstallMethod(IsStronglyConnectedDigraph, "for a digraph by out-neighbours",

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -40,8 +40,8 @@ D -> IsConnectedDigraph(D) and IsEmpty(Bridges(D)));
 
 # The method below is based on Listing 11.9 of 'Free Lattices'
 # by Ralph Freese et. al.
-InstallMethod(DIGRAPHS_MeetJoinTable, "for a digraph, a list, a list,
-                                         and a bool",
+InstallMethod(DIGRAPHS_MeetJoinTable,
+"for a digraph, a list, a list, and a bool",
 [IsDigraph, IsList, IsList, IsBool],
 function(D, P, U, join)
   local ord, tab, S, N, i, x, T, l, q, z, y;

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -50,6 +50,11 @@ function(D, join)
   fi;
 
   D   := DigraphImmutableCopyIfMutable(D);
+
+  if IsMultiDigraph(D) then
+    D := DigraphRemoveAllMultipleEdges(D);
+  fi;
+
   N   := DigraphNrVertices(D);
   tab := List([1 .. N], x -> []);  # table of meets/joins
 

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -40,9 +40,9 @@ D -> IsConnectedDigraph(D) and IsEmpty(Bridges(D)));
 
 # The method below is based on Listing 11.9 of 'Free Lattices'
 # by Ralph Freese et. al.
-InstallMethod(DIGRAPHS_MeetJoinTable, "for a digraph, a list, and a list of lists",
-[IsDigraph, IsList, IsList],
-function(D, P, U)
+InstallMethod(DIGRAPHS_MeetJoinTable, "for a digraph, a list, a list, and a bool",
+[IsDigraph, IsList, IsList, IsBool],
+function(D, P, U, join)
   local ord, tab, S, N, i, x, T, l, q, z, y;
 
   N   := DigraphNrVertices(D);
@@ -75,7 +75,9 @@ function(D, P, U)
         fi;
       od;
       for z in T do
-        if not IsDigraphEdge(D, q, z) then
+        if join and not IsDigraphEdge(D, q, z) then
+          return false;
+        elif not join and not IsDigraphEdge(D, z, q) then
           return false;
         fi;
       od;
@@ -99,7 +101,7 @@ function(D)
   copy   := DigraphMutableCopyIfMutable(D); # copy iff D is mutable
   P      := DigraphTopologicalSort(D);
   U      := OutNeighbours(DigraphReflexiveTransitiveReduction(copy)); # copy iff D is immutable
-  tab    := DIGRAPHS_MeetJoinTable(D, P, U);
+  tab    := DIGRAPHS_MeetJoinTable(D, P, U, true);
   if tab = fail then
     SetJoinSemilatticeDigraphJoinTable(D, fail);
     return [false, fail];
@@ -120,7 +122,7 @@ function(D)
   copy   := DigraphMutableCopyIfMutable(D); # copy iff D is mutable
   P      := Reversed(DigraphTopologicalSort(D));
   U      := InNeighbours(DigraphReflexiveTransitiveReduction(copy)); # copy iff D is immutable
-  tab    := DIGRAPHS_MeetJoinTable(D, P, U);
+  tab    := DIGRAPHS_MeetJoinTable(D, P, U, false);
   if tab = fail then
     SetJoinSemilatticeDigraphJoinTable(D, fail);
     return [false, fail];

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -38,6 +38,8 @@ D -> IsConnectedDigraph(D) and IsEmpty(ArticulationPoints(D)));
 InstallMethod(IsBridgelessDigraph, "for a digraph", [IsDigraph],
 D -> IsConnectedDigraph(D) and IsEmpty(Bridges(D)));
 
+# The method below is based on Listing 11.9 of 'Free Lattices'
+# by Ralph Freese et. al.
 InstallMethod(DIGRAPHS_IsMeetJoinSemilatticeDigraph, "for a digraph and a bool",
 [IsDigraph, IsBool],
 function(D, join)

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -105,7 +105,7 @@ function(D)
   P      := DigraphTopologicalSort(D);
   U      := OutNeighbours(DigraphReflexiveTransitiveReduction(copy)); # copy iff D is immutable
   tab    := DIGRAPHS_MeetJoinTable(D, P, U, true);
-  SetJoinSemilatticeDigraphJoinTable(D, tab);
+  SetDigraphJoinTable(D, tab);
   return [tab <> fail, tab];
 end);
 
@@ -122,7 +122,7 @@ function(D)
   P      := Reversed(DigraphTopologicalSort(D));
   U      := InNeighbours(DigraphReflexiveTransitiveReduction(copy)); # copy iff D is immutable
   tab    := DIGRAPHS_MeetJoinTable(D, P, U, false);
-  SetMeetSemilatticeDigraphMeetTable(D, tab);
+  SetDigraphMeetTable(D, tab);
   return [tab <> fail, tab];
 end);
 

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -40,7 +40,8 @@ D -> IsConnectedDigraph(D) and IsEmpty(Bridges(D)));
 
 # The method below is based on Listing 11.9 of 'Free Lattices'
 # by Ralph Freese et. al.
-InstallMethod(DIGRAPHS_MeetJoinTable, "for a digraph, a list, a list, and a bool",
+InstallMethod(DIGRAPHS_MeetJoinTable, "for a digraph, a list, a list,
+                                         and a bool",
 [IsDigraph, IsList, IsList, IsBool],
 function(D, P, U, join)
   local ord, tab, S, N, i, x, T, l, q, z, y;
@@ -101,9 +102,9 @@ function(D)
   elif IsMultiDigraph(D) then
     ErrorNoReturn("the argument must not be a multidigraph,");
   fi;
-  copy   := DigraphMutableCopyIfMutable(D); # copy iff D is mutable
+  copy   := DigraphMutableCopyIfMutable(D);
   P      := DigraphTopologicalSort(D);
-  U      := OutNeighbours(DigraphReflexiveTransitiveReduction(copy)); # copy iff D is immutable
+  U      := OutNeighbours(DigraphReflexiveTransitiveReduction(copy));
   tab    := DIGRAPHS_MeetJoinTable(D, P, U, true);
   SetDigraphJoinTable(D, tab);
   return [tab <> fail, tab];
@@ -118,9 +119,9 @@ function(D)
   elif IsMultiDigraph(D) then
     ErrorNoReturn("the argument must not be a multidigraph,");
   fi;
-  copy   := DigraphMutableCopyIfMutable(D); # copy iff D is mutable
+  copy   := DigraphMutableCopyIfMutable(D);
   P      := Reversed(DigraphTopologicalSort(D));
-  U      := InNeighbours(DigraphReflexiveTransitiveReduction(copy)); # copy iff D is immutable
+  U      := InNeighbours(DigraphReflexiveTransitiveReduction(copy));
   tab    := DIGRAPHS_MeetJoinTable(D, P, U, false);
   SetDigraphMeetTable(D, tab);
   return [tab <> fail, tab];

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -99,7 +99,7 @@ function(D)
   if not IsPartialOrderDigraph(D) then
     return [false, fail];
   elif IsMultiDigraph(D) then
-    Error();
+    ErrorNoReturn("the argument must not be a multidigraph,");
   fi;
   copy   := DigraphMutableCopyIfMutable(D); # copy iff D is mutable
   P      := DigraphTopologicalSort(D);
@@ -116,7 +116,7 @@ function(D)
   if not IsPartialOrderDigraph(D) then
     return [false, fail];
   elif IsMultiDigraph(D) then
-    Error();
+    ErrorNoReturn("the argument must not be a multidigraph,");
   fi;
   copy   := DigraphMutableCopyIfMutable(D); # copy iff D is mutable
   P      := Reversed(DigraphTopologicalSort(D));

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -65,7 +65,7 @@ function(D, P, U, join)
       T := Set(T);
       l := Length(T);
       if l = 0 then
-        return false;
+        return fail;
       fi;
       q := T[l];
       for i in [1 .. l - 1] do
@@ -76,9 +76,9 @@ function(D, P, U, join)
       od;
       for z in T do
         if join and not IsDigraphEdge(D, q, z) then
-          return false;
+          return fail;
         elif not join and not IsDigraphEdge(D, z, q) then
-          return false;
+          return fail;
         fi;
       od;
       tab[x, y] := q;
@@ -94,7 +94,7 @@ InstallMethod(DIGRAPHS_IsJoinSemilatticeAndJoinTable, "for a digraph",
 function(D)
   local tab, copy, P, U;
   if not IsPartialOrderDigraph(D) then
-    return false;
+    return [false, fail];
   elif IsMultiDigraph(D) then
     Error();
   fi;
@@ -102,12 +102,8 @@ function(D)
   P      := DigraphTopologicalSort(D);
   U      := OutNeighbours(DigraphReflexiveTransitiveReduction(copy)); # copy iff D is immutable
   tab    := DIGRAPHS_MeetJoinTable(D, P, U, true);
-  if tab = fail then
-    SetJoinSemilatticeDigraphJoinTable(D, fail);
-    return [false, fail];
-  fi;
   SetJoinSemilatticeDigraphJoinTable(D, tab);
-  return [true, tab];
+  return [tab <> fail, tab];
 end);
 
 InstallMethod(DIGRAPHS_IsMeetSemilatticeAndMeetTable, "for a digraph",
@@ -115,7 +111,7 @@ InstallMethod(DIGRAPHS_IsMeetSemilatticeAndMeetTable, "for a digraph",
 function(D)
   local tab, copy, P, U;
   if not IsPartialOrderDigraph(D) then
-    return false;
+    return [false, fail];
   elif IsMultiDigraph(D) then
     Error();
   fi;
@@ -123,12 +119,8 @@ function(D)
   P      := Reversed(DigraphTopologicalSort(D));
   U      := InNeighbours(DigraphReflexiveTransitiveReduction(copy)); # copy iff D is immutable
   tab    := DIGRAPHS_MeetJoinTable(D, P, U, false);
-  if tab = fail then
-    SetJoinSemilatticeDigraphJoinTable(D, fail);
-    return [false, fail];
-  fi;
-  SetJoinSemilatticeDigraphJoinTable(D, tab);
-  return [true, tab];
+  SetMeetSemilatticeDigraphMeetTable(D, tab);
+  return [tab <> fail, tab];
 end);
 
 InstallMethod(IsJoinSemilatticeDigraph, "for a digraph",

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -78,9 +78,9 @@ function(D, join)
   for x in P do
     tab[x, x] := x;
     for y in S do
-      T := [];  # EmptyPlist didn't improve speed
+      T := [];
       for z in U[x] do
-        Add(T, tab[y, z]);  # SetAdd didn't improve speed
+        Add(T, tab[y, z]);
       od;
       T := Set(T);
       l := Length(T);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -45,6 +45,9 @@ InstallMethod(DIGRAPHS_MeetJoinTable, "for a digraph, a list, a list, and a bool
 function(D, P, U, join)
   local ord, tab, S, N, i, x, T, l, q, z, y;
 
+  # The algorithm runs for joins where the argument <join> is true. Otherwise
+  # it is run for meets.
+
   N   := DigraphNrVertices(D);
   tab := List([1 .. N], x -> []);  # table of meets/joins
 

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -49,7 +49,7 @@ function(D, join)
     return false;
   fi;
 
-  D   := DigraphMutableCopyIfMutable(D);
+  D   := DigraphImmutableCopyIfMutable(D);
   N   := DigraphNrVertices(D);
   tab := List([1 .. N], x -> []);  # table of meets/joins
 

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2804,6 +2804,36 @@ false
 gap> NonLowerSemimodularPair(D);
 [ 10, 9 ]
 
+# JoinSemilatticeDigraphJoinTable and MeetSemilatticeDigraphMeetTable
+gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(4));
+<immutable preorder digraph with 4 vertices, 10 edges>
+gap> JoinSemilatticeDigraphJoinTable(D);
+[ [ 1, 2, 3, 4 ], [ 2, 2, 3, 4 ], [ 3, 3, 3, 4 ], [ 4, 4, 4, 4 ] ]
+gap> D := Digraph(IsMutable, [[2, 3], [4], [4], []]);
+<mutable digraph with 4 vertices, 4 edges>
+gap> DigraphReflexiveTransitiveClosure(D);
+<mutable digraph with 4 vertices, 9 edges>
+gap> MeetSemilatticeDigraphMeetTable(D);
+[ [ 1, 1, 1, 1 ], [ 1, 2, 1, 2 ], [ 1, 1, 3, 3 ], [ 1, 2, 3, 4 ] ]
+gap> D;
+<mutable digraph with 4 vertices, 9 edges>
+gap> JoinSemilatticeDigraphJoinTable(D);
+[ [ 1, 2, 3, 4 ], [ 2, 2, 4, 4 ], [ 3, 4, 3, 4 ], [ 4, 4, 4, 4 ] ]
+gap> D := ChainDigraph(3);
+<immutable chain digraph with 3 vertices>
+gap> JoinSemilatticeDigraphJoinTable(D);
+fail
+gap> D := DigraphAddVertex(D, 4);
+<immutable digraph with 4 vertices, 2 edges>
+gap> D := DigraphAddEdge(D, [4, 3]);
+<immutable digraph with 4 vertices, 3 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 8 edges>
+gap> JoinSemilatticeDigraphJoinTable(D);
+[ [ 1, 2, 3, 3 ], [ 2, 2, 3, 3 ], [ 3, 3, 3, 3 ], [ 3, 3, 3, 4 ] ]
+gap> MeetSemilatticeDigraphMeetTable(D);
+fail
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(adj1);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2804,24 +2804,24 @@ false
 gap> NonLowerSemimodularPair(D);
 [ 10, 9 ]
 
-# JoinSemilatticeDigraphJoinTable and MeetSemilatticeDigraphMeetTable
+# DigraphJoinTable and DigraphMeetTable
 gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(4));
 <immutable preorder digraph with 4 vertices, 10 edges>
-gap> JoinSemilatticeDigraphJoinTable(D);
+gap> DigraphJoinTable(D);
 [ [ 1, 2, 3, 4 ], [ 2, 2, 3, 4 ], [ 3, 3, 3, 4 ], [ 4, 4, 4, 4 ] ]
 gap> D := Digraph(IsMutable, [[2, 3], [4], [4], []]);
 <mutable digraph with 4 vertices, 4 edges>
 gap> DigraphReflexiveTransitiveClosure(D);
 <mutable digraph with 4 vertices, 9 edges>
-gap> MeetSemilatticeDigraphMeetTable(D);
+gap> DigraphMeetTable(D);
 [ [ 1, 1, 1, 1 ], [ 1, 2, 1, 2 ], [ 1, 1, 3, 3 ], [ 1, 2, 3, 4 ] ]
 gap> D;
 <mutable digraph with 4 vertices, 9 edges>
-gap> JoinSemilatticeDigraphJoinTable(D);
+gap> DigraphJoinTable(D);
 [ [ 1, 2, 3, 4 ], [ 2, 2, 4, 4 ], [ 3, 4, 3, 4 ], [ 4, 4, 4, 4 ] ]
 gap> D := ChainDigraph(3);
 <immutable chain digraph with 3 vertices>
-gap> JoinSemilatticeDigraphJoinTable(D);
+gap> DigraphJoinTable(D);
 fail
 gap> D := DigraphAddVertex(D, 4);
 <immutable digraph with 4 vertices, 2 edges>
@@ -2829,9 +2829,9 @@ gap> D := DigraphAddEdge(D, [4, 3]);
 <immutable digraph with 4 vertices, 3 edges>
 gap> D := DigraphReflexiveTransitiveClosure(D);
 <immutable preorder digraph with 4 vertices, 8 edges>
-gap> JoinSemilatticeDigraphJoinTable(D);
+gap> DigraphJoinTable(D);
 [ [ 1, 2, 3, 3 ], [ 2, 2, 3, 3 ], [ 3, 3, 3, 3 ], [ 3, 3, 3, 4 ] ]
-gap> MeetSemilatticeDigraphMeetTable(D);
+gap> DigraphMeetTable(D);
 fail
 
 #  DIGRAPHS_UnbindVariables

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2575,6 +2575,30 @@ Error, the 1st argument (a digraph) must be a lattice digraph
 gap> LatticeDigraphEmbedding(G, D);
 Error, the 2nd argument (a digraph) must be a lattice digraph
 
+# IsLatticeHomomorphism
+gap> D := DigraphFromDigraph6String("&G~tSrCO{D?oC");
+<immutable digraph with 8 vertices, 27 edges>
+gap> G := DigraphFromDigraph6String("&J~}|SggsO__r?a?{?g?o?_");
+<immutable digraph with 11 vertices, 43 edges>
+gap> f := LatticeDigraphEmbedding(D, G);
+Transformation( [ 1, 8, 6, 10, 2, 9, 7, 11, 9, 10, 11 ] )
+gap> IsLatticeHomomorphism(f, D, G);
+true
+gap> IsLatticeHomomorphism(f, G, D);
+false
+gap> G := Digraph([[2, 4], [3, 7], [6], [5, 7], [6], [], [6]]);
+<immutable digraph with 7 vertices, 9 edges>
+gap> D := DigraphRemoveVertex(G, 7);
+<immutable digraph with 6 vertices, 6 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 7 vertices, 22 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 6 vertices, 17 edges>
+gap> IsDigraphEmbedding(D, G, IdentityTransformation);
+true
+gap> IsLatticeHomomorphism(D, G, IdentityTransformation);
+false
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);
 gap> Unbind(epis);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2574,6 +2574,46 @@ gap> LatticeDigraphEmbedding(D, G);
 Error, the 1st argument (a digraph) must be a lattice digraph
 gap> LatticeDigraphEmbedding(G, D);
 Error, the 2nd argument (a digraph) must be a lattice digraph
+gap> s := ".|}oGCAAB`?w[OL@@P?ga@@DO`SKTDEBW_kZGDbHGw]OdQqSodEEcgw{eTcSAXOnDBRa`SrFCdrLC\
+> kWLEwCGz\\nFwHuO]Oqbko{bdgS\\@CcQsbyMg_QHzyEedRiYy@ChkHdAhVBMpRquK^UrSYu[cVKIi\
+> \\]oaGTkdCmXrsj@fPRKUbUq_VJzQ`aqZptI|fUTKejeujYLvLpWu[Mf^";
+".|}oGCAAB`?w[OL@@P?ga@@DO`SKTDEBW_kZGDbHGw]OdQqSodEEcgw{eTcSAXOnDBRa`SrFCdrLC\
+kWLEwCGz\\nFwHuO]Oqbko{bdgS\\@CcQsbyMg_QHzyEedRiYy@ChkHdAhVBMpRquK^UrSYu[cVKIi\
+\\]oaGTkdCmXrsj@fPRKUbUq_VJzQ`aqZptI|fUTKejeujYLvLpWu[Mf^"
+gap> G := DigraphFromDiSparse6String(s);
+<immutable digraph with 61 vertices, 176 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 61 vertices, 660 edges>
+gap> D := DigraphFromDiSparse6String(".DsGEA_QM@Gs");
+<immutable digraph with 5 vertices, 14 edges>
+gap> f := LatticeDigraphEmbedding(D, G);
+Transformation( [ 1, 3, 2, 9, 10, 6, 7, 8, 9, 10 ] )
+gap> f := IsLatticeEmbedding(D, G, f);
+true
+gap> D := DigraphFromDiSparse6String(".F{GE@I@M@HGCbU@GsTn");
+<immutable digraph with 7 vertices, 25 edges>
+gap> G := DigraphFromDiSparse6String(".|}oGCI@@AO_cKLD__gWeIECpp?gV?_bWOuGLcb`{AAQ`Cg`I\
+> IRIpa`UQRIRQSweXgDRLIESMTRc[\m\\NSrc_k]OQb@t@NIEYH_sbbBqCu[egHgW|LXMHjXxOilGCyiybSigyTO\
+> hddaxaW^Ogd{S[OjEbZEUPQkXA\\OpoitbHhIGhtMHGkUlhaxesZTrYLJ^TjTrfGnXKvN@iv[Mf^");
+<immutable digraph with 61 vertices, 176 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 61 vertices, 660 edges>
+gap> f := LatticeDigraphEmbedding(D, G);
+Transformation( [ 1, 3, 4, 10, 8, 11, 13, 8, 9, 10, 11, 12, 13 ] )
+gap> IsLatticeEmbedding(D, G, f);
+true
+gap> D := DigraphFromDiSparse6String(".Ww__`aB_`DdeFaFbEcGHIdfKkhLM`obOeKOgLPRcPQiMQRj\
+> NSTU");
+<immutable digraph with 24 vertices, 49 edges>
+gap> G := DigraphFromDiSparse6String(".Yy___bb`BdEaC_`HcDH`aKeKcEfIJNgLMN_dQkQfMRSaHQgJ\
+> RUiLSUoPTVW");
+<immutable digraph with 26 vertices, 57 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 24 vertices, 148 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 26 vertices, 162 edges>
+gap> LatticeDigraphEmbedding(D, G);
+fail
 
 # IsLatticeHomomorphism (for transformations)
 gap> D := DigraphFromDigraph6String("&G~tSrCO{D?oC");

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2598,6 +2598,14 @@ gap> IsDigraphEmbedding(D, G, IdentityTransformation);
 true
 gap> IsLatticeHomomorphism(D, G, IdentityTransformation);
 false
+gap> D := CycleDigraph(3);
+<immutable cycle digraph with 3 vertices>
+gap> G := Digraph([[1]]);
+<immutable digraph with 1 vertex, 1 edge>
+gap> IsLatticeHomomorphism(D, G, IdentityTransformation);
+Error, the 1st argument (a digraph) must be a lattice digraph
+gap> IsLatticeHomomorphism(G, D, IdentityTransformation);
+Error, the 2nd argument (a digraph) must be a lattice digraph
 
 # IsLatticeHomomorphism (for permutations)
 gap> D := Digraph([[2, 3], [4], [4], []]);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2575,16 +2575,16 @@ Error, the 1st argument (a digraph) must be a lattice digraph
 gap> LatticeDigraphEmbedding(G, D);
 Error, the 2nd argument (a digraph) must be a lattice digraph
 
-# IsLatticeHomomorphism
+# IsLatticeHomomorphism (for transformations)
 gap> D := DigraphFromDigraph6String("&G~tSrCO{D?oC");
 <immutable digraph with 8 vertices, 27 edges>
 gap> G := DigraphFromDigraph6String("&J~}|SggsO__r?a?{?g?o?_");
 <immutable digraph with 11 vertices, 43 edges>
 gap> f := LatticeDigraphEmbedding(D, G);
 Transformation( [ 1, 8, 6, 10, 2, 9, 7, 11, 9, 10, 11 ] )
-gap> IsLatticeHomomorphism(f, D, G);
+gap> IsLatticeHomomorphism(D, G, f);
 true
-gap> IsLatticeHomomorphism(f, G, D);
+gap> IsLatticeHomomorphism(G, D, f);
 false
 gap> G := Digraph([[2, 4], [3, 7], [6], [5, 7], [6], [], [6]]);
 <immutable digraph with 7 vertices, 9 edges>
@@ -2597,6 +2597,50 @@ gap> D := DigraphReflexiveTransitiveClosure(D);
 gap> IsDigraphEmbedding(D, G, IdentityTransformation);
 true
 gap> IsLatticeHomomorphism(D, G, IdentityTransformation);
+false
+
+# IsLatticeEndomorphism (for transformations)
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> f := Transformation([1, 3, 2, 4]);
+Transformation( [ 1, 3, 2 ] )
+gap> IsLatticeEndomorphism(D, f);
+true
+
+# IsLatticeEmbedding and IsLatticeMonomorphism (for transformations)
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> G := Digraph([[2, 3], [4], [4], [5], []]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 5 vertices, 14 edges>
+gap> IsLatticeEmbedding(D, G, IdentityTransformation);
+true
+gap> IsLatticeMonomorphism(D, G, IdentityTransformation);
+true
+gap> f := Transformation([1, 1, 1, 1]);
+Transformation( [ 1, 1, 1, 1 ] )
+gap> IsLatticeEmbedding(D, G, f);
+false
+
+# IsLatticeEpimorphism
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> G := Digraph([[2, 3], [4], [4], [5], []]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 5 vertices, 14 edges>
+gap> f := Transformation([1, 2, 3, 4, 4]);
+Transformation( [ 1, 2, 3, 4, 4 ] )
+gap> IsLatticeEpimorphism(G, D, f);
+true
+gap> IsLatticeEpimorphism(D, G, f);
 false
 
 #  DIGRAPHS_UnbindVariables

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2498,6 +2498,75 @@ Error, the 1st argument (a digraph) must not satisfy IsMultiDigraph
 gap> MinimalCommonSuperdigraph(Digraph([[1, 1]]), Digraph([[1]]));
 Error, the 1st argument (a digraph) must not satisfy IsMultiDigraph
 
+# LatticeDigraphEmbedding
+gap> D := Digraph([[2], [3], [4], []]);
+<immutable digraph with 4 vertices, 3 edges>
+gap> G := Digraph([[], [1], [2], [3]]);
+<immutable digraph with 4 vertices, 3 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 10 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 4 vertices, 10 edges>
+gap> LatticeDigraphEmbedding(D, G);
+[ 4, 3, 2, 1 ]
+gap> D := Digraph([[2], [3], [4], []]);
+<immutable digraph with 4 vertices, 3 edges>
+gap> G := Digraph([[2], [3], [4], [5], []]);
+<immutable digraph with 5 vertices, 4 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 10 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 5 vertices, 15 edges>
+gap> LatticeDigraphEmbedding(G, D);
+fail
+gap> LatticeDigraphEmbedding(D, G);
+[ 1, 2, 3, 4 ]
+gap> D := Digraph([[2, 3, 5], [4, 6], [4, 7, 9], [8, 11], [6, 10], [11],
+>   [8, 12], [14], [10, 13], [11, 12], [14], [14], [14], []]);
+<immutable digraph with 14 vertices, 23 edges>
+gap> N5 := Digraph([[2, 4], [3], [5], [5], []]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 14 vertices, 66 edges>
+gap> N5 := DigraphReflexiveTransitiveClosure(N5);
+<immutable preorder digraph with 5 vertices, 13 edges>
+gap> LatticeDigraphEmbedding(N5, D);
+[ 1, 2, 6, 9, 11 ]
+gap> D := Digraph([[2], [3], [4], []]);
+<immutable digraph with 4 vertices, 3 edges>
+gap> G := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 10 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> LatticeDigraphEmbedding(D, G);
+fail
+gap> LatticeDigraphEmbedding(G, D);
+fail
+gap> N5 := Digraph([[2, 4], [3], [5], [5], []]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> H := Digraph([[], [1], [1], [2], [3], [2, 3], [4, 5, 6]]);
+<immutable digraph with 7 vertices, 9 edges>
+gap> N5 := DigraphReflexiveTransitiveClosure(N5);
+<immutable preorder digraph with 5 vertices, 13 edges>
+gap> H := DigraphReflexiveTransitiveClosure(H);
+<immutable preorder digraph with 7 vertices, 22 edges>
+gap> LatticeDigraphEmbedding(N5, H);
+[ 7, 4, 2, 5, 1 ]
+gap> D := Digraph([[2, 6], [3, 7], [4], [], [4], [5, 7], [4]]);
+<immutable digraph with 7 vertices, 9 edges>
+gap> G := DigraphRemoveVertex(D, 7);
+<immutable digraph with 6 vertices, 6 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 6 vertices, 17 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 7 vertices, 22 edges>
+gap> DigraphEmbedding(G, D);
+IdentityTransformation
+gap> LatticeDigraphEmbedding(G, D);
+fail
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);
 gap> Unbind(epis);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2508,7 +2508,7 @@ gap> D := DigraphReflexiveTransitiveClosure(D);
 gap> G := DigraphReflexiveTransitiveClosure(G);
 <immutable preorder digraph with 4 vertices, 10 edges>
 gap> LatticeDigraphEmbedding(D, G);
-[ 4, 3, 2, 1 ]
+Transformation( [ 4, 3, 2, 1 ] )
 gap> D := Digraph([[2], [3], [4], []]);
 <immutable digraph with 4 vertices, 3 edges>
 gap> G := Digraph([[2], [3], [4], [5], []]);
@@ -2520,7 +2520,7 @@ gap> G := DigraphReflexiveTransitiveClosure(G);
 gap> LatticeDigraphEmbedding(G, D);
 fail
 gap> LatticeDigraphEmbedding(D, G);
-[ 1, 2, 3, 4 ]
+IdentityTransformation
 gap> D := Digraph([[2, 3, 5], [4, 6], [4, 7, 9], [8, 11], [6, 10], [11],
 >   [8, 12], [14], [10, 13], [11, 12], [14], [14], [14], []]);
 <immutable digraph with 14 vertices, 23 edges>
@@ -2531,7 +2531,7 @@ gap> D := DigraphReflexiveTransitiveClosure(D);
 gap> N5 := DigraphReflexiveTransitiveClosure(N5);
 <immutable preorder digraph with 5 vertices, 13 edges>
 gap> LatticeDigraphEmbedding(N5, D);
-[ 1, 2, 6, 9, 11 ]
+Transformation( [ 1, 9, 10, 2, 11, 6, 7, 8, 9, 10, 11 ] )
 gap> D := Digraph([[2], [3], [4], []]);
 <immutable digraph with 4 vertices, 3 edges>
 gap> G := Digraph([[2, 3], [4], [4], []]);
@@ -2553,7 +2553,7 @@ gap> N5 := DigraphReflexiveTransitiveClosure(N5);
 gap> H := DigraphReflexiveTransitiveClosure(H);
 <immutable preorder digraph with 7 vertices, 22 edges>
 gap> LatticeDigraphEmbedding(N5, H);
-[ 7, 4, 2, 5, 1 ]
+Transformation( [ 7, 5, 3, 4, 1, 6, 7 ] )
 gap> D := Digraph([[2, 6], [3, 7], [4], [], [4], [5, 7], [4]]);
 <immutable digraph with 7 vertices, 9 edges>
 gap> G := DigraphRemoveVertex(D, 7);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2571,9 +2571,9 @@ gap> D := CycleDigraph(5);
 gap> G := Digraph([[1]]);
 <immutable digraph with 1 vertex, 1 edge>
 gap> LatticeDigraphEmbedding(D, G);
-Error, the first argument must be a lattice digraph,
+Error, the 1st argument (a digraph) must be a lattice digraph
 gap> LatticeDigraphEmbedding(G, D);
-Error, the second argument must be a lattice digraph,
+Error, the 2nd argument (a digraph) must be a lattice digraph
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2566,6 +2566,14 @@ gap> DigraphEmbedding(G, D);
 IdentityTransformation
 gap> LatticeDigraphEmbedding(G, D);
 fail
+gap> D := CycleDigraph(5);
+<immutable cycle digraph with 5 vertices>
+gap> G := Digraph([[1]]);
+<immutable digraph with 1 vertex, 1 edge>
+gap> LatticeDigraphEmbedding(D, G);
+Error, the first argument must be a lattice digraph,
+gap> LatticeDigraphEmbedding(G, D);
+Error, the second argument must be a lattice digraph,
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2599,6 +2599,18 @@ true
 gap> IsLatticeHomomorphism(D, G, IdentityTransformation);
 false
 
+# IsLatticeHomomorphism (for permutations)
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> IsLatticeHomomorphism(D, D, (2, 3));
+true
+gap> IsLatticeHomomorphism(D, D, (1, 2, 3, 4, 5));
+false
+gap> IsLatticeHomomorphism(D, D, (1, 4));
+false
+
 # IsLatticeEndomorphism (for transformations)
 gap> D := Digraph([[2, 3], [4], [4], []]);
 <immutable digraph with 4 vertices, 4 edges>
@@ -2608,6 +2620,12 @@ gap> f := Transformation([1, 3, 2, 4]);
 Transformation( [ 1, 3, 2 ] )
 gap> IsLatticeEndomorphism(D, f);
 true
+
+# IsLatticeEndomorphism (for permutations)
+gap> IsLatticeEndomorphism(D, (2, 3));
+true
+gap> IsLatticeEndomorphism(D, (5, 6));
+false
 
 # IsLatticeEmbedding and IsLatticeMonomorphism (for transformations)
 gap> D := Digraph([[2, 3], [4], [4], []]);
@@ -2627,7 +2645,25 @@ Transformation( [ 1, 1, 1, 1 ] )
 gap> IsLatticeEmbedding(D, G, f);
 false
 
-# IsLatticeEpimorphism
+# IsLatticeEmbedding and IsLatticeMonomorphism (for permutations)
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> G := Digraph([[2, 3], [4], [4], [5], []]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 5 vertices, 14 edges>
+gap> IsLatticeEmbedding(D, G, (2, 3));
+true
+gap> IsLatticeEmbedding(D, G, ());
+true
+gap> IsLatticeEmbedding(D, G, (1, 2, 3));
+false
+gap> IsLatticeMonomorphism(D, G, ());
+true
+
+# IsLatticeEpimorphism (for transformations)
 gap> D := Digraph([[2, 3], [4], [4], []]);
 <immutable digraph with 4 vertices, 4 edges>
 gap> D := DigraphReflexiveTransitiveClosure(D);
@@ -2642,6 +2678,22 @@ gap> IsLatticeEpimorphism(G, D, f);
 true
 gap> IsLatticeEpimorphism(D, G, f);
 false
+
+# IsLatticeEpimorphism (for permutations)
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> G := Digraph([[2, 3], [4], [4], [5], []]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> G := DigraphReflexiveTransitiveClosure(G);
+<immutable preorder digraph with 5 vertices, 14 edges>
+gap> IsLatticeEpimorphism(D, G, (2, 3));
+false
+gap> IsLatticeEpimorphism(G, D, (2, 3));
+false
+gap> IsLatticeEpimorphism(D, D, (2, 3));
+true
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1712,6 +1712,16 @@ gap> gr := CycleDigraph(5);
 <immutable cycle digraph with 5 vertices>
 gap> PartialOrderDigraphJoinOfVertices(gr, 1, 4);
 Error, the 1st argument <D> must satisfy IsPartialOrderDigraph,
+gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(4));
+<immutable preorder digraph with 4 vertices, 10 edges>
+gap> IsJoinSemilatticeDigraph(D);
+true
+gap> PartialOrderDigraphJoinOfVertices(D, 2, 3);
+3
+gap> IsMeetSemilatticeDigraph(D);
+true
+gap> PartialOrderDigraphMeetOfVertices(D, 2, 3);
+2
 
 #Join semilattice on 9 vertices
 gap> gr := DigraphFromDiSparse6String(".HiR@AeNcC?oD?G`oAGXIoAGXAe_COqDK^F");

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1208,6 +1208,38 @@ gap> IsMeetSemilatticeDigraph(gr);
 false
 gap> IsJoinSemilatticeDigraph(gr);
 false
+gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(10));
+<immutable preorder digraph with 10 vertices, 55 edges>
+gap> IsMeetSemilatticeDigraph(D);
+true
+gap> IsJoinSemilatticeDigraph(D);
+true
+gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(10));
+<immutable preorder digraph with 10 vertices, 55 edges>
+gap> IsJoinSemilatticeDigraph(D);
+true
+gap> IsMeetSemilatticeDigraph(D);
+true
+gap> D := DigraphAddVertex(D, 11);
+<immutable digraph with 11 vertices, 55 edges>
+gap> D := DigraphAddEdge(D, [11, 4]);
+<immutable digraph with 11 vertices, 56 edges>
+gap> D := DigraphReflexiveTransitiveClosure(D);
+<immutable preorder digraph with 11 vertices, 63 edges>
+gap> IsJoinSemilatticeDigraph(D);
+true
+gap> IsMeetSemilatticeDigraph(D);
+false
+gap> D := Digraph([[1], [2]]);
+<immutable digraph with 2 vertices, 2 edges>
+gap> IsJoinSemilatticeDigraph(D);
+false
+gap> D := ChainDigraph(IsMutable, 4);
+<mutable digraph with 4 vertices, 3 edges>
+gap> IsMeetSemilatticeDigraph(D);
+false
+gap> D;
+<mutable digraph with 4 vertices, 3 edges>
 
 # Join semilattice on 9 vertices
 gap> gr := DigraphFromDiSparse6String(".HiR@AeNcC?oD?G`oAGXIoAGXAe_COqDK^F");

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1240,6 +1240,12 @@ gap> IsMeetSemilatticeDigraph(D);
 false
 gap> D;
 <mutable digraph with 4 vertices, 3 edges>
+gap> D := Digraph(IsMutable, [[2, 3], [4], [4], []]);
+<mutable digraph with 4 vertices, 4 edges>
+gap> DigraphReflexiveTransitiveClosure(D);
+<mutable digraph with 4 vertices, 9 edges>
+gap> IsJoinSemilatticeDigraph(D);
+true
 
 # Join semilattice on 9 vertices
 gap> gr := DigraphFromDiSparse6String(".HiR@AeNcC?oD?G`oAGXIoAGXAe_COqDK^F");

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1246,6 +1246,20 @@ gap> DigraphReflexiveTransitiveClosure(D);
 <mutable digraph with 4 vertices, 9 edges>
 gap> IsJoinSemilatticeDigraph(D);
 true
+gap> D := Digraph([[1, 2, 2], [2]]);
+<immutable multidigraph with 2 vertices, 4 edges>
+gap> IsJoinSemilatticeDigraph(D);
+Error, the argument must not be a multidigraph,
+gap> IsMeetSemilatticeDigraph(D);
+Error, the argument must not be a multidigraph,
+gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(4));
+<immutable preorder digraph with 4 vertices, 10 edges>
+gap> AdjacencyMatrix(D);
+[ [ 1, 1, 1, 1 ], [ 0, 1, 1, 1 ], [ 0, 0, 1, 1 ], [ 0, 0, 0, 1 ] ]
+gap> IsJoinSemilatticeDigraph(D);
+true
+gap> IsMeetSemilatticeDigraph(D);
+true
 
 # Join semilattice on 9 vertices
 gap> gr := DigraphFromDiSparse6String(".HiR@AeNcC?oD?G`oAGXIoAGXAe_COqDK^F");


### PR DESCRIPTION
This PR adds a method for finding an embedding from a lattice digraph into another lattice digraph.

A lattice embedding is an injective lattice homomorphism. In terms of partial order digraphs (of which lattice digraphs are a type) a lattice homomorphism is a digraph homomorphism, which respects the meets and joins of all pairs of vertices.

There were two competing methods for `LatticeDigraphEmbedding`. The one in this pull request is based on the digraph homomorphism finding algorithm, where the notion that "meets must maps to meets, and joins must map to joins" is enforced. The other method called `RepresentativesDigraphsEmbeddings`, iterating through vertices to search for a digraph embedding which respects the meets and joins. When I update this PR, I will include some timing graphs comparing the two. It was decided in conversation with @james-d-mitchell that the lattice-specific method of this PR was the way to go.

**The meet/join table functions of #533 are used here, so this shouldn't be merged before #533.**

**Todo**
- [x] Check things work for mutable digraphs
- [x] Perhaps provide better explanation in the documentation
- [x] Add timing graphs to PR
- [x] Consider optimisations
- [x] Change output to a transformation, rather than a list
