### PR TITLE
kernel: fix mem leaks for permutations allocated but not freed.

### DIFF
--- a/src/homos-graphs.c
+++ b/src/homos-graphs.c
@@ -240,6 +240,7 @@ static void bliss_hook(void*               user_param_arg,  // perm_coll!
     p[i] = i;
   }
   add_perm_coll((PermColl*) user_param_arg, p);
+  free(p);
 }
 
 #ifdef DIGRAPHS_WITH_INCLUDED_BLISS

--- a/src/homos.c
+++ b/src/homos.c
@@ -531,7 +531,9 @@ static void set_automorphisms(Obj aut_grp_obj, PermColl* out) {
   for (UInt i = 1; i <= LEN_LIST(gens); ++i) {
     Obj gen_obj = ELM_LIST(gens, i);
     if (LargestMovedPointPerm(gen_obj) > 0) {
-      add_perm_coll(out, new_perm_from_gap(gen_obj, PERM_DEGREE));
+      Perm const p = new_perm_from_gap(gen_obj, PERM_DEGREE);
+      add_perm_coll(out, p);
+      free(p);
     }
   }
 }


### PR DESCRIPTION
This PR arose from the discussion at:

https://github.com/semigroups/Semigroups/issues/948
https://github.com/semigroups/Semigroups/pull/942#issuecomment-1712458666

