### PR TITLE
Add DigraphContractEdge

### DIFF
--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1923,25 +1923,26 @@ true
 <#GAPDoc Label="DigraphContractEdge">
 <ManSection>
     <Oper Name="DigraphContractEdge" Arg="digraph, edge"
-        Label="for a digraph and an edge"/>
+        Label="for a digraph and a list of positive integers"/>
     <Oper Name="DigraphContractEdge" Arg="digraph, src, ran"
-        Label="for a digraph, source, and range"/>
+        Label="for a digraph and two positive integers"/>
   <Returns>A digraph.</Returns>
   <Description>
     If <A>edge</A> is a pair of vertices of <A>digraph</A>, or <A>src</A> and
     <A>ran</A> are vertices of <A>digraph</A>, where <A>ran</A> &lt;&gt; <A>src</A>, 
-    then this operation returns a new digraph constructed from <A>digraph</A>,
+    then then this operation merges the two vertices of the edge given into one. 
+    Edges incident to <A>src</A> and <A>ran</A> will now be incident to <C>v</C>, 
+    the new vertex, with their direction preserved. <P/>
+    
+    A new digraph constructed from <A>digraph</A> is returned,
     unless <A>digraph</A> belongs to <Ref Filt="IsMutableDigraph"/>;
-    in this case changes are made directly to <A>digraph</A>. 
-    <A>digraph</A> must not belong to <Ref Filt="IsMultiDigraph"/>. <P/>
+    in this case changes are made directly to <A>digraph</A>, which is then returned. 
+    The <A>digraph</A> must not belong to <Ref Filt="IsMultiDigraph"/>. <P/>
 
-    A new vertex <C>v</C> is added; <A>src</A> and <A>ran</A> are both 
-    removed. Any incident edges of <A>src</A> or <A>ran</A> are now 
-    incident to <C>v</C>, preserving their direction.
-    If <A>digraph</A> belongs to <C>HaveEdgeLabelsBeenAssigned</C>, edge labels are preserved. 
-    The edge label of <A>[src, ran]</A> is removed. 
+    The labels of any remaining edges will be preserved. <P/>
+
     Assigned vertex labels for <A>src</A> and <A>ran</A> are
-    combined into a list, and assigned to new vertex <C>v</C>. <P/>
+    combined into a list, and assigned to the new vertex <C>v</C>. <P/>
 
     If an edge <A>[src, src]</A> or <A>[ran, ran]</A> exists,
     a singular edge <C>[v, v]</C> is created. If edge <A>[ran, src]</A>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1920,6 +1920,52 @@ true
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DigraphContractEdge">
+<ManSection>
+    <Oper Name="DigraphContractEdge" Arg="digraph, edge"
+        Label="for a digraph and an edge"/>
+    <Oper Name="DigraphContractEdge" Arg="digraph, src, ran"
+        Label="for a digraph, source, and range"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+    If <A>edge</A> is a pair of vertices of <A>digraph</A>, or <A>src</A> and
+    <A>ran</A> are vertices of <A>digraph</A>, where <A>ran</A> <> <A>src</A>, 
+    then this operation returns a new digraph constructed from <A>digraph</A>,
+    unless <A>digraph</A> belongs to <Filt Prop="IsMutableDigraph">;
+    in this case changes are made directly to <A>digraph</A>. 
+    <A>digraph</A> must not belong to <Ref Filt="IsMultiDigraph">.
+
+    A new vertex <M>v</M> is added; <A>src</A> and <A>ran</A> are both 
+    removed. Any incident edges of <A>src</A> or <A>ran</A> are now 
+    incident to <M>v</>, preserving their direction.
+    If <A>digraph</A> belongs to <Ref Filt="HaveEdgeLabelsBeenAssigned">,
+    edge labels are preserved. The edge label of <A>[src, ran]</A>
+    is removed. Assigned vertex labels for <A>src</A> and <A>ran</A> are 
+    combined into a list, and assigned to new vertex <M>v</M>. 
+
+    If an edge <A>[src, src]</A> or <A>[ran, ran]</A> exists,
+    a singular edge <M>[v, v]</M> is created. If edge <A>[ran, src]</A>
+    exists, this is also removed. 
+
+    <Example><![CDATA[
+gap> D := DigraphByEdges([[1, 2], [2, 1]]);
+<immutable digraph with 2 vertices, 2 edges>
+gap> D2 := DigraphContractEdge(D, 1, 2);
+<immutable empty digraph with 1 vertex>
+gap> DigraphEdges(D2);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 3], [3, 4]]);
+<mutable digraph with 4 vertices, 3 edges>
+gap> DigraphVertexLabels(D);; # setting vertex labels
+gap> DigraphContractEdge(D, [2, 3]);
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 3, 2 ] ]
+gap> DigraphVertexLabels(D);
+[ 1, 4, [ 2, 3 ] ] # combined vertex label of contracted edge
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="IsMatching">
 <ManSection>
   <Oper Name="IsMatching" Arg="digraph, list"/>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1929,23 +1929,23 @@ true
   <Returns>A digraph.</Returns>
   <Description>
     If <A>edge</A> is a pair of vertices of <A>digraph</A>, or <A>src</A> and
-    <A>ran</A> are vertices of <A>digraph</A>, where <A>ran</A> &lt;&gt <A>src</A>, 
+    <A>ran</A> are vertices of <A>digraph</A>, where <A>ran</A> &lt;&gt; <A>src</A>, 
     then this operation returns a new digraph constructed from <A>digraph</A>,
-    unless <A>digraph</A> belongs to <Filt Prop="IsMutableDigraph">;
+    unless <A>digraph</A> belongs to <Ref Filt="IsMutableDigraph"/>;
     in this case changes are made directly to <A>digraph</A>. 
-    <A>digraph</A> must not belong to <Ref Filt="IsMultiDigraph">.
+    <A>digraph</A> must not belong to <Ref Filt="IsMultiDigraph"/>. <P/>
 
-    A new vertex <M>v</M> is added; <A>src</A> and <A>ran</A> are both 
+    A new vertex <C>v</C> is added; <A>src</A> and <A>ran</A> are both 
     removed. Any incident edges of <A>src</A> or <A>ran</A> are now 
-    incident to <M>v</>, preserving their direction.
-    If <A>digraph</A> belongs to <Ref Filt="HaveEdgeLabelsBeenAssigned">,
-    edge labels are preserved. The edge label of <A>[src, ran]</A>
-    is removed. Assigned vertex labels for <A>src</A> and <A>ran</A> are 
-    combined into a list, and assigned to new vertex <M>v</M>. 
+    incident to <C>v</C>, preserving their direction.
+    If <A>digraph</A> belongs to <C>HaveEdgeLabelsBeenAssigned</C>, edge labels are preserved. 
+    The edge label of <A>[src, ran]</A> is removed. 
+    Assigned vertex labels for <A>src</A> and <A>ran</A> are
+    combined into a list, and assigned to new vertex <C>v</C>. <P/>
 
     If an edge <A>[src, src]</A> or <A>[ran, ran]</A> exists,
-    a singular edge <M>[v, v]</M> is created. If edge <A>[ran, src]</A>
-    exists, this is also removed. 
+    a singular edge <C>[v, v]</C> is created. If edge <A>[ran, src]</A>
+    exists, this is also removed. <P/>
 
     <Example><![CDATA[
 gap> D := DigraphByEdges([[1, 2], [2, 1]]);
@@ -1953,14 +1953,15 @@ gap> D := DigraphByEdges([[1, 2], [2, 1]]);
 gap> D2 := DigraphContractEdge(D, 1, 2);
 <immutable empty digraph with 1 vertex>
 gap> DigraphEdges(D2);
+[  ]
 gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 3], [3, 4]]);
 <mutable digraph with 4 vertices, 3 edges>
-gap> DigraphVertexLabels(D);; # setting vertex labels
+gap> DigraphVertexLabels(D);;  # setting vertex labels
 gap> DigraphContractEdge(D, [2, 3]);
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 3, 2 ] ]
 gap> DigraphVertexLabels(D);
-[ 1, 4, [ 2, 3 ] ] # combined vertex label of contracted edge
+[ 1, 4, [ 2, 3 ] ]
 ]]></Example>
   </Description>
 </ManSection>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1959,6 +1959,7 @@ gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 3], [3, 4]]);
 <mutable digraph with 4 vertices, 3 edges>
 gap> DigraphVertexLabels(D);;  # setting vertex labels
 gap> DigraphContractEdge(D, [2, 3]);
+<mutable digraph with 3 vertices, 2 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 3, 2 ] ]
 gap> DigraphVertexLabels(D);

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1929,7 +1929,7 @@ true
   <Returns>A digraph.</Returns>
   <Description>
     If <A>edge</A> is a pair of vertices of <A>digraph</A>, or <A>src</A> and
-    <A>ran</A> are vertices of <A>digraph</A>, where <A>ran</A> <> <A>src</A>, 
+    <A>ran</A> are vertices of <A>digraph</A>, where <A>ran</A> &lt;&gt <A>src</A>, 
     then this operation returns a new digraph constructed from <A>digraph</A>,
     unless <A>digraph</A> belongs to <Filt Prop="IsMutableDigraph">;
     in this case changes are made directly to <A>digraph</A>. 

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -53,6 +53,7 @@
     <#Include Label="DigraphRemoveEdges">
     <#Include Label="DigraphRemoveLoops">
     <#Include Label="DigraphRemoveAllMultipleEdges">
+    <#Include Label="DigraphContractEdge">
     <#Include Label="DigraphReverseEdges">
     <#Include Label="DigraphDisjointUnion">
     <#Include Label="DigraphEdgeUnion">

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -35,6 +35,8 @@ DeclareOperation("DigraphReverseEdges", [IsDigraph, IsList]);
 
 DeclareOperation("DigraphClosure", [IsDigraph, IsPosInt]);
 
+DeclareOperation("DigraphContractEdge", [IsDigraph, IsPosInt, IsPosInt]);
+
 # 3. Ways of combining digraphs . . .
 DeclareGlobalFunction("DigraphDisjointUnion");
 DeclareGlobalFunction("DigraphJoin");

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -36,6 +36,7 @@ DeclareOperation("DigraphReverseEdges", [IsDigraph, IsList]);
 DeclareOperation("DigraphClosure", [IsDigraph, IsPosInt]);
 
 DeclareOperation("DigraphContractEdge", [IsDigraph, IsPosInt, IsPosInt]);
+DeclareOperation("DigraphContractEdge", [IsDigraph, IsList]);
 
 # 3. Ways of combining digraphs . . .
 DeclareGlobalFunction("DigraphDisjointUnion");

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -36,7 +36,7 @@ DeclareOperation("DigraphReverseEdges", [IsDigraph, IsList]);
 DeclareOperation("DigraphClosure", [IsDigraph, IsPosInt]);
 
 DeclareOperation("DigraphContractEdge", [IsDigraph, IsPosInt, IsPosInt]);
-DeclareOperation("DigraphContractEdge", [IsDigraph, IsList]);
+DeclareOperation("DigraphContractEdge", [IsDigraph, IsDenseList]);
 
 # 3. Ways of combining digraphs . . .
 DeclareGlobalFunction("DigraphDisjointUnion");

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -473,7 +473,7 @@ function(D, u, v)
   # add vertex w with combined labels from u and v
   NewDigraph := DigraphAddVertex(NewDigraph, [DigraphVertexLabel(D, u), DigraphVertexLabel(D, v)]); # add vertex w
 
-  vertices := DigraphVertices(D);
+  vertices := DigraphVertices(NewDigraph);
   w := vertices[Length(vertices)]; # w is the new vertix identifier 
 
   # Handle loops from edges u or w, with the same source / range

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -377,67 +377,74 @@ InstallMethod(DigraphClosure,
 [IsImmutableDigraph, IsPosInt],
 {D, k} -> MakeImmutable(DigraphClosure(DigraphMutableCopy(D), k)));
 
+DIGRAPHS_CheckContractEdgeDigraph := function(D, u, v)
+  if not IsDigraphEdge(D, u, v) then  # Check if [u, v] is an edge in digraph D
+    ErrorNoReturn("expected an edge between the 2nd and 3rd arguments ",
+                  "(vertices) ", u, " and ", v, " but found none");
+  elif IsMultiDigraph(D) then
+    ErrorNoReturn("The 1st argument (a digraph) must not satisfy ",
+                   "IsMultiDigraph");
+  elif u = v then  # edge should not be contracted if u = v
+    ErrorNoReturn("The 2nd argument <u> must not be equal to the 3rd ",
+                   "argument <v>");
+  fi;
+
+end;
+
 InstallMethod(DigraphContractEdge,
 "for a mutable digraph and two positive integers",
 [IsMutableDigraph, IsPosInt, IsPosInt],
 function(D, u, v)
   local w, neighbours, transformations_to_edge, transformations_to_old_edges,
-  old_edge, new_edge, neighbour, t, copy, vertices;
+  old_edge, new_edge, neighbour, t, vertices, edge_label;
 
-  if not IsDigraphEdge(D, u, v) then  # Check if [u, v] is an edge in digraph D
-    ErrorNoReturn("u, v is not an edge of D");
-  fi;
+  DIGRAPHS_CheckContractEdgeDigraph(D, u, v);
 
-  if IsMultiDigraph(D) then  # multi digraphs cannot have their edges contracted
-    ErrorNoReturn("Cannot contract an edge for a MultiDigraph");
-  fi;
-
-  if u = v then  # edge should not be contracted if u = v
-    ErrorNoReturn("Cannot contract an edge with the same source and range");
-  fi;
-
-  if IsDigraphEdge(D, v, u) then  # if (v, u) is an edge,
-    DigraphRemoveEdge(D, v, u);   # disallow loops, so also remove (v, u)
+  # if (v, u) is an edge, disallow loops, so remove (v, u)
+  if IsDigraphEdge(D, v, u) then
+    DigraphRemoveEdge(D, v, u);
   fi;
 
   # remove the contracted edge
   DigraphRemoveEdge(D, u, v);
 
-  copy := DigraphImmutableCopy(D);  # create a copy of the original digraph,
-                                    # with removed edges, to use as a reference
-                                    # for edge labels
+  # Find vertex neighbours of u and v to construct new incident edges of w
 
-  neighbours := [InNeighboursOfVertex(copy, u), InNeighboursOfVertex(copy, v),
-                 OutNeighboursOfVertex(copy, u), OutNeighboursOfVertex(copy, v)];
+  neighbours := [Immutable(InNeighboursOfVertex(D, u)),
+                 Immutable(InNeighboursOfVertex(D, v)),
+                 Immutable(OutNeighboursOfVertex(D, u)),
+                 Immutable(OutNeighboursOfVertex(D, v))];
+
+  # immutable reference to old edge labels to add to any
+  # new transformed incident edges
 
   DigraphAddVertex(D, [DigraphVertexLabel(D, u),
-                   DigraphVertexLabel(D, v)]);  # add vertex w
+                       DigraphVertexLabel(D, v)]);  # add vertex w
 
   vertices := DigraphVertices(D);
-  w := vertices[Length(vertices)];  # w is the new vertex identifier
+  w := Length(vertices);  # w is the new vertex identifier
 
   # Handle loops from edges u or w, with the same source / range
-  if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v)
-      then DigraphAddEdge(D, w, w);
-         SetDigraphEdgeLabel(D, w, w, [DigraphEdgeLabel(copy, u, u),
-         DigraphEdgeLabel(copy, v, v)]);
-  else
-    if IsDigraphEdge(D, u, u) then DigraphAddEdge(D, w, w);
-                                   SetDigraphEdgeLabel(D, w, w,
-                                   DigraphEdgeLabel(copy, u, u));
-    else
-      if IsDigraphEdge(D, v, v)
-          then DigraphAddEdge(D, w, w);
-               SetDigraphEdgeLabel(D, w, w,
-               DigraphEdgeLabel(copy, v, v));
-        fi;
-      fi;
-    fi;
+  # No relevant edges are removed from D until vertices are removed
+  # So old edge labls are taken from D
+
+  if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v) then
+    DigraphAddEdge(D, w, w);
+    edge_label := [DigraphEdgeLabel(D, u, u), DigraphEdgeLabel(D, w, w)];
+    SetDigraphEdgeLabel(D, w, w, edge_label);
+  elif IsDigraphEdge(D, u, u) then
+      DigraphAddEdge(D, w, w);
+      edge_label := DigraphEdgeLabel(D, u, u);
+      SetDigraphEdgeLabel(D, w, w, edge_label);
+  elif IsDigraphEdge(D, v, v) then
+      DigraphAddEdge(D, w, w);
+      edge_label := DigraphEdgeLabel(D, v, v);
+      SetDigraphEdgeLabel(D, w, w, edge_label);
+  fi;
 
   # translate edges based on neighbours
 
   # transformation functions translating neighbours to their new edge
-
   transformations_to_edge := [{x, y} -> [x, y],
                               {x, y} -> [x, y],
                               {x, y} -> [y, x],
@@ -446,27 +453,27 @@ function(D, u, v)
   # transformation functions translating neighbours
   # to their original edge in D
 
-  transformations_to_old_edges := [e -> [e, u], e -> [e, v],
-                                   e -> [u, e], e -> [v, e]];
+  transformations_to_old_edges := [e -> [e, u],
+                                   e -> [e, v],
+                                   e -> [u, e],
+                                   e -> [v, e]];
 
   # Add translated new edges, and setup edge labels
+
   for t in [1 .. Length(transformations_to_edge)] do
     for neighbour in neighbours[t] do
         new_edge := transformations_to_edge[t](neighbour, w);
-
-        # old_edge is what the new transformed edge was previously
         old_edge := transformations_to_old_edges[t](neighbour);
+        edge_label := DigraphEdgeLabel(D, old_edge[1], old_edge[2]);
         DigraphAddEdge(D, new_edge);
-        SetDigraphEdgeLabel(D, new_edge[1], new_edge[2],
-                            DigraphEdgeLabel(copy, old_edge[1],
-                                             old_edge[2]));
+        SetDigraphEdgeLabel(D, new_edge[1], new_edge[2], edge_label);
     od;
   od;
 
   DigraphRemoveVertices(D, [u, v]);  # remove the vertices of the
                                      # contracted edge (and therefore,
                                      # all its incident edges)
-
+  return D;
 end);
 
 InstallMethod(DigraphContractEdge,
@@ -474,60 +481,48 @@ InstallMethod(DigraphContractEdge,
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(D, u, v)
   local w, neighbours, transformations_to_edge, transformations_to_old_edges,
-  existing_edges, edges_to_not_include, NewDigraph, new_edge, old_edge,
-  neighbour, t, vertices;
+  existing_edges, edges_to_not_include, new_digraph, new_edge, old_edge,
+  neighbour, t, vertices, edge_label;
 
-  if not IsDigraphEdge(D, u, v) then  # Check if [u, v] is an edge in digraph D
-    ErrorNoReturn("u, v is not an edge of D");
-  fi;
+  DIGRAPHS_CheckContractEdgeDigraph(D, u, v);
 
-  if IsMultiDigraph(D) then  # multi digraphs cannot have their edges contracted
-    ErrorNoReturn("Cannot contract an edge for a MultiDigraph");
-  fi;
-
-  if u = v then  # edge should not be contracted if u = v
-    ErrorNoReturn("Cannot contract an edge with the same source and range");
-  fi;
-
-  edges_to_not_include := [];  # Incident edges to [u, v] that will be
-                               # transformed to be incident to w
+  # Incident edges to [u, v] that will be transformed to be incident to w
+  edges_to_not_include := [];
 
   existing_edges := [];  # existing edges that should be re added
 
-  NewDigraph := DigraphByEdges([]);  # contracted edge should not be added to
-                                     # the new digraph
+  # contracted edge should not be added to the new digraph
+  new_digraph := NullDigraph(IsMutableDigraph, 0);
 
-  if IsDigraphEdge(D, v, u) then       # if (v, u) is an edge, disallow loops,
-     D := DigraphRemoveEdge(D, v, u);  # so also remove (v, u)
-      fi;
+  # if (v, u) is an edge, disallow loops, so remove (v, u)
+  if IsDigraphEdge(D, v, u) then
+     D := DigraphRemoveEdge(D, v, u);
+  fi;
 
   D := DigraphRemoveEdge(D, u, v);  # remove the edge to be contracted
 
-  NewDigraph := DigraphAddVertices(NewDigraph, DigraphVertexLabels(D));
+  DigraphAddVertices(new_digraph, DigraphVertexLabels(D));
 
   # add vertex w with combined labels from u and v
-  NewDigraph := DigraphAddVertex(NewDigraph, [DigraphVertexLabel(D, u),
-                                 DigraphVertexLabel(D, v)]);  # add vertex w
+  DigraphAddVertex(new_digraph, [DigraphVertexLabel(D, u),
+                   DigraphVertexLabel(D, v)]);  # add vertex w
 
-  vertices := DigraphVertices(NewDigraph);
-  w := vertices[Length(vertices)];  # w is the new vertex identifier
+  vertices := DigraphVertices(new_digraph);
+  w := Length(vertices);  # w is the new vertex identifier
 
   # Handle loops from edges u or w, with the same source / range
-  if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v)
-      then NewDigraph := DigraphAddEdge(NewDigraph, w, w);
-           SetDigraphEdgeLabel(NewDigraph, w, w, [DigraphEdgeLabel(D, u, u),
-                               DigraphEdgeLabel(D, v, v)]);
-  else
-    if IsDigraphEdge(D, u, u)
-        then NewDigraph := DigraphAddEdge(NewDigraph, w, w);
-                           SetDigraphEdgeLabel(NewDigraph, w, w,
-                                               DigraphEdgeLabel(D, u, u));
-    else
-      if IsDigraphEdge(D, v, v)
-          then NewDigraph := DigraphAddEdge(NewDigraph, w, w);
-               SetDigraphEdgeLabel(NewDigraph, w, w, DigraphEdgeLabel(D, v, v));
-      fi;
-    fi;
+
+  if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v) then
+    DigraphAddEdge(new_digraph, w, w);
+    SetDigraphEdgeLabel(new_digraph, w, w, [DigraphEdgeLabel(D, u, u),
+                                           DigraphEdgeLabel(D, v, v)]);
+  elif IsDigraphEdge(D, u, u) then
+    DigraphAddEdge(new_digraph, w, w);
+    SetDigraphEdgeLabel(new_digraph, w, w,
+                        DigraphEdgeLabel(D, u, u));
+  elif IsDigraphEdge(D, v, v) then
+    DigraphAddEdge(new_digraph, w, w);
+    SetDigraphEdgeLabel(new_digraph, w, w, DigraphEdgeLabel(D, v, v));
   fi;
 
   # if there were loops in D at the vertices u or w, don't include these edges,
@@ -537,17 +532,24 @@ function(D, u, v)
 
   # Find vertex neighbours of u and v to construct new incident edges of w
 
-  neighbours := [InNeighboursOfVertex(D, u), InNeighboursOfVertex(D, v),
-                 OutNeighboursOfVertex(D, u), OutNeighboursOfVertex(D, v)];
+  neighbours := [InNeighboursOfVertex(D, u),
+                 InNeighboursOfVertex(D, v),
+                 OutNeighboursOfVertex(D, u),
+                 OutNeighboursOfVertex(D, v)];
 
   # translate edges based on neighbours
 
   # transformation functions translating neighbours to their new edge
+
   transformations_to_edge := [{x, y} -> [x, y], {x, y} -> [x, y],
                               {x, y} -> [y, x], {x, y} -> [y, x]];
+
   # transformation functions translating neighbours to their original edge in D
-  transformations_to_old_edges := [e -> [e, u], e -> [e, v],
-                                   e -> [u, e], e -> [v, e]];
+
+  transformations_to_old_edges := [e -> [e, u],
+                                   e -> [e, v],
+                                   e -> [u, e],
+                                   e -> [v, e]];
 
   # remove edges that will be adjusted
 
@@ -557,50 +559,43 @@ function(D, u, v)
   od;
 
   # Find edges that should be included, but remain the same
+
   Sort(edges_to_not_include);
   Append(existing_edges, ShallowCopy(DigraphEdges(D)));
   Sort(existing_edges);
   SubtractSet(existing_edges, edges_to_not_include);
 
   # Add translated new edges, and setup edge labels
+
   for t in [1 .. Length(transformations_to_edge)] do
     for neighbour in neighbours[t] do
         new_edge := transformations_to_edge[t](neighbour, w);
 
         # old_edge is what the new transformed edge was previously
         old_edge := transformations_to_old_edges[t](neighbour);
-        NewDigraph := DigraphAddEdge(NewDigraph, new_edge);
-        SetDigraphEdgeLabel(NewDigraph, new_edge[1], new_edge[2],
-                            DigraphEdgeLabel(D, old_edge[1], old_edge[2]));
+        edge_label := DigraphEdgeLabel(D, old_edge[1], old_edge[2]);
+        new_digraph := DigraphAddEdge(new_digraph, new_edge);
+        SetDigraphEdgeLabel(new_digraph, new_edge[1], new_edge[2], edge_label);
     od;
   od;
 
   # Add the existing edges that have not changed,
   # and set their edge labels to that of the previous digraph
+
   for new_edge in existing_edges do
-    NewDigraph := DigraphAddEdge(NewDigraph, new_edge);
-    SetDigraphEdgeLabel(NewDigraph, new_edge[1], new_edge[2],
+    new_digraph := DigraphAddEdge(new_digraph, new_edge);
+    SetDigraphEdgeLabel(new_digraph, new_edge[1], new_edge[2],
                         DigraphEdgeLabel(D, new_edge[1], new_edge[2]));
   od;
 
   # remove the vertices of the contracted edge
-  return DigraphRemoveVertices(NewDigraph, [u, v]);
+  return MakeImmutable(DigraphRemoveVertices(new_digraph, [u, v]));
 
 end);
 
 InstallMethod(DigraphContractEdge,
-"for a mutable digraph and a dense list",
-[IsMutableDigraph, IsDenseList],
-function(D, edge)
-  if Length(edge) <> 2 then
-    ErrorNoReturn("the 2nd argument <edge> must be a list of length 2");
-  fi;
-  DigraphContractEdge(D, edge[1], edge[2]);
-end);
-
-InstallMethod(DigraphContractEdge,
-"for an immutable digraph and a dense list",
-[IsImmutableDigraph, IsDenseList],
+"for a digraph and a dense list",
+[IsDigraph, IsDenseList],
 function(D, edge)
   if Length(edge) <> 2 then
     ErrorNoReturn("the 2nd argument <edge> must be a list of length 2");

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -593,7 +593,7 @@ InstallMethod(DigraphContractEdge,
 [IsMutableDigraph, IsDenseList],
 function(D, edge)
   if Length(edge) <> 2 then
-    ErrorNoReturn("the 2nd argument <edge> must be a list of length 2,");
+    ErrorNoReturn("the 2nd argument <edge> must be a list of length 2");
   fi;
   DigraphContractEdge(D, edge[1], edge[2]);
 end);
@@ -603,7 +603,7 @@ InstallMethod(DigraphContractEdge,
 [IsImmutableDigraph, IsDenseList],
 function(D, edge)
   if Length(edge) <> 2 then
-    ErrorNoReturn("the 2nd argument <edge> must be a list of length 2,");
+    ErrorNoReturn("the 2nd argument <edge> must be a list of length 2");
   fi;
   return DigraphContractEdge(D, edge[1], edge[2]);
 end);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -408,7 +408,7 @@ function(D, u, v)
   DigraphAddVertex(D, [DigraphVertexLabel(D, u), DigraphVertexLabel(D, v)]); # add vertex w
 
   vertices := DigraphVertices(D);
-  w := vertices[Length(vertices)]; # w is the new vertix identifier 
+  w := vertices[Length(vertices)]; # w is the new vertex identifier 
 
   # Handle loops from edges u or w, with the same source / range
   if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v) then DigraphAddEdge(D, w, w); SetDigraphEdgeLabel(D, w, w, [DigraphEdgeLabel(copy, u, u), DigraphEdgeLabel(copy, v, v)]);
@@ -474,7 +474,7 @@ function(D, u, v)
   NewDigraph := DigraphAddVertex(NewDigraph, [DigraphVertexLabel(D, u), DigraphVertexLabel(D, v)]); # add vertex w
 
   vertices := DigraphVertices(NewDigraph);
-  w := vertices[Length(vertices)]; # w is the new vertix identifier 
+  w := vertices[Length(vertices)]; # w is the new vertex identifier 
 
   # Handle loops from edges u or w, with the same source / range
   if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v) then NewDigraph := DigraphAddEdge(NewDigraph, w, w); SetDigraphEdgeLabel(NewDigraph, w, w, [DigraphEdgeLabel(D, u, u), DigraphEdgeLabel(D, v, v)]);
@@ -531,8 +531,18 @@ function(D, u, v)
 end);
 
 InstallMethod(DigraphContractEdge,
-"for a digraph and a list",
-[IsDigraph, IsList],
+"for a mutable digraph and a dense list",
+[IsMutableDigraph, IsDenseList],
+function(D, edge)
+  if Length(edge) <> 2 then
+    ErrorNoReturn("the 2nd argument <edge> must be a list of length 2,");
+  fi;
+  DigraphContractEdge(D, edge[1], edge[2]);
+end);
+
+InstallMethod(DigraphContractEdge,
+"for an immutable digraph and a dense list",
+[IsImmutableDigraph, IsDenseList],
 function(D, edge)
   if Length(edge) <> 2 then
     ErrorNoReturn("the 2nd argument <edge> must be a list of length 2,");

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -381,8 +381,7 @@ InstallMethod(DigraphContractEdge,
 "for a mutable digraph and two positive integers",
 [IsMutableDigraph, IsPosInt, IsPosInt],
 function(D, u, v)
-  local w, neighbours, transformations_to_edge, transformations_to_old_edges, old_edge, new_edge, neighbour, t, copy;
-
+  local w, neighbours, transformations_to_edge, transformations_to_old_edges, old_edge, new_edge, neighbour, t, copy, vertices;
 
   if not IsDigraphEdge(D, u, v) then # Check if [u, v] is an edge in digraph D
     ErrorNoReturn("u, v is not an edge of D");
@@ -398,7 +397,6 @@ function(D, u, v)
 
   if IsDigraphEdge(D, v, u) then # if (v, u) is an edge, disallow loops, so also remove (v, u)
     DigraphRemoveEdge(D, v, u);
-    
   fi;
 
   # remove the contracted edge
@@ -409,7 +407,8 @@ function(D, u, v)
   
   DigraphAddVertex(D, [DigraphVertexLabel(D, u), DigraphVertexLabel(D, v)]); # add vertex w
 
-  w := Last(DigraphVertices(D)); # w is the new vertix identifier 
+  vertices := DigraphVertices(D);
+  w := vertices[Length(vertices)]; # w is the new vertix identifier 
 
   # Handle loops from edges u or w, with the same source / range
   if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v) then DigraphAddEdge(D, w, w); SetDigraphEdgeLabel(D, w, w, [DigraphEdgeLabel(copy, u, u), DigraphEdgeLabel(copy, v, v)]);
@@ -444,7 +443,7 @@ InstallMethod(DigraphContractEdge,
 "for an immutable digraph and two positive integers",
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(D, u, v)
-  local w, neighbours, transformations_to_edge, transformations_to_old_edges, existing_edges, edges_to_not_include, NewDigraph, new_edge, old_edge, neighbour, t;
+  local w, neighbours, transformations_to_edge, transformations_to_old_edges, existing_edges, edges_to_not_include, NewDigraph, new_edge, old_edge, neighbour, t, vertices;
 
   if not IsDigraphEdge(D, u, v) then # Check if [u, v] is an edge in digraph D
     ErrorNoReturn("u, v is not an edge of D");
@@ -474,7 +473,8 @@ function(D, u, v)
   # add vertex w with combined labels from u and v
   NewDigraph := DigraphAddVertex(NewDigraph, [DigraphVertexLabel(D, u), DigraphVertexLabel(D, v)]); # add vertex w
 
-  w := Last(DigraphVertices(NewDigraph)); # w is the new vertix identifier 
+  vertices := DigraphVertices(D);
+  w := vertices[Length(vertices)]; # w is the new vertix identifier 
 
   # Handle loops from edges u or w, with the same source / range
   if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v) then NewDigraph := DigraphAddEdge(NewDigraph, w, w); SetDigraphEdgeLabel(NewDigraph, w, w, [DigraphEdgeLabel(D, u, u), DigraphEdgeLabel(D, v, v)]);
@@ -528,6 +528,16 @@ function(D, u, v)
 
   return NewDigraph;
 
+end);
+
+InstallMethod(DigraphContractEdge,
+"for a digraph and a list",
+[IsDigraph, IsList],
+function(D, edge)
+  if Length(edge) <> 2 then
+    ErrorNoReturn("the 2nd argument <edge> must be a list of length 2,");
+  fi;
+  return DigraphContractEdge(D, edge[1], edge[2]);
 end);
 
 #############################################################################

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -377,6 +377,159 @@ InstallMethod(DigraphClosure,
 [IsImmutableDigraph, IsPosInt],
 {D, k} -> MakeImmutable(DigraphClosure(DigraphMutableCopy(D), k)));
 
+InstallMethod(DigraphContractEdge,
+"for a mutable digraph and two positive integers",
+[IsMutableDigraph, IsPosInt, IsPosInt],
+function(D, u, v)
+  local w, neighbours, transformations_to_edge, transformations_to_old_edges, old_edge, new_edge, neighbour, t, copy;
+
+
+  if not IsDigraphEdge(D, u, v) then # Check if [u, v] is an edge in digraph D
+    ErrorNoReturn("u, v is not an edge of D");
+  fi;
+
+  if IsMultiDigraph(D) then # multi digraphs cannot have their edges contracted
+    ErrorNoReturn("Cannot contract an edge for a MultiDigraph");
+  fi;
+
+  if u = v then # check if u and v are equal, edge should not be contracted in this case
+    ErrorNoReturn("Cannot contract an edge with the same source and range");
+  fi;
+
+  if IsDigraphEdge(D, v, u) then # if (v, u) is an edge, disallow loops, so also remove (v, u)
+    DigraphRemoveEdge(D, v, u);
+    
+  fi;
+
+  # remove the contracted edge
+  DigraphRemoveEdge(D, u, v);
+
+  copy := DigraphImmutableCopy(D); # create a copy of the original digraph, with removed edges, to use as a reference for edge labels
+  neighbours := [InNeighboursOfVertex(copy, u), InNeighboursOfVertex(copy, v), OutNeighboursOfVertex(copy, u), OutNeighboursOfVertex(copy, v)];
+  
+  DigraphAddVertex(D, [DigraphVertexLabel(D, u), DigraphVertexLabel(D, v)]); # add vertex w
+
+  w := Last(DigraphVertices(D)); # w is the new vertix identifier 
+
+  # Handle loops from edges u or w, with the same source / range
+  if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v) then DigraphAddEdge(D, w, w); SetDigraphEdgeLabel(D, w, w, [DigraphEdgeLabel(copy, u, u), DigraphEdgeLabel(copy, v, v)]);
+  else 
+    if IsDigraphEdge(D, u, u) then DigraphAddEdge(D, w, w); SetDigraphEdgeLabel(D, w, w, DigraphEdgeLabel(copy, u, u)); 
+    else if IsDigraphEdge(D, v, v) then DigraphAddEdge(D, w, w); SetDigraphEdgeLabel(D, w, w, DigraphEdgeLabel(copy, v, v)); fi; fi; fi;
+
+  # translate edges based on neighbours
+
+  # transformation functions translating neighbours to their new edge
+  transformations_to_edge := [{x, y} -> [x, y], {x, y} -> [x, y], {x, y} -> [y, x], {x, y} -> [y, x]];
+  # transformation functions translating neighbours to their original edge in D
+  transformations_to_old_edges := [e -> [e, u], e -> [e, v], e -> [u, e], e -> [v, e]];
+
+
+  # Add translated new edges, and setup edge labels
+  for t in [1..Length(transformations_to_edge)] do
+    for neighbour in neighbours[t] do
+        new_edge := transformations_to_edge[t](neighbour, w);
+        old_edge := transformations_to_old_edges[t](neighbour); # old_edge is what the new transformed edge was previously
+        DigraphAddEdge(D, new_edge);
+        SetDigraphEdgeLabel(D, new_edge[1], new_edge[2], DigraphEdgeLabel(copy, old_edge[1], old_edge[2]));
+    od;
+  od;
+
+  DigraphRemoveVertices(D, [u, v]); # remove the vertices of the contracted edge (and therefore, all its incident edges)
+  
+end);
+
+
+InstallMethod(DigraphContractEdge,
+"for an immutable digraph and two positive integers",
+[IsImmutableDigraph, IsPosInt, IsPosInt],
+function(D, u, v)
+  local w, neighbours, transformations_to_edge, transformations_to_old_edges, existing_edges, edges_to_not_include, NewDigraph, new_edge, old_edge, neighbour, t;
+
+  if not IsDigraphEdge(D, u, v) then # Check if [u, v] is an edge in digraph D
+    ErrorNoReturn("u, v is not an edge of D");
+  fi;
+
+  if IsMultiDigraph(D) then # multi digraphs cannot have their edges contracted
+    ErrorNoReturn("Cannot contract an edge for a MultiDigraph");
+  fi;
+
+  if u = v then # check if u and v are equal, edge should not be contracted in this case
+    ErrorNoReturn("Cannot contract an edge with the same source and range");
+  fi;
+
+  edges_to_not_include := []; # Incident edges to [u, v] that will be transformed to be incident to w
+  existing_edges := []; # existing edges that should be re added
+
+  NewDigraph := DigraphByEdges([]); # edge should not be added to the new digraph
+  
+  if IsDigraphEdge(D, v, u) then # if (v, u) is an edge, disallow loops, so also remove (v, u)
+    D := DigraphRemoveEdge(D, v, u);
+  fi;
+
+  D := DigraphRemoveEdge(D, u, v); # remove the edge to be contracted
+
+  NewDigraph := DigraphAddVertices(NewDigraph, DigraphVertexLabels(D)); 
+
+  # add vertex w with combined labels from u and v
+  NewDigraph := DigraphAddVertex(NewDigraph, [DigraphVertexLabel(D, u), DigraphVertexLabel(D, v)]); # add vertex w
+
+  w := Last(DigraphVertices(NewDigraph)); # w is the new vertix identifier 
+
+  # Handle loops from edges u or w, with the same source / range
+  if IsDigraphEdge(D, u, u) and IsDigraphEdge(D, v, v) then NewDigraph := DigraphAddEdge(NewDigraph, w, w); SetDigraphEdgeLabel(NewDigraph, w, w, [DigraphEdgeLabel(D, u, u), DigraphEdgeLabel(D, v, v)]);
+  else 
+    if IsDigraphEdge(D, u, u) then NewDigraph := DigraphAddEdge(NewDigraph, w, w); SetDigraphEdgeLabel(NewDigraph, w, w, DigraphEdgeLabel(D, u, u)); 
+    else if IsDigraphEdge(D, v, v) then NewDigraph := DigraphAddEdge(NewDigraph, w, w); SetDigraphEdgeLabel(NewDigraph, w, w, DigraphEdgeLabel(D, v, v)); fi; fi; fi;
+
+  # if there were loops in D at the vertices u or w, don't include these edges, but include a new loop at w
+  Append(edges_to_not_include, [[u, u], [v, v]]);
+
+  # Find vertex neighbours of u and v to construct new incident edges of w
+
+  neighbours := [InNeighboursOfVertex(D, u), InNeighboursOfVertex(D, v), OutNeighboursOfVertex(D, u), OutNeighboursOfVertex(D, v)];
+
+  # translate edges based on neighbours
+
+  # transformation functions translating neighbours to their new edge
+  transformations_to_edge := [{x, y} -> [x, y], {x, y} -> [x, y], {x, y} -> [y, x], {x, y} -> [y, x]];
+  # transformation functions translating neighbours to their original edge in D
+  transformations_to_old_edges := [e -> [e, u], e -> [e, v], e -> [u, e], e -> [v, e]];
+
+  # remove edges that will be adjusted
+
+  for t in [1..Length(transformations_to_old_edges)] do
+    Append(edges_to_not_include, List(neighbours[t], transformations_to_old_edges[t]));
+  od;
+
+  # Find edges that should be included, but remain the same
+  Sort(edges_to_not_include);
+  Append(existing_edges, ShallowCopy(DigraphEdges(D)));
+  Sort(existing_edges);
+  SubtractSet(existing_edges, edges_to_not_include);
+      
+  # Add translated new edges, and setup edge labels
+  for t in [1..Length(transformations_to_edge)] do
+    for neighbour in neighbours[t] do
+        new_edge := transformations_to_edge[t](neighbour, w);
+        old_edge := transformations_to_old_edges[t](neighbour); # old_edge is what the new transformed edge was previously
+        NewDigraph := DigraphAddEdge(NewDigraph, new_edge);
+        SetDigraphEdgeLabel(NewDigraph, new_edge[1], new_edge[2], DigraphEdgeLabel(D, old_edge[1], old_edge[2]));
+    od;
+  od;
+
+  # Add the existing edges that have not changed, and set their edge labels to that of the previous digraph
+  for new_edge in existing_edges do
+    NewDigraph := DigraphAddEdge(NewDigraph, new_edge);
+    SetDigraphEdgeLabel(NewDigraph, new_edge[1], new_edge[2], DigraphEdgeLabel(D, new_edge[1], new_edge[2]));
+  od;
+
+  NewDigraph := DigraphRemoveVertices(NewDigraph, [u, v]); # remove the vertices of the contracted edge
+
+  return NewDigraph;
+
+end);
+
 #############################################################################
 # 3. Ways of combining digraphs
 #############################################################################

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -2897,6 +2897,286 @@ gap> List(res[2], x -> List(x));
 [ [ Z(2)^0, Z(2)^0, Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], 
   [ 0*Z(2), 0*Z(2), 0*Z(2), Z(2)^0, Z(2)^0, Z(2)^0, Z(2)^0 ] ]
 
+# DigraphContractEdge
+
+# DigraphContractEdge: multi digraphs
+gap> D := Digraph([[2, 3, 3], [2], [1]]);;
+gap> DigraphContractEdge(D, 1, 3);
+Error, Cannot contract an edge for a MultiDigraph
+
+# DigraphContractEdge: Edge does not exist
+gap> D := DigraphByEdges([[1, 2], [2, 1]]);;
+gap> DigraphContractEdge(D, 1, 3);
+Error, u, v is not an edge of D
+
+# DigraphContractEdge: Edge is a looped edge (u = v)
+gap> D := DigraphByEdges([[1, 1], [2, 1], [1, 2]]);;
+gap> DigraphVertexLabels(D);; 
+gap> C := DigraphContractEdge(D, 1, 1);
+Error, Cannot contract an edge with the same source and range
+gap> DigraphHasLoops(D);
+true
+gap> DigraphEdges(D);
+[ [ 1, 1 ], [ 2, 1 ], [ 1, 2 ] ]
+gap> DigraphVertexLabels(D);
+[ 1, 2 ]
+
+# DigraphContractEdge: Loop contracting to an empty Digraph
+gap> D := DigraphByEdges([[1, 2], [2, 1]]);;
+gap> SetDigraphVertexLabel(D, 1, "1");;
+gap> SetDigraphVertexLabel(D, 2, "2");;
+gap> C := DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(C);
+[  ]
+gap> DigraphVertices(C);
+[ 1 ]
+gap> DigraphVertexLabel(C, 1);
+[ "2", "1" ]
+
+# DigraphContractEdge: Double loop contracting, one edge result
+gap> D := DigraphByEdges([[1, 2], [1, 3], [2, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(C);
+[ [ 2, 1 ] ]
+gap> DigraphVertices(C);
+[ 1, 2 ]
+gap> DigraphVertexLabels(C);
+[ 3, [ 2, 1 ] ]
+
+# DigraphContractEdge: Loop contracting, leaving another loop remaining
+gap> D := DigraphByEdges([[1, 2], [1, 3], [3, 1], [2, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(C);
+[ [ 1, 2 ], [ 2, 1 ] ]
+gap> DigraphVertices(C);
+[ 1, 2 ]
+gap> DigraphVertexLabels(C);
+[ 3, [ 2, 1 ] ]
+
+# DigraphContractEdge: Test with a larger graph, vertex labels and an edge label, making sure D was not modified
+gap> D := DigraphByEdges([[2, 1], [1, 3], [3, 1], [4, 2], [4, 5], [3, 4], [5, 3]]);;
+gap> SetDigraphVertexLabels(D, ["1", "2", "3", "4", "5"]);;
+gap> SetDigraphEdgeLabel(D, 2, 1, "newlabel");
+gap> C := DigraphContractEdge(D, 3, 4);;
+gap> DigraphEdges(C);
+[ [ 1, 4 ], [ 2, 1 ], [ 3, 4 ], [ 4, 1 ], [ 4, 2 ], [ 4, 3 ] ]
+gap> DigraphVertexLabels(C);
+[ "1", "2", "5", [ "3", "4" ] ]
+gap> DigraphEdgeLabel(C, 2, 1);
+"newlabel"
+gap> DigraphEdges(D);
+[ [ 2, 1 ], [ 1, 3 ], [ 3, 1 ], [ 4, 2 ], [ 4, 5 ], [ 3, 4 ], [ 5, 3 ] ]
+gap> DigraphVertices(D);
+[ 1 .. 5 ]
+gap> DigraphVertexLabels(D);
+[ "1", "2", "3", "4", "5" ]
+
+# DigraphContractEdge: Test with a loop (u, u)
+gap> D := DigraphByEdges([[1, 2], [2, 3], [3, 4], [4, 1], [1, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, 1, 2);;
+gap> DigraphEdges(C);
+[ [ 1, 2 ], [ 2, 3 ], [ 3, 3 ], [ 3, 1 ] ]
+gap> DigraphVertices(C);
+[ 1 .. 3 ]
+gap> DigraphVertexLabels(C);
+[ 3, 4, [ 1, 2 ] ]
+
+# DigraphContractEdge: Test with a loop (w, w)
+gap> D := DigraphByEdges([[1, 2], [2, 3], [3, 4], [4, 1], [1, 1], [2, 1]]);;
+gap> C := DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(C);
+[ [ 1, 2 ], [ 2, 3 ], [ 3, 3 ], [ 3, 1 ] ]
+gap> DigraphVertices(C);
+[ 1 .. 3 ]
+
+# DigraphContractEdge: Test with a loop (w, w)
+gap> D := DigraphByEdges([[1, 2], [2, 3], [3, 4], [4, 1], [1, 1], [2, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(C);
+[ [ 1, 2 ], [ 2, 3 ], [ 3, 3 ], [ 3, 1 ] ]
+gap> DigraphVertices(C);
+[ 1 .. 3 ]
+gap> DigraphVertexLabels(C);
+[ 3, 4, [ 2, 1 ] ]
+
+# DigraphContractEdge: Test with a single edge (u, v)
+gap> D := DigraphByEdges([[1, 2]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, 1, 2);;
+gap> DigraphEdges(C);
+[  ]
+gap> DigraphVertices(C);
+[ 1 ]
+gap> DigraphVertexLabels(C);
+[ [ 1, 2 ] ]
+
+# DigraphContractEdge: Test with a single node, with one loop, and one incident edge
+gap> D := DigraphByEdges([[1, 1], [2, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(C);
+[ [ 1, 1 ] ]
+gap> DigraphVertices(C);
+[ 1 ]
+gap> DigraphVertexLabels(C);
+[ [ 2, 1 ] ]
+
+# DigraphContractEdge: Standard test
+gap> D := DigraphByEdges([[2, 1], [3, 1], [3, 4], [1, 4], [4, 2], [5, 2], [4, 5], [5, 5]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(C);
+[ [ 1, 4 ], [ 1, 2 ], [ 2, 4 ], [ 2, 3 ], [ 3, 4 ], [ 3, 3 ], [ 4, 2 ] ]
+gap> DigraphVertices(C);
+[ 1 .. 4 ]
+gap> DigraphVertexLabels(C);
+[ 3, 4, 5, [ 2, 1 ] ]
+
+# DigraphContractEdge: Disconnected test
+gap> D := DigraphByEdges([[1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 2], [4, 4], [4, 5], [4, 6], [5, 5], [5, 4]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, 4, 5);;
+gap> DigraphEdges(C);
+[ [ 1, 2 ], [ 1, 3 ], [ 2, 1 ], [ 2, 2 ], [ 2, 3 ], [ 3, 2 ], [ 5, 5 ], 
+  [ 5, 4 ] ]
+gap> DigraphVertexLabels(C);
+[ 1, 2, 3, 6, [ 4, 5 ] ]
+
+# DigraphContractEdge: MultiDigraph (mutable)
+gap> D := Digraph(IsMutableDigraph, [[2, 3, 3], [2], [1]]);;
+gap> DigraphContractEdge(D, 1, 3);
+Error, Cannot contract an edge for a MultiDigraph
+
+# DigraphContractEdge: Edge does not exist (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1]]);;
+gap> DigraphContractEdge(D, 1, 3);
+Error, u, v is not an edge of D
+
+# DigraphContractEdge: Edge is a looped edge (u = v) (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 1], [2, 1], [1, 2]]);;
+gap> DigraphVertexLabels(D);; 
+gap> DigraphContractEdge(D, 1, 1);
+Error, Cannot contract an edge with the same source and range
+gap> DigraphHasLoops(D);
+true
+gap> DigraphEdges(D);
+[ [ 1, 1 ], [ 1, 2 ], [ 2, 1 ] ]
+gap> DigraphVertexLabels(D);
+[ 1, 2 ]
+
+# DigraphContractEdge: Loop contracting to an empty Digraph (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1]]);;
+gap> SetDigraphVertexLabel(D, 1, "1");;
+gap> SetDigraphVertexLabel(D, 2, "2");;
+gap> DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(D);
+[  ]
+gap> DigraphVertices(D);
+[ 1 ]
+gap> DigraphVertexLabel(D, 1);
+[ "2", "1" ]
+
+# DigraphContractEdge: Double loop contracting, one edge result (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [1, 3], [2, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(D);
+[ [ 2, 1 ] ]
+gap> DigraphVertices(D);
+[ 1, 2 ]
+gap> DigraphVertexLabels(D);
+[ 3, [ 2, 1 ] ]
+
+# DigraphContractEdge: Loop contracting, leaving another loop remaining (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [1, 3], [3, 1], [2, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(D);
+[ [ 1, 2 ], [ 2, 1 ] ]
+gap> DigraphVertices(D);
+[ 1, 2 ]
+gap> DigraphVertexLabels(D);
+[ 3, [ 2, 1 ] ]
+
+# DigraphContractEdge: Test with a larger graph, vertex labels and an edge label (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[2, 1], [1, 3], [3, 1], [4, 2], [4, 5], [3, 4], [5, 3]]);;
+gap> SetDigraphVertexLabels(D, ["1", "2", "3", "4", "5"]);;
+gap> SetDigraphEdgeLabel(D, 2, 1, "newlabel");
+gap> DigraphContractEdge(D, 3, 4);;
+gap> DigraphEdges(D);
+[ [ 1, 4 ], [ 2, 1 ], [ 3, 4 ], [ 4, 1 ], [ 4, 2 ], [ 4, 3 ] ]
+gap> DigraphVertexLabels(D);
+[ "1", "2", "5", [ "3", "4" ] ]
+gap> DigraphEdgeLabel(D, 2, 1);
+"newlabel"
+
+# DigraphContractEdge: Test with a loop (u, u) (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 3], [3, 4], [4, 1], [1, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, 1, 2);;
+gap> DigraphEdges(D);
+[ [ 1, 2 ], [ 2, 3 ], [ 3, 3 ], [ 3, 1 ] ]
+gap> DigraphVertices(D);
+[ 1 .. 3 ]
+gap> DigraphVertexLabels(D);
+[ 3, 4, [ 1, 2 ] ]
+
+# DigraphContractEdge: Test with a loop (w, w) (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 3], [3, 4], [4, 1], [1, 1], [2, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(D);
+[ [ 1, 2 ], [ 2, 3 ], [ 3, 3 ], [ 3, 1 ] ]
+gap> DigraphVertices(D);
+[ 1 .. 3 ]
+gap> DigraphVertexLabels(D);
+[ 3, 4, [ 2, 1 ] ]
+
+# DigraphContractEdge: Test with a single edge (u, v) (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, 1, 2);;
+gap> DigraphEdges(D);
+[  ]
+gap> DigraphVertices(D);
+[ 1 ]
+gap> DigraphVertexLabels(D);
+[ [ 1, 2 ] ]
+
+# DigraphContractEdge: Test with a single node, with one loop, and one incident edge (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 1], [2, 1]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(D);
+[ [ 1, 1 ] ]
+gap> DigraphVertices(D);
+[ 1 ]
+gap> DigraphVertexLabels(D);
+[ [ 2, 1 ] ]
+
+# DigraphContractEdge: Standard test (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[2, 1], [3, 1], [3, 4], [1, 4], [4, 2], [5, 2], [4, 5], [5, 5]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(D);
+[ [ 1, 2 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], [ 3, 3 ], [ 3, 4 ], [ 4, 2 ] ]
+gap> DigraphVertexLabels(D);
+[ 3, 4, 5, [ 2, 1 ] ]
+
+# DigraphContractEdge: Disconnected test (mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 2], [4, 4], [4, 5], [4, 6], [5, 5], [5, 4]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, 4, 5);;
+gap> DigraphEdges(D);
+[ [ 1, 2 ], [ 1, 3 ], [ 2, 1 ], [ 2, 2 ], [ 2, 3 ], [ 3, 2 ], [ 5, 5 ], 
+  [ 5, 4 ] ]
+gap> DigraphVertexLabels(D);
+[ 1, 2, 3, 6, [ 4, 5 ] ]
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(C);
 gap> Unbind(D);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -2899,6 +2899,11 @@ gap> List(res[2], x -> List(x));
 
 # DigraphContractEdge
 
+# DigraphContractEdge: wrong length list
+gap> D := Digraph([[2, 3, 3], [2], [1]]);;
+gap> DigraphContractEdge(D, [1]);
+Error, the 2nd argument <edge> must be a list of length 2
+
 # DigraphContractEdge: multi digraphs
 gap> D := Digraph([[2, 3, 3], [2], [1]]);;
 gap> DigraphContractEdge(D, 1, 3);
@@ -3036,6 +3041,17 @@ gap> DigraphVertices(C);
 gap> DigraphVertexLabels(C);
 [ 3, 4, 5, [ 2, 1 ] ]
 
+# DigraphContractEdge: Standard test (list)
+gap> D := DigraphByEdges([[2, 1], [3, 1], [3, 4], [1, 4], [4, 2], [5, 2], [4, 5], [5, 5]]);;
+gap> DigraphVertexLabels(D);;
+gap> C := DigraphContractEdge(D, [2, 1]);;
+gap> DigraphEdges(C);
+[ [ 1, 4 ], [ 1, 2 ], [ 2, 4 ], [ 2, 3 ], [ 3, 4 ], [ 3, 3 ], [ 4, 2 ] ]
+gap> DigraphVertices(C);
+[ 1 .. 4 ]
+gap> DigraphVertexLabels(C);
+[ 3, 4, 5, [ 2, 1 ] ]
+
 # DigraphContractEdge: Disconnected test
 gap> D := DigraphByEdges([[1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 2], [4, 4], [4, 5], [4, 6], [5, 5], [5, 4]]);;
 gap> DigraphVertexLabels(D);;
@@ -3045,6 +3061,11 @@ gap> DigraphEdges(C);
   [ 5, 4 ] ]
 gap> DigraphVertexLabels(C);
 [ 1, 2, 3, 6, [ 4, 5 ] ]
+
+# DigraphContractEdge: wrong length list (mutable
+gap> D := Digraph(IsMutableDigraph, [[2, 3, 3], [2], [1]]);;
+gap> DigraphContractEdge(D, [1]);
+Error, the 2nd argument <edge> must be a list of length 2
 
 # DigraphContractEdge: MultiDigraph (mutable)
 gap> D := Digraph(IsMutableDigraph, [[2, 3, 3], [2], [1]]);;
@@ -3162,6 +3183,15 @@ gap> DigraphVertexLabels(D);
 gap> D := DigraphByEdges(IsMutableDigraph, [[2, 1], [3, 1], [3, 4], [1, 4], [4, 2], [5, 2], [4, 5], [5, 5]]);;
 gap> DigraphVertexLabels(D);;
 gap> DigraphContractEdge(D, 2, 1);;
+gap> DigraphEdges(D);
+[ [ 1, 2 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], [ 3, 3 ], [ 3, 4 ], [ 4, 2 ] ]
+gap> DigraphVertexLabels(D);
+[ 3, 4, 5, [ 2, 1 ] ]
+
+# DigraphContractEdge: Standard test (list, mutable)
+gap> D := DigraphByEdges(IsMutableDigraph, [[2, 1], [3, 1], [3, 4], [1, 4], [4, 2], [5, 2], [4, 5], [5, 5]]);;
+gap> DigraphVertexLabels(D);;
+gap> DigraphContractEdge(D, [2, 1]);;
 gap> DigraphEdges(D);
 [ [ 1, 2 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], [ 3, 3 ], [ 3, 4 ], [ 4, 2 ] ]
 gap> DigraphVertexLabels(D);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -2907,18 +2907,19 @@ Error, the 2nd argument <edge> must be a list of length 2
 # DigraphContractEdge: multi digraphs
 gap> D := Digraph([[2, 3, 3], [2], [1]]);;
 gap> DigraphContractEdge(D, 1, 3);
-Error, Cannot contract an edge for a MultiDigraph
+Error, The 1st argument (a digraph) must not satisfy IsMultiDigraph
 
 # DigraphContractEdge: Edge does not exist
 gap> D := DigraphByEdges([[1, 2], [2, 1]]);;
 gap> DigraphContractEdge(D, 1, 3);
-Error, u, v is not an edge of D
+Error, expected an edge between the 2nd and 3rd arguments (vertices) 1 and 
+3 but found none
 
 # DigraphContractEdge: Edge is a looped edge (u = v)
 gap> D := DigraphByEdges([[1, 1], [2, 1], [1, 2]]);;
 gap> DigraphVertexLabels(D);; 
 gap> C := DigraphContractEdge(D, 1, 1);
-Error, Cannot contract an edge with the same source and range
+Error, The 2nd argument <u> must not be equal to the 3rd argument <v>
 gap> DigraphHasLoops(D);
 true
 gap> DigraphEdges(D);
@@ -3070,18 +3071,19 @@ Error, the 2nd argument <edge> must be a list of length 2
 # DigraphContractEdge: MultiDigraph (mutable)
 gap> D := Digraph(IsMutableDigraph, [[2, 3, 3], [2], [1]]);;
 gap> DigraphContractEdge(D, 1, 3);
-Error, Cannot contract an edge for a MultiDigraph
+Error, The 1st argument (a digraph) must not satisfy IsMultiDigraph
 
 # DigraphContractEdge: Edge does not exist (mutable)
 gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1]]);;
 gap> DigraphContractEdge(D, 1, 3);
-Error, u, v is not an edge of D
+Error, expected an edge between the 2nd and 3rd arguments (vertices) 1 and 
+3 but found none
 
 # DigraphContractEdge: Edge is a looped edge (u = v) (mutable)
 gap> D := DigraphByEdges(IsMutableDigraph, [[1, 1], [2, 1], [1, 2]]);;
 gap> DigraphVertexLabels(D);; 
 gap> DigraphContractEdge(D, 1, 1);
-Error, Cannot contract an edge with the same source and range
+Error, The 2nd argument <u> must not be equal to the 3rd argument <v>
 gap> DigraphHasLoops(D);
 true
 gap> DigraphEdges(D);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -429,7 +429,21 @@ gap> DigraphRemoveEdge(D, 1, 2);;
 gap> DigraphEdgeLabels(D);
 [ [ 1 ], [ 1 ], [ 1 ], [ 1 ] ]
 
+# DigraphContractEdge
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1]]);
+<mutable digraph with 2 vertices, 2 edges>
+gap> DigraphContractEdge(D, 2, 1);
+gap> DigraphEdges(D);
+[  ]
+gap> D := DigraphByEdges([[1, 2], [2, 1], [2, 3]]);
+<immutable digraph with 3 vertices, 3 edges>
+gap> C := DigraphContractEdge(D, 2, 1);
+<immutable digraph with 2 vertices, 1 edge>
+gap> DigraphEdges(C);
+[ [ 2, 1 ] ]
+
 #  DIGRAPHS_UnbindVariables
+gap> Unbind(C);
 gap> Unbind(D);
 gap> Unbind(adj);
 gap> Unbind(d);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -432,7 +432,7 @@ gap> DigraphEdgeLabels(D);
 # DigraphContractEdge
 gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1]]);
 <mutable digraph with 2 vertices, 2 edges>
-gap> DigraphContractEdge(D, 2, 1);
+gap> DigraphContractEdge(D, 2, 1);;
 gap> DigraphEdges(D);
 [  ]
 gap> D := DigraphByEdges([[1, 2], [2, 1], [2, 3]]);


### PR DESCRIPTION
Initial implementation of ContractEdge (see [Contract Edge Wikipedia Article](https://en.wikipedia.org/wiki/Edge_contraction); as discussed, this implementation should not create multiple edges). Mutable and Immutable methods exist for this. 

Edge labels should be handled if `DigraphRemoveEdge` were removing them, but this has not been tested yet because of this issue. 

Contract edge takes a non looping edge `(u, v)`, and contracts this into a single vertex `w`. The edge is removed, vertex labels are combined (in a list), and incident edges to `(u, v)` become incident to `w`. `MultiDigraphs` are not accepted into this function. If an edge `(v, u)` exists, this is also contracted (removed). 

Documentation has not been written yet (this is in progress). 