### PR TITLE
Change `CayleyDigraph` to use `AsSet`

### DIFF
--- a/gap/grape.gi
+++ b/gap/grape.gi
@@ -104,7 +104,7 @@ function(G, gens)
   fi;
 
   # vertex i in the Cayley digraph corresponds to elts[i].
-  elts := AsList(G);
+  elts := AsSet(G);
   adj := {x, y} -> LeftQuotient(x, y) in gens;
 
   D := Digraph(IsImmutableDigraph, G, elts, OnLeftInverse, adj);


### PR DESCRIPTION
... instead of `AsList`, to produce a stable output that does not depend on the specific GAP version, random sources or anything else.

This should fix CI tests for latest GAP master, where the output of `AsList` for permutation groups changed: it used to match `AsSet` but doesn't anymore. See https://github.com/gap-system/gap/pull/5216 for details.