### PR TITLE
Avoid src/ prefix for GAP headers

### DIFF
--- a/src/conditions.h
+++ b/src/conditions.h
@@ -17,7 +17,7 @@
 #include <string.h>   // for NULL, memcpy, size_t
 
 // GAP headers
-#include "src/system.h"  // for ALWAYS_INLINE
+#include "compiled.h"  // for ALWAYS_INLINE
 
 // Digraphs headers
 #include "bitarray.h"        // for BitArray, intersect_bit_arrays, size_b...

--- a/src/perms.h
+++ b/src/perms.h
@@ -22,8 +22,7 @@
 #include "digraphs-debug.h"  // for DIGRAPHS_ASSERT
 
 // GAP headers
-#include "compiled.h"      // for Obj, Int
-#include "src/permutat.h"  // for ADDR_PERM, IS_PERM
+#include "compiled.h"
 
 #define MAXVERTS 512
 #define UNDEFINED MAXVERTS + 1


### PR DESCRIPTION
... so that future GAP versions can stop installing /usr/local/include/gap/src