### PR TITLE
Always close files (`ReadDigraphs`, `WriteDigraphs`)

### DIFF
--- a/gap/io.gi
+++ b/gap/io.gi
@@ -402,7 +402,7 @@ end);
 
 InstallGlobalFunction(ReadDigraphs,
 function(arg...)
-  local nr, decoder, name, file, i, next, out;
+  local nr, decoder, name, file, i, next, out, line;
 
   # defaults
   nr      := infinity;
@@ -474,8 +474,12 @@ function(arg...)
 
   out := [];
   if NameFunction(decoder) in WholeFileDecoders then
-    Add(out, decoder(IO_ReadUntilEOF(file)));
-    next := IO_Nothing;
+    line := IO_ReadUntilEOF(file);
+    if IsString(arg[1]) then
+      IO_Close(file);
+    fi;
+    Add(out, decoder(line));
+    return out;
   else
     next := decoder(file);
   fi;
@@ -606,6 +610,9 @@ function(arg...)
     fi;
     file := DigraphFile(name, encoder, mode);
     if NameFunction(file!.coder) in WholeFileEncoders and file!.mode <> "w" then
+      if IsString(arg[1]) then
+        IO_Close(file);
+      fi;
       ErrorNoReturn(NameFunction(file!.coder), " is a whole file ",
                     "encoder and so the argument <mode> must be \"w\".");
     fi;

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -499,8 +499,7 @@ end);
 InstallGlobalFunction(WriteDigraphs,
 function(arg...)
   local name, digraphs, encoder, mode, splitname, compext, g6sum, s6sum, v, e,
-        dg6sum, ds6sum, file, D, i, out, oldBoE, oldSNE, CloseAndCleanup,
-        SafeEncode;
+        dg6sum, ds6sum, file, D, i, oldBoE, oldSNE, CloseAndCleanup, SafeEncode;
 
   # defaults
   encoder := fail;
@@ -657,8 +656,7 @@ function(arg...)
           " is a whole file encoder, and so only one digraph should be ",
           "specified. Only the last digraph will be encoded.");
     fi;
-    out := SafeEncode(encoder, [digraphs[Length(digraphs)]]);
-    IO_Write(file, out);
+    IO_Write(file, SafeEncode(encoder, [digraphs[Length(digraphs)]]));
   else
     for i in [1 .. Length(digraphs)] do
       SafeEncode(encoder, [file, digraphs[i]]);

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -1059,6 +1059,9 @@ gap> IO_Close(file);;
 # Ensure all files introduced by tests are closed
 gap> IO.OpenFiles = files;
 true
+gap> OnBreak = Where;  # remove this line post debugging
+true
+gap> OnBreak := Where;;  # remove this line post debugging
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(D);

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -893,12 +893,12 @@ gap> str := DIMACSString(gr);
 gap> DigraphFromDIMACSString(str) = gr;
 true
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/more.dimacs");;
-gap> WriteDigraphs(filename, gr);
-Error, DIMACSString is a whole file encoder and so the argument <mode> must be\
- "w".
 gap> WriteDigraphs(filename, gr, "w");;
 gap> ReadDigraphs(filename)[1] = gr;
 true
+gap> WriteDigraphs(filename, gr);
+Error, DIMACSString is a whole file encoder and so the argument <mode> must be\
+ "w".
 gap> DigraphVertexLabels(gr) = [1 .. 3];
 true
 

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -1066,9 +1066,8 @@ gap> IO_Close(file);;
 # Ensure all files introduced by tests are closed
 gap> IO.OpenFiles = files;
 true
-gap> OnBreak = Where;  # remove this line post debugging
+gap> OnBreak = oldOnBreak;
 true
-gap> OnBreak := Where;;  # remove this line post debugging
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(D);

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -13,6 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 gap> files := ShallowCopy(IO.OpenFiles);;
+gap> oldOnBreak := OnBreak;;
 
 #  DigraphFromGraph6String and Graph6String
 gap> DigraphFromGraph6String("?");
@@ -280,6 +281,8 @@ gap> gr[3] := Digraph([[1, 2], [1, 2]]);
 gap> WriteDigraphs(filename, Digraph([[2], []]), Graph6String);
 Error, the argument <D> must be a symmetric digraph with no loops or multiple \
 edges,
+gap> OnBreak := oldOnBreak;;
+gap> IO_Close(IO.OpenFiles[Length(IO.OpenFiles)]);;
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/test.s6.bz2");;
 gap> WriteDigraphs(filename, gr, "w");
 IO_OK
@@ -680,6 +683,8 @@ Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `WriteDIMACSDigraph' on 2 arguments
 gap> WriteDIMACSDigraph("file", ChainDigraph(2));
 Error, the argument <D> must be a symmetric digraph,
+gap> OnBreak := oldOnBreak;;
+gap> IO_Close(IO.OpenFiles[Length(IO.OpenFiles)]);;
 gap> WriteDIMACSDigraph(filename, gr);
 Error, cannot open the file given as the 1st argument <name>,
 gap> filename := "tmp.gz";;
@@ -959,6 +964,8 @@ gap> DreadnautString(D, 1);
 Error, the second argument <partition> must be a list
 gap> WriteDigraphs(filename, Digraph([]), "w");
 Error, the argument <D> must be a digraph with at least one vertex
+gap> OnBreak := oldOnBreak;;
+gap> IO_Close(IO.OpenFiles[Length(IO.OpenFiles)]);;
 gap> WriteDigraphs(filename, D, "w");
 IO_OK
 

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -957,6 +957,8 @@ gap> DreadnautString(1);
 Error, the first argument <D> must be a digraph
 gap> DreadnautString(D, 1);
 Error, the second argument <partition> must be a list
+gap> WriteDigraphs(filename, Digraph([]), "w");
+Error, the argument <D> must be a digraph with at least one vertex
 gap> WriteDigraphs(filename, D, "w");
 IO_OK
 

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -12,6 +12,7 @@ gap> LoadPackage("digraphs", false);;
 
 #
 gap> DIGRAPHS_StartTest();
+gap> files := ShallowCopy(IO.OpenFiles);;
 
 #  DigraphFromGraph6String and Graph6String
 gap> DigraphFromGraph6String("?");
@@ -276,6 +277,9 @@ gap> gr = ReadDigraphs(filename);
 true
 gap> gr[3] := Digraph([[1, 2], [1, 2]]);
 <immutable digraph with 2 vertices, 4 edges>
+gap> WriteDigraphs(filename, Digraph([[2], []]), Graph6String);
+Error, the argument <D> must be a symmetric digraph with no loops or multiple \
+edges,
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/test.s6.bz2");;
 gap> WriteDigraphs(filename, gr, "w");
 IO_OK
@@ -889,6 +893,9 @@ gap> str := DIMACSString(gr);
 gap> DigraphFromDIMACSString(str) = gr;
 true
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/more.dimacs");;
+gap> WriteDigraphs(filename, gr);
+Error, DIMACSString is a whole file encoder and so the argument <mode> must be\
+ "w".
 gap> WriteDigraphs(filename, gr, "w");;
 gap> ReadDigraphs(filename)[1] = gr;
 true
@@ -1045,6 +1052,11 @@ gap> DigraphFromDreadnautString("$=1n3dg\n1 : 2 3.\nf=[1:\n:]");
 Error, Invalid range 1 : ':' in partition specification (line 3)
 gap> DigraphFromDreadnautString("$=1n3dg\n1 : 2 3.\nf=[1\nf=2");
 Error, Unexpected character 'f' in partition specification (line 4)
+gap> IO_Close(file);;
+
+# Ensure all files introduced by tests are closed
+gap> IO.OpenFiles = files;
+true
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(D);
@@ -1066,6 +1078,7 @@ gap> Unbind(rdgr);
 gap> Unbind(read);
 gap> Unbind(str);
 gap> Unbind(x);
+gap> Unbind(files);
 
 #
 gap> DIGRAPHS_StopTest();


### PR DESCRIPTION
Related to #377, which ensured files close on error when decoding.

`ReadDigraphs` is leaving files open if a malformed file is fed in when using a whole file decoder (dreadnaut/dimacs) -- my bad. I had also carelessly left a file open in the tests. The suggested changes fixes those issues.

Something that's not my fault is that this issue propagates to encoding with `WriteDigraphs` but affects all file formats. I think this issue has probably been around for a while. If we encounter an error while encoding (i.e. due to the digraph being incompatible somehow with the file format), then the file isn't closed. For instance,

```
gap> filename := "/Users/pramothragavan/Downloads/10.txt";;
gap> D := Digraph([[2], []]);
<immutable digraph with 2 vertices, 1 edge>
gap> IO.OpenFiles;
[  ]
gap> WriteDigraphs(filename, D, Graph6String);
Error, the argument <D> must be a symmetric digraph with no loops or multiple edges, at /Users/pramothragavan/gap/pkg/Digraphs/gap/io.gi:2227 called from
encoder( D ) at /Users/pramothragavan/gap/pkg/Digraphs/gap/io.gi:246 called from
encoder( file, digraphs[i] ); at /Users/pramothragavan/gap/pkg/Digraphs/gap/io.gi:640 called from
<function "WriteDigraphs">( <arguments> )
 called from read-eval loop at *stdin*:8
type 'quit;' to quit to outer loop
brk> quit;
gap> IO.OpenFiles;
[ <file fd=4 wbufsize=65536 wdata=0> ]
```

I'm not really sure how to fix this, because you inevitably need to keep the file open while the digraph is being encoded. Is there maybe a good way of doing a try/catch style statement?

I've added a few lines to the tests to make sure the list of open files is the same before and after the test runs. Consequently, CI should fail here.