### PR TITLE
configure.ac: fix bashism in string equality test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,7 @@ AC_ARG_WITH([intrinsics],
                             [do not use compiler intrinsics even if available])]
            )
 
-AS_IF([test "x$with_intrinsics" == "xno" ],
+AS_IF([test "x$with_intrinsics" = "xno" ],
       [AC_MSG_NOTICE([compiler intrinsics will not be used even if available])])
 
 dnl compiler builtins


### PR DESCRIPTION
Using `==` for string equality only works in the Bash shell, while ./configure is meant to be run in any POSIX /bin/sh. We change one instance to `=` to fix the following error in (for example) Dash:

```
./configure: 5587: test: x: unexpected operator
```