### PR TITLE
Fix startup bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
-.ipynb_checkpoints
+*.DS_Store
+*.Plo
+*.Tpo
 *.a
 *.aux
 *.bbl
 *.blg
 *.brf
 *.digraphs
-*.DS_Store
 *.dylib
 *.g6
 *.gcda
@@ -23,7 +24,6 @@
 *.o
 *.out
 *.pdf
-*.Plo
 *.pnr
 *.pyc
 *.six
@@ -35,11 +35,12 @@
 *.tex
 *.toc
 *.top
-*.Tpo
 *.tui
 *.txt
+.ipynb_checkpoints
 /doc/*.css
 /doc/*.js
+Makefile
 aclocal.m4
 autom4te.*
 bin/
@@ -50,9 +51,9 @@ coverage
 depcomp
 digraphs-config.h
 digraphs-lib
+doc/_*.xml
 gen/
 gh-pages/
-Makefile
 manual.lab
 missing
 src/pkgconfig.h.in

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -25,6 +25,10 @@ _STANDREWSMATHS := Concatenation(["Mathematical Institute, North Haugh, ",
 _STANDREWSCS := Concatenation(["Jack Cole Building, North Haugh, ",
                                "St Andrews, Fife, KY16 9SX, Scotland"]);
 
+if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
+  IsKernelExtensionAvailable := fail;
+fi;
+
 SetPackageInfo(rec(
 PackageName := "Digraphs",
 Subtitle := "Graphs, digraphs, and multidigraphs in GAP",
@@ -444,6 +448,8 @@ AvailabilityTest := function()
                                  "the package cannot be loaded."]);
       return fail;
     fi;
+    # Stop GAP from erroring that IsKernelExtensionAvailable is not a bound
+    # global in the next line.
   fi;
   return true;
 end,
@@ -452,3 +458,7 @@ Autoload := false,
 TestFile := "tst/teststandard.g",
 Keywords := []
 ));
+
+if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
+  Unbind(IsKernelExtensionAvailable);
+fi;


### PR DESCRIPTION
In release v1.8.0 we didn't increase the required version of GAP but we did start using `IsKernelExtensionAvailable` which was introduced in GAP 4.12. This lead to start up errors on versions of GAP earlier than 4.12, due to "unbound global variable" warnings.
