### PR TITLE
Add more descriptive warning when using `NautyAutomorphismGroup` with `MultiDigraph`s

### DIFF
--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -313,8 +313,7 @@ function(D, colors)
       "consider calling either DigraphsUseBliss followed by ",
       "AutomorphismGroup, or BlissAutomorphismGroup.");
     return fail;
-  fi;
-  if not DIGRAPHS_NautyAvailable then
+  elif not DIGRAPHS_NautyAvailable then
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;

--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -305,7 +305,16 @@ end);
 InstallMethod(NautyAutomorphismGroup, "for a digraph and vertex coloring",
 [IsDigraph, IsHomogeneousList],
 function(D, colors)
-  if not DIGRAPHS_NautyAvailable or IsMultiDigraph(D) then
+  if IsMultiDigraph(D) then
+    Info(
+      InfoWarning,
+      1,
+      "NautyTracesInterfaces is not compatible with MultiDigraphs. Please ",
+      "consider calling either DigraphsUseBliss followed by ",
+      "AutomorphismGroup, or BlissAutomorphismGroup.");
+    return fail;
+  fi;
+  if not DIGRAPHS_NautyAvailable then
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;


### PR DESCRIPTION
This PR adds a more descriptive warnings for when `NautyAutomorphismGroup` is used with a `MultiDigraph`.