### PR TITLE
Revert "build(deps): bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           GAP_TESTFILE: "tst/github_actions/extreme.g"
       - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
 
   test-cygwin:
     name: "cygwin / GAP master"
@@ -98,7 +98,7 @@ jobs:
           tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
       - uses: gap-actions/run-pkg-tests@cygwin-v2
       - uses: gap-actions/process-coverage@cygwin-v2
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
 
   with-external-planarity-bliss:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
This reverts commit b5f1306f6cdcf7d6b2a904d890192f5e1475e6be. Which hopefully (!?) will fix the cygwin ci job that seems to almost always time out now.