### PR TITLE
Standardise the way that `UndirectedSpanningForest` works in relation to mutability

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2250,35 +2250,37 @@ InstallMethod(DigraphReflexiveTransitiveReductionAttr,
 "for an immutable digraph",
 [IsImmutableDigraph], DigraphReflexiveTransitiveReduction);
 
-InstallMethod(UndirectedSpanningForest, "for a digraph by out-neighbours",
-[IsDigraphByOutNeighboursRep],
+InstallMethod(UndirectedSpanningForest,
+"for a mutable digraph by out-neighbours",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep],
+function(D)
+  if DigraphHasNoVertices(D) then
+    return fail;
+  fi;
+  MaximalSymmetricSubdigraph(D);
+  D!.OutNeighbours := DIGRAPH_SYMMETRIC_SPANNING_FOREST(D!.OutNeighbours);
+  ClearDigraphEdgeLabels(D);
+  return D;
+end);
+
+InstallMethod(UndirectedSpanningForest, "for an immutable digraph",
+[IsImmutableDigraph], UndirectedSpanningForestAttr);
+
+InstallMethod(UndirectedSpanningForestAttr, "for an immutable digraph",
+[IsImmutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   local C;
   if DigraphHasNoVertices(D) then
     return fail;
   fi;
-  C := MaximalSymmetricSubdigraph(D)!.OutNeighbours;
-  C := DIGRAPH_SYMMETRIC_SPANNING_FOREST(C);
-  if IsMutableDigraph(D) then
-    D!.OutNeighbours := C;
-    ClearDigraphEdgeLabels(D);
-    return D;
-  fi;
+  C := MaximalSymmetricSubdigraph(D);
+  C := DIGRAPH_SYMMETRIC_SPANNING_FOREST(C!.OutNeighbours);
   C := ConvertToImmutableDigraphNC(C);
-  SetUndirectedSpanningForestAttr(D, C);
   SetIsUndirectedForest(C, true);
   SetIsMultiDigraph(C, false);
   SetDigraphHasLoops(C, false);
   return C;
 end);
-
-InstallMethod(UndirectedSpanningForest,
-"for a digraph with known undirected spanning forest",
-[IsDigraph and HasUndirectedSpanningForestAttr], SUM_FLAGS,
-UndirectedSpanningForestAttr);
-
-InstallMethod(UndirectedSpanningForestAttr, "for an immutable digraph",
-[IsImmutableDigraph], UndirectedSpanningForest);
 
 InstallMethod(UndirectedSpanningTree, "for a mutable digraph",
 [IsMutableDigraph],


### PR DESCRIPTION
The currently-existing methods for `UndirectedSpanningForest` in `attr.gi` date from quite a while ago, during a time when we dealt with mutability in a mix of different ways.

(`UndirectedSpanningForest` is a bit special, since it delegates to a C method that takes and returns a list of adjacencies - I think that's why it's been untouched for a while.)

In this PR I've made `UndirectedSpanningForest` a bit more normal, I think. The setup now has a similar structure to `UndirectedSpanningTree`, which comes just after it in the file. In particular, this lets us remove the use of a `SUM_FLAGS` and of having to explicitly do `SetUndirectedSpanningForestAttr`.

There is now the slightest bit of code duplication, but in my opinion this is a price worth paying for the increased clarity of the result.