### PR TITLE
Don't try to read doc.g, file was previously removed

### DIFF
--- a/read.g
+++ b/read.g
@@ -22,8 +22,6 @@ BindGlobal("DIGRAPHS_NautyAvailable",
 
 Unbind(_NautyTracesInterfaceVersion);
 
-ReadPackage("digraphs", "gap/doc.g");
-
 ReadPackage("digraphs", "gap/utils.gi");
 ReadPackage("digraphs", "gap/digraph.gi");
 ReadPackage("digraphs", "gap/constructors.gi");


### PR DESCRIPTION
The file `gap/doc.g` was removed in 32ed64a, but GAP still tries (and fails) to read it when Digraphs is loaded.