### PR TITLE
Remove references to bin/gap.sh

### DIFF
--- a/ci/coverage.py
+++ b/ci/coverage.py
@@ -38,7 +38,7 @@ OutputAnnotatedCodeCoverageFiles(x, filesdir, outdir);
 QUIT_GAP(0);
 '''
 
-_RUN_GAP = '../../bin/gap.sh -A -q -m 1g -o 2g -T --cover ' + _DIR + '/profile.gz -c "' + _COMMANDS.replace('"', '\\"') + '"'
+_RUN_GAP = '../../gap -A -q -m 1g -o 2g -T --cover ' + _DIR + '/profile.gz -c "' + _COMMANDS.replace('"', '\\"') + '"'
 
 try:
     pro = subprocess.Popen(_RUN_GAP, shell=True)

--- a/ci/docker-test.sh
+++ b/ci/docker-test.sh
@@ -58,7 +58,7 @@ env | grep -v "^LS_COLORS"
 # Common curl settings
 CURL="curl --connect-timeout 5 --max-time 40 --retry 5 --retry-delay 0  -L"
 TESTLOG="$GAP_HOME/testlog.txt"
-GAPSH="$GAP_HOME/bin/gap.sh"
+GAPSH="$GAP_HOME/gap"
 DIG_DIR="$GAP_HOME/pkg/digraphs"
 
 ################################################################################

--- a/scripts/check-code-coverage.sh
+++ b/scripts/check-code-coverage.sh
@@ -58,7 +58,7 @@ printf "\033[1m";
 printf "Running Test(\"$1\"); in GAP . . .\n"; 
 printf "\033[0m"; 
 printf "\033[2m";
-~/gap/bin/gap.sh -A -m 1g -T <<< "Test(\"$1\"); quit;";
+~/gap/gap -A -m 1g -T <<< "Test(\"$1\"); quit;";
 printf "\033[0m"; 
 
 printf "\033[1m";


### PR DESCRIPTION
Resolves #595

(It seems `master` and `stable-1.6` have diverged, neither is a subset of the other, so I am just guessing that this PR should go to stable-1.6?)