### PR TITLE
Minor doc updates

### DIFF
--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -592,6 +592,7 @@ Transformation( [ 2, 4, 3, 4 ] )
 ]]></Example>
   </Description>
 </ManSection>
+<Index Key="subgraph isomorphism">subgraph isomorphism</Index>
 <#/GAPDoc>
 
 <#GAPDoc Label="EmbeddingsDigraphs">
@@ -786,6 +787,7 @@ gap> IsDigraphEmbedding(src, ran, IdentityTransformation);
 false]]></Example>
   </Description>
 </ManSection>
+<Index Key="subgraph isomorphism">subgraph isomorphism</Index>
 <#/GAPDoc>
 
 <#GAPDoc Label="IsDigraphColouring">

--- a/doc/z-chap0.xml
+++ b/doc/z-chap0.xml
@@ -16,24 +16,8 @@
     <Item>Wilf A. Wilson, and</Item>
     <Item>Michael C. Young.</Item>
   </List>
-  Additional contributions were made by:
-  <List>
-    <Item>Marina Anagnostopoulou-Merkouri,</Item>
-    <Item>Finn Buck,</Item>
-    <Item>Stuart Burrell,</Item>
-    <Item>Reinis Cirpons,</Item>
-    <Item>Tom Conti-Leslie,</Item>
-    <Item>Luke Elliott,</Item>
-    <Item>Ewan Gilligan,</Item>
-    <Item>Max Horn,</Item>
-    <Item>Christopher Jefferson,</Item>
-    <Item>Markus Pfeiffer,</Item>
-    <Item>Lea Racine,</Item>
-    <Item>Christopher Russell,</Item>
-    <Item>Finn Smith,</Item>
-    <Item>Ben Spiers, and</Item>
-    <Item>Murray Whyte.</Item>
-  </List>
+  Additional contributions were made by many people, for which the authors are
+  very grateful. A full list can be found on the title page.
 
   The &Digraphs; package contains a variety of methods for efficiently creating
   and storing mutable and immutable digraphs and computing information about


### PR DESCRIPTION
This PR removes the outdated list of contributors from the first chapter, and adds "subgraph isomorphism" to the index (addressing #561).