### PR TITLE
Clarify homomorphisms finder with specified image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 /doc/*.css
 /doc/*.js
 Makefile
+_*.xml
 aclocal.m4
 autom4te.*
 bin/
@@ -54,9 +55,9 @@ digraphs-lib
 doc/_*.xml
 gen/
 gh-pages/
+main.xml
 manual.lab
 missing
 src/pkgconfig.h.in
 tags
 tst/out/
-_*.xml

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -95,7 +95,20 @@
         This argument should be a subset of the vertices of the graph <A>D2</A>.
         <C>HomomorphismDigraphsFinder</C> only finds homomorphisms from
         <A>D1</A> to the subgraph of <A>D2</A> induced by the vertices
-        <A>image</A>.
+        <A>image</A>.<P/>
+
+        The returned homomorphisms (if any) are still "up to the action" of the
+        group specified by <A>aut_grp</A> (which is the entire automorphism
+        group by default). This might generate unexpected results. For example,
+        if <A>D1</A> has automorphism group where one orbit consists of, say,
+        <C>1</C> and <C>2</C>, then <C>HomomorphismDigraphsFinder</C> will only
+        attempt to find homomorphisms mapping <C>1</C> to <C>1</C>, and if
+        there are no such homomorphisms with image set equal to <A>image</A>,
+        then no homomorphisms will be returned (even if there is a homomorphism
+        from <A>D1</A> to <A>D2</A> mapping <C>1</C> to <C>2</C>). To ensure that
+        that <B>all</B> homomorphisms with image set equal to <A>image</A> are
+        considered it is necessary for the last argument <A>aut_grp</A> to be
+        the trivial permutation group.
       </Item>
 
       <Mark><A>partial_map</A></Mark>
@@ -133,6 +146,7 @@
         idea for this to be the <Ref Attr="DigraphWelshPowellOrder"/>, i.e.
         vertices ordered from highest to lowest degree.
       </Item>
+      <Mark><A>aut_grp</A></Mark>
       <Item>
         The optional argument <A>aut_grp</A> should be a subgroup of the
         automorphism group of <A>D2</A>. This function returns unique
@@ -149,6 +163,10 @@ gap> D := DigraphSymmetricClosure(D);
 <immutable symmetric digraph with 10 vertices, 18 edges>
 gap> HomomorphismDigraphsFinder(D, D, fail, [], infinity, 2, 0,
 > [3, 4], [], fail, fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset
+of the vertices of the target digraph. This might lead to unexpected
+results! If this happens, try passing Group(()) as the last argument.
+Please see the documentation of HomomorphismDigraphsFinder for details.
 [ Transformation( [ 3, 4, 3, 4, 3, 4, 3, 4, 3, 4 ] ),
   Transformation( [ 4, 3, 4, 3, 4, 3, 4, 3, 4, 3 ] ) ]
 gap> D2 := CompleteDigraph(6);;

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -648,14 +648,27 @@ gap> EmbeddingsDigraphs(D1, D2);
     A permutation or transformation <A>x</A> is a <E>homomorphism</E> from a
     digraph <A>src</A> to a digraph <A>ran</A> if the following hold:
     <List>
-      <Item>
-        <C>[u ^ <A>x</A>, v ^ <A>x</A>]</C> is an edge of
-        <A>ran</A> whenever <C>[u, v]</C> is an
-        edge of <A>src</A>; and </Item>
-      <Item>
-        <A>x</A> fixes every <C>i</C> which is not a vertex of <A>src</A>.
-      </Item>
+    <Item>
+    <C>[u ^ <A>x</A>, v ^
+    <A>x</A>]</C> is an edge of <A>ran</A> whenever <C>[u, v]</C> is an edge of
+    <A>src</A>; and
+    </Item>
+    <Item>
+    <A>x</A> maps the vertices of <A>src</A> to a subset of the vertices of
+    <A>ran</A>, i.e. <C>IsSubset(DigraphVertices(<A>ran</A>),
+    OnSets(DigraphVertices(<A>src</A>), <A>x</A>))</C> is <K>true</K>.
+    </Item>
     </List>
+
+    Note that if <C>i</C> is any integer greater than
+    <C>DigraphNrVertice(<A>src</A>)</C>, then the action of <A>x</A> on
+    <C>i</C> is ignored by this function. One consequence of this is that
+    distinct transformations or permutations might represent the same
+    homomorphism. For example, if <A>src</A> and <A>ran</A> are
+    <C>CycleDigraph(2)</C>, then both the permutations <C>(1, 2)</C> and <C>(1,
+    2)(3, 4)</C> represent the same automorphism of <A>src</A>.
+    <P/>
+
     See also <Ref Func="GeneratorsOfEndomorphismMonoid"/>.<P/>
 
 

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -814,7 +814,7 @@ true
 gap> IsDigraphAutomorphism(src, (2, 3), [2, 2, 1]);
 false
 gap> IsDigraphAutomorphism(src, (2, 3)(4, 5));
-false
+true
 gap> IsDigraphAutomorphism(src, (1, 4));
 false
 gap> IsDigraphAutomorphism(src, ());

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -362,7 +362,8 @@ function(H, G)
                                [],                  # partial_map
                                fail,                # colors1
                                fail,                # colors2
-                               DigraphWelshPowellOrder(H));
+                               DigraphWelshPowellOrder(H),
+                               Group(()));
     if Length(map) <> 0 then
       Add(result, map[1]);
     fi;

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -576,7 +576,7 @@ function(src, ran, x)
   if IsMultiDigraph(src) or IsMultiDigraph(ran) then
     ErrorNoReturn("the 1st and 2nd arguments <src> and <ran> must be digraphs",
                   " with no multiple edges,");
-  elif LargestMovedPoint(x) > DigraphNrVertices(src) then
+  elif not IsSubset(DigraphVertices(ran), OnSets(DigraphVertices(src), x)) then
     return false;
   fi;
   for i in DigraphVertices(src) do

--- a/src/bitarray.c
+++ b/src/bitarray.c
@@ -33,7 +33,7 @@
 ////////////////////////////////////////////////////////////////////////
 
 bool     LOOKUPS_INITIALISED = false;
-size_t*  NR_BLOCKS_LOOKUP   = NULL;
+size_t*  NR_BLOCKS_LOOKUP    = NULL;
 size_t*  QUOTIENT_LOOKUP     = NULL;
 size_t*  REMAINDER_LOOKUP    = NULL;
 Block*   MASK_LOOKUP         = NULL;
@@ -113,7 +113,7 @@ BitArray* new_bit_array(uint16_t const nr_bits) {
   bit_array->nr_bits = nr_bits;
   bit_array->nr_blocks =
       ((nr_bits % NR_BITS_PER_BLOCK) == 0 ? nr_bits / NR_BITS_PER_BLOCK
-                                           : nr_bits / NR_BITS_PER_BLOCK + 1);
+                                          : nr_bits / NR_BITS_PER_BLOCK + 1);
   bit_array->blocks = safe_calloc(bit_array->nr_blocks, NR_BITS_PER_BLOCK);
 
   return bit_array;
@@ -141,6 +141,7 @@ void set_bit_array_from_gap_list(BitArray* const bit_array, Obj list_obj) {
     return;
   }
   init_bit_array(bit_array, false, bit_array->nr_bits);
+  // TODO assert that bit_array->nr_bits > LEN_LIST(list_obj)?
   for (int i = 1; i <= LEN_LIST(list_obj); i++) {
     if (ISB_LIST(list_obj, i)) {
       set_bit_array_from_gap_int(bit_array, ELM_LIST(list_obj, i));

--- a/src/bitarray.h
+++ b/src/bitarray.h
@@ -195,4 +195,5 @@ void set_bit_array_from_gap_int(BitArray* const bit_array, Obj o);
 //! plain or dense).
 void set_bit_array_from_gap_list(BitArray* const bit_array, Obj list_obj);
 
+// void print_bit_array(BitArray const* const bit_array);
 #endif  //  DIGRAPHS_SRC_BITARRAY_H_

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -57,6 +57,7 @@ Obj IsSubset;
 Obj OnTuples;
 Obj Group;
 Obj ClosureGroup;
+Obj InfoWarning;
 
 static inline bool IsAttributeStoringRep(Obj o) {
   return (CALL_1ARGS(IsAttributeStoringRepObj, o) == True ? true : false);
@@ -2195,6 +2196,7 @@ static Int InitKernel(StructInitInfo* module) {
   ImportGVarFromLibrary("OnTuples", &OnTuples);
   ImportGVarFromLibrary("Group", &Group);
   ImportGVarFromLibrary("ClosureGroup", &ClosureGroup);
+  ImportGVarFromLibrary("InfoWarning", &InfoWarning);
   /* return success                                                      */
   return 0;
 }

--- a/src/digraphs.h
+++ b/src/digraphs.h
@@ -33,5 +33,6 @@ extern Obj GeneratorsOfGroup;
 extern Obj IsDigraph;
 extern Obj IsMultiDigraph;
 extern Obj IsDigraphEdge;
+extern Obj InfoWarning;
 
 #endif  // DIGRAPHS_SRC_DIGRAPHS_H_

--- a/src/homos.c
+++ b/src/homos.c
@@ -2205,8 +2205,8 @@ Obj FuncHomomorphismDigraphsFinder(Obj self, Obj args) {
       Obj msg = MakeImmString(
           "WARNING you are trying to find homomorphisms by specifying a "
           "subset of the vertices of the target digraph. This might lead "
-          "to unexpect results! If this happens, try passing Group(()) as the "
-          "last argument. Please see the documentation of "
+          "to unexpected results! If this happens, try passing Group(()) as "
+          "the last argument. Please see the documentation of "
           "HomomorphismDigraphsFinder for details.");
       Obj info_args = NEW_PLIST(T_PLIST, 1);
       SET_ELM_PLIST(info_args, 1, msg);

--- a/src/homos.c
+++ b/src/homos.c
@@ -1931,9 +1931,10 @@ static bool init_data_from_args(Obj digraph1_obj,
 //                      group will be used.
 
 Obj FuncHomomorphismDigraphsFinder(Obj self, Obj args) {
-  if (LEN_PLIST(args) != 11 && LEN_PLIST(args) != 12 && LEN_PLIST(args) != 13) {
-    ErrorQuit(
-        "there must be 11 or 12 arguments, found %d,", LEN_PLIST(args), 0L);
+  if (LEN_PLIST(args) < 11 || LEN_PLIST(args) > 13) {
+    ErrorQuit("there must be 11, 12, or 13 arguments, found %d,",
+              LEN_PLIST(args),
+              0L);
   }
   Obj digraph1_obj    = ELM_PLIST(args, 1);
   Obj digraph2_obj    = ELM_PLIST(args, 2);

--- a/src/homos.c
+++ b/src/homos.c
@@ -1748,6 +1748,7 @@ static bool init_data_from_args(Obj digraph1_obj,
   set_bit_array_from_gap_list(IMAGE_RESTRICT, image_obj);
   if (INT_INTOBJ(injective_obj) > 0
       && size_bit_array(IMAGE_RESTRICT, nr1) < nr1) {
+    // TODO shouldn't the first nr1 be nr2?
     // homomorphisms should be injective (by injective_obj) but are not since
     // the image is too restricted.
     return false;

--- a/src/perms.c
+++ b/src/perms.c
@@ -25,34 +25,29 @@ Perm new_perm(uint16_t const degree) {
 }
 
 Perm new_perm_from_gap(Obj gap_perm_obj, uint16_t const degree) {
-  UInt lmp = LargestMovedPointPerm(gap_perm_obj);
-  DIGRAPHS_ASSERT(lmp <= MAXVERTS);
-  if (lmp > MAXVERTS) {
-    ErrorQuit("expected permutations of degree at most %d, but got a "
-              "permutation of degree %d",
-              MAXVERTS,
-              lmp);
-  }
-
-  DIGRAPHS_ASSERT(lmp <= degree);
-
   Perm p = new_perm(degree > 0 ? degree : 1);
+
+  size_t copy_up_to = degree;
+  size_t lmp        = LargestMovedPointPerm(gap_perm_obj);
+  if (degree > lmp) {
+    copy_up_to = lmp;
+  }
 
   if (IS_PERM2(gap_perm_obj)) {
     UInt2* gap_perm_ptr = ADDR_PERM2(gap_perm_obj);
-    for (UInt i = 0; i < lmp; ++i) {
+    for (UInt i = 0; i < copy_up_to; ++i) {
       p[i] = gap_perm_ptr[i];
     }
-    for (UInt i = lmp; i < degree; ++i) {
+    for (UInt i = copy_up_to; i < degree; ++i) {
       p[i] = i;
     }
   } else {
     DIGRAPHS_ASSERT(IS_PERM4(gap_perm_obj));
     UInt4* gap_perm_ptr = ADDR_PERM4(gap_perm_obj);
-    for (UInt i = 0; i < lmp; ++i) {
+    for (UInt i = 0; i < copy_up_to; ++i) {
       p[i] = gap_perm_ptr[i];
     }
-    for (UInt i = lmp; i < degree; ++i) {
+    for (UInt i = copy_up_to; i < degree; ++i) {
       p[i] = i;
     }
   }

--- a/tst/extreme/grahom.tst
+++ b/tst/extreme/grahom.tst
@@ -29,8 +29,10 @@ gap> Size(Semigroup(gens));
 105120
 gap> HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, 0,
 > [1, 14, 28, 39, 42], [], fail, fail);;
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 gap> str := HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, 0,
 > [1, 14, 28, 39, 42], [], fail, fail);;
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 gap> Length(str);
 192
 
@@ -424,12 +426,14 @@ gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 25, 0, [1 .. 40],
       37, 38 ] ) ]
 gap> t := HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 23, 0,
 > [4 .. 37], [], fail, fail, DigraphWelshPowellOrder(gr1))[1];
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 Transformation( [ 15, 11, 4, 7, 4, 9, 6, 17, 11, 31, 10, 7, 25, 9, 26, 22, 29,
  8, 21, 27, 25, 25, 30, 19, 18, 13, 16, 8, 5, 32, 31, 32 ] )
 gap> ForAll(DigraphEdges(gr1), e -> IsDigraphEdge(gr2, [e[1] ^ t, e[2] ^ t]));
 true
 gap> t := HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 23, 0,
 > [6 .. 37], [], fail, fail, DigraphWelshPowellOrder(gr1))[1];
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 Transformation( [ 13, 20, 6, 30, 25, 24, 6, 23, 17, 30, 14, 9, 29, 11, 19, 28,
  13, 34, 32, 7, 9, 10, 18, 15, 12, 21, 7, 11, 37, 19, 31, 32, 33, 34, 35, 36,
   37 ] )

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -79,6 +79,7 @@ gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 1, 1, [],
 Error, the 9th argument <partial_map> is too long, must be at most 2, found 4,
 gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 1, 1, [1], [1],
 > fail, fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> HomomorphismDigraphsFinder(CompleteDigraph(2),
 >                               CompleteDigraph(3),
@@ -91,24 +92,30 @@ gap> HomomorphismDigraphsFinder(CompleteDigraph(2),
 >                               [1],     # 1 -> 1
 >                               fail,    # no colours
 >                               fail);   # no colours
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [ IdentityTransformation ]
 gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 3, 0, [1, 2], [1],
 > fail, fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> HomomorphismDigraphsFinder(gr2, gr1, fail, [], 1, 3, 0, [1, 2], [1],
 > fail, fail);
 [  ]
 gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 1, 0, [], [], fail,
 > fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 1, 0, [1, 2], [],
 > fail, fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 1, 0, [1, 2], [],
 > fail, fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], 1, 2, 0, [1], [], fail,
 > fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> HomomorphismDigraphsFinder(gr1, gr1, fail, [], 1, 2, 0, [1, 2], [],
 > fail, fail);
@@ -708,6 +715,7 @@ gap> gr := Digraph([[2, 3], [], [], [5], [], []]);
 <immutable digraph with 6 vertices, 3 edges>
 gap> HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, 0,
 > [1 .. 5], [], fail, fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [ Transformation( [ 1, 2, 3, 4, 5, 1 ] ), 
   Transformation( [ 1, 2, 3, 4, 5, 2 ] ), 
   Transformation( [ 1, 2, 3, 4, 5, 3 ] ), 
@@ -1129,6 +1137,7 @@ gap> gr := DigraphFromDigraph6String(Concatenation(
 <immutable digraph with 22 vertices, 198 edges>
 gap> t := HomomorphismDigraphsFinder(gr, gr, fail, [], 1, fail, 0,
 > [2, 6, 7, 11, 12, 13, 14, 15, 19, 20, 21], [], fail, fail)[1];
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 Transformation( [ 2, 13, 20, 19, 21, 19, 14, 13, 15, 14, 20, 6, 15, 21, 11,
   12, 6, 7, 7, 12, 2, 11 ] )
 gap> ForAll(DigraphEdges(gr), e -> IsDigraphEdge(gr, e[1] ^ t, e[2] ^ t));
@@ -1569,6 +1578,7 @@ gap> HomomorphismDigraphsFinder(D,
 >                               [],          # map
 >                               [1, 2, 3],   # colours1
 >                               [1, 3, 2]);  # colours2
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> EmbeddingsDigraphsRepresentatives(NullDigraph(2),
 >                                      Digraph([[2, 3], [], []]));
@@ -1593,10 +1603,12 @@ gap> D := DigraphFromDigraph6String(Concatenation(
 > "HBSatQlC[TIC{iSBlo_VrO@u[_Eyk?]YS?"));;
 gap> HomomorphismDigraphsFinder(D, D, fail, [], 1, fail, 1,
 > [2, 6, 7, 11, 12, 13, 14, 15, 19, 20, 21], [], fail, fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> D := Digraph([[2], []]);;
 gap> HomomorphismDigraphsFinder(D, D, fail, [], 1, fail, 1,
 > [1], [], fail, fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 
 # Test monomorphisms for graphs
@@ -1804,6 +1816,7 @@ gap> HomomorphismDigraphsFinder(D,
 >                               [, 3],       # map
 >                               fail,        # colours1
 >                               fail);       # colours2
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 gap> D := DigraphAddAllLoops(Digraph([[2, 3], [1], [1], [], [5]]));;
 gap> EmbeddingsDigraphsRepresentatives(NullDigraph(2), D);
@@ -2790,6 +2803,7 @@ on 1 of the group generators,
 gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
 > fail, true, [1, 2, 3], [1], fail, fail,
 > Group((511, 512)));
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [ IdentityTransformation ]
 
 # Issue 697
@@ -2815,6 +2829,7 @@ gap> HomomorphismDigraphsFinder(H,
 > [],                     # partial_map
 > fail,                   # colors1
 > fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [  ]
 
 # With partial map, no hint
@@ -2829,6 +2844,7 @@ gap> HomomorphismDigraphsFinder(H,
 > [8],                     # partial_map
 > fail,                   # colors1
 > fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [ Transformation( [ 8, 1, 5, 7, 3, 4, 6, 8 ] ) ]
 
 # With group, no hint
@@ -2859,6 +2875,7 @@ gap> HomomorphismDigraphsFinder(H,
 > [8],                    # partial_map
 > fail,                   # colors1
 > fail);
+#I  WARNING you are trying to find homomorphisms by specifying a subset of the vertices of the target digraph. This might lead to unexpected results! If this happens, try passing Group(()) as the last argument. Please see the documentation of HomomorphismDigraphsFinder for details.
 [ Transformation( [ 8, 1, 5, 7, 3, 4, 6, 8 ] ) ]
 
 # With group, with hint

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -1048,6 +1048,8 @@ gap> monos := MonomorphismsDigraphs(gr1, gr2);
   Transformation( [ 2, 3, 3 ] ), Transformation( [ 2, 5, 3, 4, 5 ] ), 
   Transformation( [ 3, 2, 3 ] ), Transformation( [ 4, 2, 3, 4 ] ), 
   Transformation( [ 4, 5, 3, 4, 5 ] ), Transformation( [ 5, 1, 3, 4, 5 ] ) ]
+gap> ForAll(monos, x -> IsDigraphMonomorphism(gr1, gr2, x));
+true
 gap> monos = MonomorphismsDigraphsRepresentatives(gr1, gr2);
 true
 gap> monos = HomomorphismsDigraphsRepresentatives(gr1, gr2);
@@ -1067,8 +1069,8 @@ gap> gr2 := CompleteDigraph(3);;
 gap> EpimorphismsDigraphs(gr1, gr2);
 [  ]
 gap> gr1 := DigraphFromDigraph6String("&I@??HO???????A????");;
-gap> DigraphEpimorphism(gr1, gr2);
-Transformation( [ 2, 1, 1, 2, 1, 3, 1, 2, 1, 1 ] )
+gap> IsDigraphEpimorphism(gr1, gr2, DigraphEpimorphism(gr1, gr2));
+true
 gap> epis := EpimorphismsDigraphsRepresentatives(gr1, gr2);;
 gap> Length(epis);
 972
@@ -1162,8 +1164,10 @@ gap> ForAll(GeneratorsOfEndomorphismMonoid(gr),
 >           x -> IsDigraphEndomorphism(gr, x));
 true
 gap> x := Transformation([2, 1, 3, 3]);;
+gap> ForAll(DigraphEdges(gr), e -> IsDigraphEdge(gr, e[1] ^ x, e[2] ^ x));
+true
 gap> IsDigraphEndomorphism(gr, x);
-false
+true
 gap> x := Transformation([3, 1, 3, 3]);;
 gap> IsDigraphEndomorphism(gr, x);
 false
@@ -1171,8 +1175,12 @@ gap> IsDigraphEndomorphism(gr, ());
 true
 gap> IsDigraphEndomorphism(gr, (1, 2));
 true
-gap> IsDigraphEndomorphism(gr, (1, 2)(3, 4));
-false
+gap> x := (1, 2)(3, 4);
+(1,2)(3,4)
+gap> IsDigraphEndomorphism(gr, x);
+true
+gap> ForAll(DigraphEdges(gr), e -> IsDigraphEdge(gr, e[1] ^ x, e[2] ^ x));
+true
 gap> IsDigraphEndomorphism(gr, (1, 2, 3, 4));
 false
 gap> IsDigraphHomomorphism(NullDigraph(1),
@@ -1845,6 +1853,8 @@ gap> D := Digraph(parts, {x, y} -> ForAll(x, z -> not z in y));
 <immutable digraph with 280 vertices, 70560 edges>
 gap> t := DigraphHomomorphism(CompleteDigraph(25), D);
 <transformation on 273 pts with rank 251>
+gap> IsDigraphHomomorphism(CompleteDigraph(25), D, t);
+true
 gap> tt := HomomorphismDigraphsFinder(CompleteDigraph(26),
 >                                     D,
 >                                     fail,       # hook
@@ -1853,12 +1863,11 @@ gap> tt := HomomorphismDigraphsFinder(CompleteDigraph(26),
 >                                     fail,
 >                                     0,
 >                                     [1 .. 280],
->                                     OnTuples([2 .. 25], t),
+>                                     [12, 23, 32, 44, 52, 1, 77, 85, 96, 103, 114,
+> 125, 136, 145, 157, 170, 262, 204, 215, 233, 246, 255, 193, 273],
 >                                     fail,
 >                                     fail)[1];
 <transformation on 273 pts with rank 250>
-gap> OnTuples([2 .. 25], t) = OnTuples([2 .. 25], tt);
-false
 
 # GAP hook function
 gap> found := 0;;
@@ -2135,7 +2144,7 @@ gap> HomomorphismDigraphsFinder(CycleDigraph(5),
 
 # More arg/error checks
 gap> HomomorphismDigraphsFinder(0);
-Error, there must be 11 or 12 arguments, found 1,
+Error, there must be 11, 12, or 13 arguments, found 1,
 gap> DigraphHomomorphism(NullDigraph(1), NullDigraph(513));
 IdentityTransformation
 gap> HomomorphismDigraphsFinder(NullDigraph(1), NullDigraph(510), fail, [], 1,
@@ -2758,6 +2767,115 @@ gap> D := DigraphFromGraph6String("O^vMMF@oM?w@o@o?w?N?@");
 <immutable symmetric digraph with 16 vertices, 84 edges>
 gap> Length(SubdigraphsMonomorphisms(CompleteMultipartiteDigraph([2, 7]), D));
 3432
+
+#
+gap> H := DigraphFromGraph6String("F~CWw");
+<immutable symmetric digraph with 7 vertices, 24 edges>
+gap> G := DigraphFromGraph6String("G@p}|{");
+<immutable symmetric digraph with 8 vertices, 36 edges>
+gap> ForAll(MonomorphismsDigraphs(H, G), x -> IsDigraphMonomorphism(H, G, x));
+true
+gap> H := NullDigraph(3);
+<immutable empty digraph with 3 vertices>
+gap> G := NullDigraph(510);
+<immutable empty digraph with 510 vertices>
+gap> p := MappingPermListList([1 .. 1000], [5 .. 1004]);;
+gap> IsDigraphAutomorphism(G, p);
+false
+gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
+> fail, true, [1, 2, 3], [1], fail, fail,
+> Group(MappingPermListList([1 .. 1000], [5 .. 1004])));
+Error, expected group of automorphisms, but found a non-automorphism in positi\
+on 1 of the group generators,
+gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
+> fail, true, [1, 2, 3], [1], fail, fail,
+> Group((511, 512)));
+[ IdentityTransformation ]
+
+# Issue 697
+gap> H := DigraphFromGraph6String("F~CWw");
+<immutable symmetric digraph with 7 vertices, 24 edges>
+gap> G := DigraphFromGraph6String("G@p}|{");
+<immutable symmetric digraph with 8 vertices, 36 edges>
+gap> p := PermList(DigraphWelshPowellOrder(H)) ^ -1;
+(1,2,3,4)
+gap> H := OnDigraphs(H, p);
+<immutable digraph with 7 vertices, 24 edges>
+gap> # Reorder H to remove the ordering from the equation
+
+# no partial map, no group
+gap> HomomorphismDigraphsFinder(H,
+> G,                      # range
+> fail,                   # hook
+> [],                     # user_param
+> 1,                      # max_results
+> 7,                      # hint (i.e. rank)
+> true,                   # injective
+> [1, 3, 4, 5, 6, 7, 8],  # image
+> [],                     # partial_map
+> fail,                   # colors1
+> fail);
+[  ]
+
+# With partial map, no hint
+gap> HomomorphismDigraphsFinder(H,
+> G,                      # range
+> fail,                   # hook
+> [],                     # user_param
+> 1,                      # max_results
+> fail,                   # hint (i.e. rank)
+> true,                   # injective
+> [1, 3, 4, 5, 6, 7, 8],  # image
+> [8],                     # partial_map
+> fail,                   # colors1
+> fail);
+[ Transformation( [ 8, 1, 5, 7, 3, 4, 6, 8 ] ) ]
+
+# With group, no hint
+gap> HomomorphismDigraphsFinder(H,
+> G,                      # range
+> fail,                   # hook
+> [],                     # user_param
+> 1,                      # max_results
+> fail,                   # hint (i.e. rank)
+> true,                   # injective
+> [1, 3, 4, 5, 6, 7, 8],
+> [],                     # partial_map
+> fail,                   # colors1
+> fail,
+> [1 .. 7],
+> Group(()));
+[ Transformation( [ 8, 1, 5, 7, 3, 4, 6, 8 ] ) ]
+
+# With partial map, with hint
+gap> HomomorphismDigraphsFinder(H,
+> G,                      # range
+> fail,                   # hook
+> [],                     # user_param
+> 1,                      # max_results
+> 7,                      # hint (i.e. rank)
+> true,                   # injective
+> [1, 3, 4, 5, 6, 7, 8],  # image
+> [8],                    # partial_map
+> fail,                   # colors1
+> fail);
+[ Transformation( [ 8, 1, 5, 7, 3, 4, 6, 8 ] ) ]
+
+# With group, with hint
+gap> HomomorphismDigraphsFinder(H,
+> G,                      # range
+> fail,                   # hook
+> [],                     # user_param
+> 1,                      # max_results
+> 7,                      # hint (i.e. rank)
+> true,                   # injective
+> [1, 3, 4, 5, 6, 7, 8],
+> [],                     # partial_map
+> fail,                   # colors1
+> fail,
+> DigraphWelshPowellOrder(H),
+> Group(()));
+[ Transformation( [ 8, 1, 5, 7, 3, 4, 6, 8 ] ) ]
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(D);


### PR DESCRIPTION
This PR resolves #697, and some related issues discovered when trying to resolve it.

~~This PR adds some tests, and other minor fixes related to #697.~~

~~Before this can be merged I'll have to:~~

- [x] ~~adjust the documentation for `IsDigraphHomomorphism` to remove the claim that values larger than `DigraphNrVertices(source_digraph)` are fixed, since this leads to the paradoxical situation where composing a monomorphism H -> G and an automorphism G -> G yields a non-homomorphism. I should add that as test case too.~~
- [x] ~~update the doc for `DigraphHomomorphismFinder` to indicate what it returns (or doesn't) when the argument `IMAGE_RESTRICT` is specified and a strict subset of the nodes of the target digraph;~~
- [x] ~~add an info warning to the code for the case above (i.e. if `IMAGE_RESTRICT` is specified and a strict subset, then in order to ensure that all/any homomorphisms with image in `IMAGE_RESTRICT` are returned, the automorphism group must be explicitly specified to be trivial).~~
- [x] ~~with the change to `IsDigraphHomomorphism` from the first point, it's possible that specified automorphisms might not fix points greater than the number of nodes in the target graph. These points should be ignored in the code.~~