### PR TITLE
Added IsTwoEdgeTransitive function

### DIFF
--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -52,6 +52,7 @@ DeclareProperty("IsMeetSemilatticeDigraph", IsDigraph);
 DeclareProperty("IsPermutationDigraph", IsDigraph);
 DeclareProperty("IsDistributiveLatticeDigraph", IsDigraph);
 DeclareProperty("IsModularLatticeDigraph", IsDigraph);
+DeclareProperty("IsTwoEdgeTransitive", IsDigraph);
 DeclareSynonymAttr("IsLatticeDigraph",
                    IsMeetSemilatticeDigraph and IsJoinSemilatticeDigraph);
 DeclareSynonymAttr("IsPreorderDigraph",

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -686,3 +686,13 @@ function(D)
 
   return LatticeDigraphEmbedding(N5, D) = fail;
 end);
+
+InstallMethod(IsTwoEdgeTransitive, "for a digraph", [IsDigraph], function(D)
+  local twoEdges;
+
+  twoEdges := Filtered(Cartesian(DigraphEdges(D), DigraphEdges(D)), pair -> pair[1][2] = pair[2][1]);
+
+  return OrbitLength(AutomorphismGroup(D), twoEdges[1], OnTuplesTuples)
+  = Length(twoEdges);
+
+end);


### PR DESCRIPTION
A _2-edge_ in a digraph is a triple (a,b,c)  of vertices such that (a,b) and (b,c) are edges and a!=c. A digraph is _2-edge transitive_ if its automorphism group acts transitively on 2-edges. 

Adds a function IsTwoEdgeTransitive() which takes a digraph and returns true if it is 2-edge transitive.