### PR TITLE
Remove references to non-existing gap/doc.g

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -27,4 +27,3 @@ ignore:
  - "makedoc.g"
  - "read.g"
  - "tst/"
- - "gap/doc.g"

--- a/read.g
+++ b/read.g
@@ -22,8 +22,6 @@ BindGlobal("DIGRAPHS_NautyAvailable",
 
 Unbind(_NautyTracesInterfaceVersion);
 
-ReadPackage("digraphs", "gap/doc.g");
-
 ReadPackage("digraphs", "gap/utils.gi");
 ReadPackage("digraphs", "gap/digraph.gi");
 ReadPackage("digraphs", "gap/constructors.gi");


### PR DESCRIPTION
Unfortunately this causes a warning when loading Digraphs in GAP 4.14.0