### PR TITLE
Fix HTML entities on the Digraphs homepage

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -504,24 +504,26 @@ Keywords := [],
 
 AutoDoc := rec(
     TitlePage := rec(
-        Copyright := """Jan De Beule, Julius Jonu&#353;as, James D. Mitchell,
-          Wilf A. Wilson, Michael Young et al.<P/>
+        Copyright := """<Par>Jan De Beule, Julius Jonu&#353;as,
+	  James D. Mitchell, Wilf A. Wilson, Michael Young et al.</Par>
 
-          <Package>Digraphs</Package> is free software;
+          <Par><Package>Digraphs</Package> is free software;
 	  you can redistribute it and/or modify
           it under the terms of the <URL Text="GNU General Public License">
           https://www.fsf.org/licenses/gpl.html</URL> as published by the
           Free Software Foundation; either version 3 of the License, or (at
-          your option) any later version.""",
+          your option) any later version.</Par>""",
         Abstract := """The <Package>Digraphs</Package> package is a
 	  <Package>GAP</Package> package containing
           methods for graphs, digraphs, and multidigraphs.""",
         Acknowledgements := """
-          We would like to thank Christopher Jefferson for his help in including
-          <Package>BLISS</Package> in <Package>Digraphs</Package>.
+          <Par>We would like to thank Christopher Jefferson for his help in
+	  including <Package>BLISS</Package> in
+	  <Package>Digraphs</Package>.</Par>
 
-          This package's methods for computing digraph homomorphisms are based
-          on work by Max Neunh&#246;ffer, and independently Artur Sch&#228;fer.
+          <Par>This package's methods for computing digraph homomorphisms
+	  are based on work by Max Neunh&#246;ffer,
+	  and independently Artur Sch&#228;fer.</Par>
         """)),
 
         AbstractHTML := ~.AutoDoc.TitlePage.Abstract));

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -526,7 +526,9 @@ AutoDoc := rec(
 	  and independently Artur Schäfer.</Par>
         """)),
 
-        AbstractHTML := ~.AutoDoc.TitlePage.Abstract));
+AbstractHTML := Concatenation(["The <b>Digraphs</b> package is a <b>GAP</b> ",
+			       "package containing methods for graphs, ",
+			       "digraphs, and multidigraphs."])));
 
 if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
   Unbind(IsKernelExtensionAvailable);

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -527,8 +527,8 @@ AutoDoc := rec(
         """)),
 
 AbstractHTML := Concatenation(["The <b>Digraphs</b> package is a <b>GAP</b> ",
-			       "package containing methods for graphs, ",
-			       "digraphs, and multidigraphs."])));
+                               "package containing methods for graphs, ",
+                               "digraphs, and multidigraphs."])));
 
 if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
   Unbind(IsKernelExtensionAvailable);

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -507,16 +507,18 @@ AutoDoc := rec(
         Copyright := """Jan De Beule, Julius Jonu&#353;as, James D. Mitchell,
           Wilf A. Wilson, Michael Young et al.<P/>
 
-          &Digraphs; is free software; you can redistribute it and/or modify
+          <Package>Digraphs</Package> is free software;
+	  you can redistribute it and/or modify
           it under the terms of the <URL Text="GNU General Public License">
           https://www.fsf.org/licenses/gpl.html</URL> as published by the
           Free Software Foundation; either version 3 of the License, or (at
           your option) any later version.""",
-        Abstract := """The &Digraphs; package is a &GAP; package containing
+        Abstract := """The <Package>Digraphs</Package> package is a
+	  <Package>GAP</Package> package containing
           methods for graphs, digraphs, and multidigraphs.""",
         Acknowledgements := """
           We would like to thank Christopher Jefferson for his help in including
-          &BLISS; in &Digraphs;.
+          <Package>BLISS</Package> in <Package>Digraphs</Package>.
 
           This package's methods for computing digraph homomorphisms are based
           on work by Max Neunh&#246;ffer, and independently Artur Sch&#228;fer.

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -504,7 +504,7 @@ Keywords := [],
 
 AutoDoc := rec(
     TitlePage := rec(
-        Copyright := """<Par>Jan De Beule, Julius Jonu&#353;as,
+        Copyright := """<Par>Jan De Beule, Julius Jonušas,
 	  James D. Mitchell, Wilf A. Wilson, Michael Young et al.</Par>
 
           <Par><Package>Digraphs</Package> is free software;
@@ -522,8 +522,8 @@ AutoDoc := rec(
 	  <Package>Digraphs</Package>.</Par>
 
           <Par>This package's methods for computing digraph homomorphisms
-	  are based on work by Max Neunh&#246;ffer,
-	  and independently Artur Sch&#228;fer.</Par>
+	  are based on work by Max Neunhöffer,
+	  and independently Artur Schäfer.</Par>
         """)),
 
         AbstractHTML := ~.AutoDoc.TitlePage.Abstract));


### PR DESCRIPTION
This pull request possibly resolves [Issue 711](https://github.com/digraphs/Digraphs/issues/711).

It appears this could be related to [PR 684](https://github.com/digraphs/Digraphs/pull/684/) in that the previous homepage was defined in raw HTML, whereas this is now defined using GAPDoc syntax and automatically generated using AutoDOC.

I should note that I can't find the Copyright nor Acknowledgements sections on the homepage, so don't know if they were parsed correctly beforehand.