### PR TITLE
Resolve issue #676

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1395,7 +1395,7 @@ InstallMethod(DigraphAllSimpleCircuits, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 function(D)
   local UNBLOCK, CIRCUIT, out, stack, endofstack, C, scc, n, blocked, B,
-  c_comp, comp, s, loops, i;
+  c_comp, comp, s, loops, i, d_labels, c_labels;
 
   if IsEmptyDigraph(D) then
     return [];
@@ -1455,9 +1455,15 @@ function(D)
   # Reduce the D, remove loops, and store the correct vertex labels
   C := DigraphRemoveLoops(ReducedDigraph(DigraphMutableCopyIfMutable(D)));
   MakeImmutable(C);
-  if DigraphVertexLabels(D) <> DigraphVertices(D) then
-    SetDigraphVertexLabels(C, Filtered(DigraphVertices(D),
-                                       x -> OutDegrees(D) <> 0));
+  if HaveVertexLabelsBeenAssigned(D)
+      and DigraphVertexLabels(D) <> DigraphVertices(D) then
+    # We require the labels of the digraph <C> to be the original nodes in <D>
+    # (this is used in CIRCUIT above). If <D> has other vertex labels, then
+    # these are copied into <C> by the functions above, and aren't then
+    # necessarily the original nodes in <D>.
+    d_labels := DigraphVertexLabels(D);
+    c_labels := List(DigraphVertexLabels(C), x -> Position(d_labels, x));
+    SetDigraphVertexLabels(C, c_labels);
   fi;
 
   # Strongly connected components of the reduced graph

--- a/gap/labels.gd
+++ b/gap/labels.gd
@@ -13,6 +13,7 @@
 #  Get vertex labels
 DeclareOperation("DigraphVertexLabel", [IsDigraph, IsPosInt]);
 DeclareOperation("DigraphVertexLabels", [IsDigraph]);
+DeclareOperation("HaveVertexLabelsBeenAssigned", [IsDigraph]);
 
 #  Set vertex labels
 DeclareOperation("SetDigraphVertexLabel", [IsDigraph, IsPosInt, IsObject]);

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -46,6 +46,9 @@ function(D, v)
                 "is not a vertex of the digraph <D> that is the 1st argument");
 end);
 
+InstallMethod(HaveVertexLabelsBeenAssigned, "for a digraph", [IsDigraph],
+D -> IsBound(D!.vertexlabels));
+
 InstallMethod(RemoveDigraphVertexLabel, "for a digraph and positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)


### PR DESCRIPTION
Properly transfer the original vertices as labels of the vertices in the reduced graph in `DigraphAllSimpleCircuits`.