### PR TITLE
Print empty lists with two spaces for consistency

### DIFF
--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -699,8 +699,8 @@ InstallMethod(PrintString, "for a digraph", [IsDigraph], String);
 InstallMethod(String, "for a digraph",
 [IsDigraph],
 function(D)
-  local n, N, i, mut, streps, outnbs_rep, lengths, strings, creators_streps,
-        creators_props, props;
+  local n, N, i, mut, streps, outnbs_rep, lengths, strings,
+        out_neighbours_string, creators_streps, creators_props, props;
   if IsMutableDigraph(D) then
     mut := "IsMutableDigraph, ";
   else
@@ -722,7 +722,11 @@ function(D)
                  ReplacedString(streps[n], "\\", "\\\\"), "\"", ")"));
   od;
 
-  outnbs_rep := Concatenation("Digraph(", mut, String(OutNeighbours(D)), ")");
+  out_neighbours_string := String(OutNeighbours(D));
+  # print empty lists with two spaces for consistency
+  # see https://github.com/gap-system/gap/pull/5418
+  out_neighbours_string := ReplacedString(out_neighbours_string, "[ ]", "[  ]");
+  outnbs_rep := Concatenation("Digraph(", mut, out_neighbours_string, ")");
   Add(strings, String(outnbs_rep));
 
   N              := DigraphNrVertices(D);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1179,9 +1179,9 @@ gap> gr1 := EmptyDigraph(0);;
 gap> gr2 := DigraphCopy(gr1);
 <immutable empty digraph with 0 vertices>
 gap> String(gr2);
-"Digraph([ ])"
+"Digraph([  ])"
 gap> PrintString(gr2);
-"Digraph([ ])"
+"Digraph([  ])"
 gap> D := CycleDigraph(10 * 10 ^ 5);
 <immutable cycle digraph with 1000000 vertices>
 gap> D1 := DigraphCopy(D);
@@ -1348,7 +1348,7 @@ gap> list := [[1, 2], []];
 gap> D := DigraphNC(IsMutableDigraph, list);
 <mutable digraph with 2 vertices, 2 edges>
 gap> PrintString(D);
-"Digraph(IsMutableDigraph, [ [ 1, 2 ], [ ] ])"
+"Digraph(IsMutableDigraph, [ [ 1, 2 ], [  ] ])"
 gap> EvalString(String(D)) = D;
 true
 gap> DigraphByAdjacencyMatrix(IsMutableDigraph, []);
@@ -1802,7 +1802,7 @@ gap> String(G);
 gap> D := Digraph([]);
 <immutable empty digraph with 0 vertices>
 gap> String(D);
-"Digraph([ ])"
+"Digraph([  ])"
 gap> D := CompleteDigraph(7);
 <immutable complete digraph with 7 vertices>
 gap> String(D);


### PR DESCRIPTION
as a preparation for https://github.com/gap-system/gap/pull/5418