### PR TITLE
Make random digraphs more random

### DIFF
--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1361,37 +1361,37 @@ end);
 InstallMethod(RandomDigraphCons, "for IsMutableDigraph and an integer",
 [IsMutableDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsMutableDigraph, n, Float(Random([0 .. n])) / n));
+-> RandomDigraphCons(IsMutableDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
 
 InstallMethod(RandomDigraphCons, "for IsMutableDigraph and an integer",
 [IsImmutableDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsImmutableDigraph, n, Float(Random([0 .. n])) / n));
+-> RandomDigraphCons(IsImmutableDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
 
 InstallMethod(RandomDigraphCons, "for IsHamiltonianDigraph and an integer",
 [IsHamiltonianDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsHamiltonianDigraph, n, Float(Random([0 .. n])) / n));
+-> RandomDigraphCons(IsHamiltonianDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
 
 InstallMethod(RandomDigraphCons, "for IsEulerianDigraph and an integer",
 [IsEulerianDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsEulerianDigraph, n, Float(Random([0 .. n])) / n));
+-> RandomDigraphCons(IsEulerianDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
 
 InstallMethod(RandomDigraphCons, "for IsConnectedDigraph and an integer",
 [IsConnectedDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsConnectedDigraph, n, Float(Random([0 .. n])) / n));
+-> RandomDigraphCons(IsConnectedDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
 
 InstallMethod(RandomDigraphCons, "for IsAcyclicDigraph and an integer",
 [IsAcyclicDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsAcyclicDigraph, n, Float(Random([0 .. n])) / n));
+-> RandomDigraphCons(IsAcyclicDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
 
 InstallMethod(RandomDigraphCons, "for IsSymmetricDigraph and an integer",
 [IsSymmetricDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsSymmetricDigraph, n, Float(Random([0 .. n])) / n));
+-> RandomDigraphCons(IsSymmetricDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
 
 InstallMethod(RandomDigraphCons,
 "for IsMutableDigraph, an integer, and a rational",

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1361,37 +1361,37 @@ end);
 InstallMethod(RandomDigraphCons, "for IsMutableDigraph and an integer",
 [IsMutableDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsMutableDigraph, n, Float(Random(0, n^2) / n^2)));
+-> RandomDigraphCons(IsMutableDigraph, n, Float(Random(0, n ^ 2) / n ^ 2)));
 
 InstallMethod(RandomDigraphCons, "for IsMutableDigraph and an integer",
 [IsImmutableDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsImmutableDigraph, n, Float(Random(0, n^2) / n^2)));
+-> RandomDigraphCons(IsImmutableDigraph, n, Float(Random(0, n ^ 2) / n ^ 2)));
 
 InstallMethod(RandomDigraphCons, "for IsHamiltonianDigraph and an integer",
 [IsHamiltonianDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsHamiltonianDigraph, n, Float(Random(0, n^2) / n^2)));
+-> RandomDigraphCons(IsHamiltonianDigraph, n, Float(Random(0, n ^ 2) / n ^ 2)));
 
 InstallMethod(RandomDigraphCons, "for IsEulerianDigraph and an integer",
 [IsEulerianDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsEulerianDigraph, n, Float(Random(0, n^2) / n^2)));
+-> RandomDigraphCons(IsEulerianDigraph, n, Float(Random(0, n ^ 2) / n ^ 2)));
 
 InstallMethod(RandomDigraphCons, "for IsConnectedDigraph and an integer",
 [IsConnectedDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsConnectedDigraph, n, Float(Random(0, n^2) / n^2)));
+-> RandomDigraphCons(IsConnectedDigraph, n, Float(Random(0, n ^ 2) / n ^ 2)));
 
 InstallMethod(RandomDigraphCons, "for IsAcyclicDigraph and an integer",
 [IsAcyclicDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsAcyclicDigraph, n, Float(Random(0, n^2) / n^2)));
+-> RandomDigraphCons(IsAcyclicDigraph, n, Float(Random(0, n ^ 2) / n ^ 2)));
 
 InstallMethod(RandomDigraphCons, "for IsSymmetricDigraph and an integer",
 [IsSymmetricDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsSymmetricDigraph, n, Float(Random(0, n^2) / n^2)));
+-> RandomDigraphCons(IsSymmetricDigraph, n, Float(Random(0, n ^ 2) / n ^ 2)));
 
 InstallMethod(RandomDigraphCons,
 "for IsMutableDigraph, an integer, and a rational",

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1361,37 +1361,37 @@ end);
 InstallMethod(RandomDigraphCons, "for IsMutableDigraph and an integer",
 [IsMutableDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsMutableDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
+-> RandomDigraphCons(IsMutableDigraph, n, Float(Random(0, n^2) / n^2)));
 
 InstallMethod(RandomDigraphCons, "for IsMutableDigraph and an integer",
 [IsImmutableDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsImmutableDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
+-> RandomDigraphCons(IsImmutableDigraph, n, Float(Random(0, n^2) / n^2)));
 
 InstallMethod(RandomDigraphCons, "for IsHamiltonianDigraph and an integer",
 [IsHamiltonianDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsHamiltonianDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
+-> RandomDigraphCons(IsHamiltonianDigraph, n, Float(Random(0, n^2) / n^2)));
 
 InstallMethod(RandomDigraphCons, "for IsEulerianDigraph and an integer",
 [IsEulerianDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsEulerianDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
+-> RandomDigraphCons(IsEulerianDigraph, n, Float(Random(0, n^2) / n^2)));
 
 InstallMethod(RandomDigraphCons, "for IsConnectedDigraph and an integer",
 [IsConnectedDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsConnectedDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
+-> RandomDigraphCons(IsConnectedDigraph, n, Float(Random(0, n^2) / n^2)));
 
 InstallMethod(RandomDigraphCons, "for IsAcyclicDigraph and an integer",
 [IsAcyclicDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsAcyclicDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
+-> RandomDigraphCons(IsAcyclicDigraph, n, Float(Random(0, n^2) / n^2)));
 
 InstallMethod(RandomDigraphCons, "for IsSymmetricDigraph and an integer",
 [IsSymmetricDigraph, IsInt],
 {_, n}
--> RandomDigraphCons(IsSymmetricDigraph, n, Float(Random(0, n * (n - 1)) / (n * (n - 1)))));
+-> RandomDigraphCons(IsSymmetricDigraph, n, Float(Random(0, n^2) / n^2)));
 
 InstallMethod(RandomDigraphCons,
 "for IsMutableDigraph, an integer, and a rational",
@@ -1440,7 +1440,7 @@ function(_, n, p)
   if p < 0.0 or 1.0 < p then
     ErrorNoReturn("the 2nd argument <p> must be between 0 and 1,");
   fi;
-  return DigraphNC(IsMutableDigraph, RANDOM_DIGRAPH(n, Int(p * 10000)));
+  return DigraphNC(IsMutableDigraph, RANDOM_DIGRAPH(n, p));
 end);
 
 # This function takes an existing adjacency list after solely creating

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -1359,10 +1359,10 @@ static Obj FuncDIGRAPH_REFLEX_TRANS_CLOSURE(Obj self, Obj digraph) {
 }
 
 static Obj FuncRANDOM_DIGRAPH(Obj self, Obj nn, Obj pp) {
-  UInt n, i, j, lim;
-  Double q, p;
-  Int  len;
-  Obj  adj, adji;
+  UInt    n, i, j;
+  Double  p, q;
+  Int     len;
+  Obj     adj, adji;
 
   n   = INT_INTOBJ(nn);
   p   = VAL_MACFLOAT(pp);

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -1358,13 +1358,14 @@ static Obj FuncDIGRAPH_REFLEX_TRANS_CLOSURE(Obj self, Obj digraph) {
       digraph, FW_FUNC_REFLEX_TRANS_CLOSURE, 0, 1, false, false, false);
 }
 
-static Obj FuncRANDOM_DIGRAPH(Obj self, Obj nn, Obj limm) {
-  UInt n, i, j, k, lim;
+static Obj FuncRANDOM_DIGRAPH(Obj self, Obj nn, Obj pp) {
+  UInt n, i, j, lim;
+  Double q, p;
   Int  len;
   Obj  adj, adji;
 
   n   = INT_INTOBJ(nn);
-  lim = INT_INTOBJ(limm);
+  p   = VAL_MACFLOAT(pp);
   adj = NEW_PLIST(T_PLIST_TAB, n);
   SET_LEN_PLIST(adj, n);
 
@@ -1375,8 +1376,8 @@ static Obj FuncRANDOM_DIGRAPH(Obj self, Obj nn, Obj limm) {
 
   for (i = 1; i <= n; i++) {
     for (j = 1; j <= n; j++) {
-      k = rand() % 10000;
-      if (k < lim) {
+      q = (double) rand() / RAND_MAX;
+      if (q < p) {
         adji = ELM_PLIST(adj, i);
         len  = LEN_PLIST(adji);
         ASS_LIST(adji, len + 1, INTOBJ_INT(j));

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2593,14 +2593,12 @@ gap> P := DigraphRemoveAllMultipleEdges(
 > ReducedDigraph(OnDigraphs(D, proj[2])));;
 gap> IsIsomorphicDigraph(CycleDigraph(4), P);
 true
-gap> G := RandomDigraph(12);;
-gap> H := RandomDigraph(50);;
+gap> G := ReducedDigraph(RandomDigraph(12));;
+gap> H := ReducedDigraph(RandomDigraph(50));;
 gap> D := DigraphDirectProduct(G, H);;
 gap> proj := DigraphDirectProductProjections(D);;
 gap> IsIdempotent(proj[1]);
 true
-gap> RankOfTransformation(proj[2]);
-50
 gap> P := DigraphRemoveAllMultipleEdges(
 > ReducedDigraph(OnDigraphs(D, proj[2])));;
 gap> IsIsomorphicDigraph(H, P);


### PR DESCRIPTION
The previous implementation of RandomDigraph was heavily biased towards empty and complete digraphs. This PR improves that (though there is still a bit of a bias for these, for reasons I haven't looked into yet).

When not specified, the edge-probability is now chosen as `Float(Random(0, n^2) / n^2)`. Maybe it would be a good idea to take a slightly higher resolution to avoid any strange resolution effects, but I don't know what these effects might be. This probability done for all types of (non-multi) digraphs, even when `n^2` isn't the correct maximum number of edges, since it shouldn't have much effect.

I haven't changed RandomMultiDigraph as its behaviour is different - it takes as second parameter a desired number of edges instead of an edge-probability (I guess it isn't clear what that would mean). 