### PR TITLE
Expand named entity GAPDoc calls in Abstract(HTML)

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -28,16 +28,21 @@ end);
 
 BindGlobal("_MakeAbstractFunction",
 function(OutputFormat)
-  local ValidOutputFormats, ErrorMsg, OutputType, AbstractRec, Abstract, line;
+  local ValidOutputFormats, ErrorMsg, OutputType, AbstractRec, AbstractParts,
+        line, Abstract;
+
+  # Validate the specified OutputFormat.
   ValidOutputFormats := ["HTML", "XML"];
   if not OutputFormat in ValidOutputFormats then
     ErrorMsg := Concatenation(["The given `OutputFormat` argument is invalid. ",
                                "Valid options are:\n"]);
     for OutputType in ValidOutputFormats do
-        ErrorMsg := Concatenation(ErrorMsg, "- ", OutputType, "\n");
+      ErrorMsg := Concatenation(ErrorMsg, "- ", OutputType, "\n");
     od;
     ErrorNoReturn(ErrorMsg);
   fi;
+
+  # Define the Abstract here.
   AbstractRec := [rec(str := "The", toReplace := false),
                   rec(str := "Digraphs", toReplace := true),
                   rec(str := "package is a", toReplace := false),
@@ -45,25 +50,30 @@ function(OutputFormat)
                   rec(str := "package containing methods", toReplace := false),
                   rec(str := "for graphs, digraphs, and", toReplace := false),
                   rec(str := "multidigraphs.", toReplace := false)];
+
+  # Build the Abstract from the processed abstract parts.
   Abstract := "";
   for line in AbstractRec do
     if line.toReplace then
       if OutputFormat = "XML" then
         line.str := Concatenation("&", line.str, ";");
       elif OutputFormat = "HTML" then
-        line.str := Concatenation(["""<strong class="pkg">""",
-                                   line.str,
-                                   """</strong>"""]);
+        line.str := Concatenation(["<strong class=\"pkg\">",
+                                   line.str, "</strong>"]);
       else
-        # Shouldn't be able to reach this state.
-        ErrorNoReturn(Concatenation(["Outputting to format ", OutputFormat,
-                                     "has not yet been implemented."]));
+        ErrorMsg := Concatenation(["Outputting to format ", OutputFormat,
+                                   " has not yet been implemented."]);
+        ErrorNoReturn(ErrorMsg);
       fi;
     fi;
-    Abstract := Concatenation(Abstract, line.str, " ");
+    line.str := Concatenation(line.str, " ");
+    Abstract := Concatenation(Abstract, line.str);
   od;
-  # Remove final whitespace char
-  NormalizeWhitespace(Abstract);
+
+  # Remove trailing whitespace chars.
+  while Abstract{[Length(Abstract)]} = " " do
+    Abstract := Abstract{[1..Length(Abstract)-1]};
+  od;
   return Abstract;
 end);
 

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -522,9 +522,9 @@ AutoDoc := rec(
           on work by Max Neunh&#246;ffer, and independently Artur Sch&#228;fer.
         """)),
 
-AbstractHTML := "The <strong class="pkg">Digraphs</strong> package
+AbstractHTML := """The <strong class="pkg">Digraphs</strong> package
           is a <strong class="pkg">GAP</strong> package containing
-          methods for graphs, digraphs, and multidigraphs."));
+          methods for graphs, digraphs, and multidigraphs."""));
 
 if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
   Unbind(IsKernelExtensionAvailable);

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -512,7 +512,8 @@ AutoDoc := rec(
           https://www.fsf.org/licenses/gpl.html</URL> as published by the
           Free Software Foundation; either version 3 of the License, or (at
           your option) any later version.""",
-        Abstract := """The &Digraphs; package is a &GAP; package containing
+        Abstract := """The <strong class="pkg">Digraphs</strong> package
+	  is a <strong class="pkg">GAP</strong> package containing
           methods for graphs, digraphs, and multidigraphs.""",
         Acknowledgements := """
           We would like to thank Christopher Jefferson for his help in including
@@ -522,7 +523,7 @@ AutoDoc := rec(
           on work by Max Neunh&#246;ffer, and independently Artur Sch&#228;fer.
         """)),
 
-        AbstractHTML := ~.AutoDoc.TitlePage.Abstract));
+AbstractHTML := ~.AutoDoc.TitlePage.Abstract));
 
 if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
   Unbind(IsKernelExtensionAvailable);

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -71,7 +71,7 @@ function(OutputFormat)
 
   # Remove trailing whitespace chars.
   while Abstract{[Length(Abstract)]} = " " do
-    Abstract := Abstract{[1..Length(Abstract)-1]};
+    Abstract := Abstract{[1 .. Length(Abstract) - 1]};
   od;
   return Abstract;
 end);

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -512,8 +512,7 @@ AutoDoc := rec(
           https://www.fsf.org/licenses/gpl.html</URL> as published by the
           Free Software Foundation; either version 3 of the License, or (at
           your option) any later version.""",
-        Abstract := """The <strong class="pkg">Digraphs</strong> package
-	  is a <strong class="pkg">GAP</strong> package containing
+        Abstract := """The &Digraphs; package is a &GAP; package containing
           methods for graphs, digraphs, and multidigraphs.""",
         Acknowledgements := """
           We would like to thank Christopher Jefferson for his help in including
@@ -523,7 +522,9 @@ AutoDoc := rec(
           on work by Max Neunh&#246;ffer, and independently Artur Sch&#228;fer.
         """)),
 
-AbstractHTML := ~.AutoDoc.TitlePage.Abstract));
+AbstractHTML := """The <strong class="pkg">Digraphs</strong> package
+          is a <strong class="pkg">GAP</strong> package containing
+          methods for graphs, digraphs, and multidigraphs.""",));
 
 if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
   Unbind(IsKernelExtensionAvailable);

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -522,9 +522,9 @@ AutoDoc := rec(
           on work by Max Neunh&#246;ffer, and independently Artur Sch&#228;fer.
         """)),
 
-AbstractHTML := """The <strong class="pkg">Digraphs</strong> package
+AbstractHTML := "The <strong class="pkg">Digraphs</strong> package
           is a <strong class="pkg">GAP</strong> package containing
-          methods for graphs, digraphs, and multidigraphs.""",));
+          methods for graphs, digraphs, and multidigraphs."));
 
 if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
   Unbind(IsKernelExtensionAvailable);

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -26,6 +26,47 @@ function(re)
   fi;
 end);
 
+BindGlobal("_MakeAbstractFunction",
+function(OutputFormat)
+  local ValidOutputFormats, ErrorMsg, OutputType, AbstractRec, Abstract, line;
+  ValidOutputFormats := ["HTML", "XML"];
+  if not OutputFormat in ValidOutputFormats then
+    ErrorMsg := Concatenation(["The given `OutputFormat` argument is invalid. ",
+                               "Valid options are:\n"]);
+    for OutputType in ValidOutputFormats do
+        ErrorMsg := Concatenation(ErrorMsg, "- ", OutputType, "\n");
+    od;
+    ErrorNoReturn(ErrorMsg);
+  fi;
+  AbstractRec := [rec(str := "The", toReplace := false),
+                  rec(str := "Digraphs", toReplace := true),
+                  rec(str := "package is a", toReplace := false),
+                  rec(str := "GAP", toReplace := true),
+                  rec(str := "package containing methods", toReplace := false),
+                  rec(str := "for graphs, digraphs, and", toReplace := false),
+                  rec(str := "multidigraphs.", toReplace := false)];
+  Abstract := "";
+  for line in AbstractRec do
+    if line.toReplace then
+      if OutputFormat = "XML" then
+        line.str := Concatenation("&", line.str, ";");
+      elif OutputFormat = "HTML" then
+        line.str := Concatenation(["""<strong class="pkg">""",
+                                   line.str,
+                                   """</strong>"""]);
+      else
+        # Shouldn't be able to reach this state.
+        ErrorNoReturn(Concatenation(["Outputting to format ", OutputFormat,
+                                     "has not yet been implemented."]));
+      fi;
+    fi;
+    Abstract := Concatenation(Abstract, line.str, " ");
+  od;
+  # Remove final whitespace char
+  NormalizeWhitespace(Abstract);
+  return Abstract;
+end);
+
 _STANDREWSMATHS := Concatenation(["Mathematical Institute, North Haugh, ",
                                   "St Andrews, Fife, KY16 9SS, Scotland"]);
 _STANDREWSCS := Concatenation(["Jack Cole Building, North Haugh, ",
@@ -512,8 +553,7 @@ AutoDoc := rec(
           https://www.fsf.org/licenses/gpl.html</URL> as published by the
           Free Software Foundation; either version 3 of the License, or (at
           your option) any later version.""",
-        Abstract := """The &Digraphs; package is a &GAP; package containing
-          methods for graphs, digraphs, and multidigraphs.""",
+        Abstract := _MakeAbstractFunction("XML"),
         Acknowledgements := """
           We would like to thank Christopher Jefferson for his help in including
           &BLISS; in &Digraphs;.
@@ -522,9 +562,7 @@ AutoDoc := rec(
           on work by Max Neunh&#246;ffer, and independently Artur Sch&#228;fer.
         """)),
 
-AbstractHTML := """The <strong class="pkg">Digraphs</strong> package
-          is a <strong class="pkg">GAP</strong> package containing
-          methods for graphs, digraphs, and multidigraphs."""));
+AbstractHTML := _MakeAbstractFunction("HTML")));
 
 if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
   Unbind(IsKernelExtensionAvailable);
@@ -532,7 +570,9 @@ fi;
 
 MakeReadWriteGlobal("_RecogsFunnyWWWURLFunction");
 MakeReadWriteGlobal("_RecogsFunnyNameFormatterFunction");
+MakeReadWriteGlobal("_MakeAbstractFunction");
 Unbind(_RecogsFunnyWWWURLFunction);
 Unbind(_RecogsFunnyNameFormatterFunction);
+Unbind(_MakeAbstractFunction);
 Unbind(_STANDREWSMATHS);
 Unbind(_STANDREWSCS);

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -28,8 +28,7 @@ end);
 
 BindGlobal("_MakeAbstractFunction",
 function(OutputFormat)
-  local ValidOutputFormats, ErrorMsg, OutputType, AbstractRec, AbstractParts,
-        line, Abstract;
+  local ValidOutputFormats, ErrorMsg, OutputType, AbstractRec, line, Abstract;
 
   # Validate the specified OutputFormat.
   ValidOutputFormats := ["HTML", "XML"];


### PR DESCRIPTION
This is my second attempt at resolving [Issue 711](https://github.com/digraphs/Digraphs/issues/711).

Derived from XML, GAPDoc has macro substitution in the form of named entities. Calling a macro, e.g. &Digraphs;, will expand the html defined for the given named entity.
The intended behaviour of the calls is exhibited in Chapter 0 of the project manual [1].
More information about named entities can be found in Chapter 2.1-9 of the GAPDoc documentation manual [2].

AutoDoc doesn't seem to expand these macros. This results in the raw macro call being displayed in the places controlled by AutoDoc, namely the project homepage [3] and Digraphs' entry on the list of GAP packages [4].

Hence to prevent unnecessarily defining the Abstract twice, with different styling for GAPDoc and AutoDoc,
instead expand the macro in-place.

Note this means any future changes to the macro (named entity) will not propagate here,
e.g. if `<strong>` html tag is replaced with the italic `<i>` tag.
But changes to the `pkg` html class should propagate.

[1] -- https://digraphs.github.io/Digraphs/doc/chap0_mj.html
[2] -- https://docs.gap-system.org/pkg/gapdoc/doc/chap2.html
[3] -- https://digraphs.github.io/Digraphs/
[4] -- https://www.gap-system.org/packages/