### PR TITLE
Simplify kernel extension code setting up StructInitInfo

### DIFF
--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -2274,34 +2274,13 @@ static Int InitLibrary(StructInitInfo* module) {
  *F  InitInfopl()  . . . . . . . . . . . . . . . . . table of init functions
  */
 static StructInitInfo module = {
-#ifdef DIGRAPHSSTATIC
-    .type = MODULE_STATIC,
-#else
-    .type = MODULE_DYNAMIC,
-#endif
+    .type        = MODULE_DYNAMIC,
     .name        = "digraphs",
     .initKernel  = InitKernel,
     .initLibrary = InitLibrary,
-    .postRestore = 0};
+};
 
-#ifndef DIGRAPHSSTATIC
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-prototypes"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#endif
-StructInitInfo* Init__Dynamic(void) {
+extern StructInitInfo* Init__Dynamic(void);  // prototype to avoid warnings
+StructInitInfo*        Init__Dynamic(void) {
   return &module;
 }
-
-StructInitInfo* Init__digraphs(void) {
-  return &module;
-}
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-#endif


### PR DESCRIPTION
I hope targeting stable-1.9 is correct, if not let me know and I can change it.

This change is not crucial in any way but since I am currently looking into all packages with kernel extensions, and sending out some tweaks, I figured I might do this one, too :-)