### PR TITLE
Fix Issue #617: DigraphRemoveEdge now removes appropriate edge label

### DIFF
--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -241,7 +241,7 @@ function(D, src, ran)
   pos := Position(D!.OutNeighbours[src], ran);
   if pos <> fail then
     Remove(D!.OutNeighbours[src], pos);
-    Remove(DigraphEdgeLabels(D)[src], pos);
+    RemoveDigraphEdgeLabel(D, src, pos);
   fi;
   return D;
 end);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -416,6 +416,19 @@ gap> d := EdgeWeightedDigraph([[2], [1]], [[5], [10]]);
 gap> EdgeWeights(d);
 [ [ 5 ], [ 10 ] ]
 
+# Issue 617: bug in DigraphRemoveEdge, wasn't removing edge labels
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 3], [3, 4], [4, 1], [1, 1]]);;
+gap> DigraphEdgeLabels(D);
+[ [ 1, 1 ], [ 1 ], [ 1 ], [ 1 ] ]
+gap> DigraphRemoveEdge(D, [1, 2]);;
+gap> DigraphEdgeLabels(D);
+[ [ 1 ], [ 1 ], [ 1 ], [ 1 ] ]
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 3], [3, 4], [4, 1], [1, 1]]);;
+gap> SetDigraphEdgeLabel(D, 1, 2, "test");
+gap> DigraphRemoveEdge(D, 1, 2);;
+gap> DigraphEdgeLabels(D);
+[ [ 1 ], [ 1 ], [ 1 ], [ 1 ] ]
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(D);
 gap> Unbind(adj);


### PR DESCRIPTION
Quick fix for #617.  Thanks to @saffronmciver for the report!

Fun fact: this fix involved removing 5 characters and adding 1 character.