### PR TITLE
Change test that relies on xpdf not being installed

### DIFF
--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -437,8 +437,8 @@ latex",
 gap> Splash("string", rec(path := "~/", filename := "filename"));
 Error, the component "type" of the 2nd argument <a record>  must be "dot" or "\
 latex",
-gap> Splash("string", rec(viewer := "xpdf"));
-Error, the viewer "xpdf" specified in the option `viewer` is not available,
+gap> Splash("string", rec(viewer := "bad"));
+Error, the viewer "bad" specified in the option `viewer` is not available,
 gap> Splash("string", rec(type := "dot", engine := "dott"));
 Error, the component "engine" of the 2nd argument <a record> must be one of: "\
 dot", "neato", "twopi", "circo", "fdp", "sfdp", or "patchwork"


### PR DESCRIPTION
Previously, the tests in display.tst try to call Splash with "xpdf" as the viewer, and we expect an error to be thrown.  This only works if xpdf is not installed, and if xpdf is installed then the tests fail.

This commit changes the test to a dummy viewer which will definitely not be installed.