### PR TITLE
Implement Meet/JoinSemilatticeTableIntoDigraph functions

### DIFF
--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -154,3 +154,7 @@ DeclareOperation("PartialOrderDigraphJoinOfVertices",
                  [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("PartialOrderDigraphMeetOfVertices",
                  [IsDigraph, IsPosInt, IsPosInt]);
+
+# 11. Operations for tables . . .
+DeclareOperation("DigraphFromMeetTable", [IsList])
+DeclareOperation("DigraphFromJoinTable", [IsList])

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -156,5 +156,5 @@ DeclareOperation("PartialOrderDigraphMeetOfVertices",
                  [IsDigraph, IsPosInt, IsPosInt]);
 
 # 11. Operations for tables . . .
-DeclareOperation("DigraphFromMeetTable", [IsList])
-DeclareOperation("DigraphFromJoinTable", [IsList])
+DeclareOperation("DigraphFromMeetTable", [IsList]);
+DeclareOperation("DigraphFromJoinTable", [IsList]);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -21,6 +21,7 @@
 # 8.  IsSomething
 # 9.  Connectivity
 # 10. Operations for vertices
+# 11. Operations for tables
 #############################################################################
 
 #############################################################################
@@ -2679,7 +2680,88 @@ function(D, i, j)
     if intr = Set(nbs[x]) then
       return x;
     fi;
-  od;
+    od;
 
   return fail;
 end);
+
+#############################################################################
+# 11. Operations for tables
+#############################################################################
+
+InstallMethod(DigraphFromMeetTable,
+"for a meet table for a meet semilattice Digraph",
+[IsList],
+function(meet_table)
+  local n, adj, i, j, output;
+  # Input verification: must be a square matrix
+    n := Length(meet_table);
+    if not ForAll(meet_table, row -> Length(row) = n) then
+      Error("Input is not a square matrix.");
+    fi;
+
+    n := Length(meet_table);
+
+  # Initialise adjacency list
+  # Every node must be related to itself to satisfy reflexitivity
+  adj := List([1 .. n], x -> [x]);
+  for i in [1 .. n] do
+    for j in [1 .. n] do
+      # meet_table[i][j]=i for meet semilattice
+      if meet_table[i][j] = i and i <> j then
+        Add(adj[i], j);
+      fi;
+      od;
+    od;
+
+  # Create a Digraph using the adjacency list
+  output := Digraph(adj);
+
+  # Post-condition tests
+  if IsMeetSemilatticeDigraph(output) then
+    if DigraphMeetTable(output) = meet_table then
+      return output;
+    else return fail;
+    fi;
+  else return fail;
+  fi;
+end);
+
+InstallMethod(DigraphFromJoinTable,
+"for a join table for a join semilattice Digraph",
+[IsList],
+function(join_table)
+  local n, adj, i, j, output;
+
+  # Input verification: must be a square matrix
+  n := Length(join_table);
+  if not ForAll(join_table, row -> Length(row) = n) then
+    Error("Input is not a square matrix.");
+  fi;
+
+  # Initialise adjacency list
+  # Every node must be related to itself to satisfy reflexitivity
+  adj := List([1..n], x -> [x]);
+  for i in [1 .. n] do
+    for j in [1 .. n] do
+      if join_table[i][j] = j and i <> j then
+        # join_table[i][j] = j for join semilattice
+        Add(adj[i], j);
+      fi;
+    od;
+  od;
+
+  # Create a Digraph using the adjacency list
+  output := Digraph(adj);
+
+  # Post-condition tests
+  if IsJoinSemilatticeDigraph(output) then
+    if DigraphJoinTable(output) = join_table then
+      return output;
+    else return fail;
+    fi;
+  else return fail;
+  fi;
+
+end);
+                                                                                                                                  

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -2680,7 +2680,7 @@ function(D, i, j)
     if intr = Set(nbs[x]) then
       return x;
     fi;
-    od;
+  od;
 
   return fail;
 end);
@@ -2741,7 +2741,7 @@ function(join_table)
 
   # Initialise adjacency list
   # Every node must be related to itself to satisfy reflexitivity
-  adj := List([1..n], x -> [x]);
+  adj := List([1 .. n], x -> [x]);
   for i in [1 .. n] do
     for j in [1 .. n] do
       if join_table[i][j] = j and i <> j then
@@ -2764,4 +2764,3 @@ function(join_table)
   fi;
 
 end);
-                                                                                                                                  

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -3234,6 +3234,20 @@ gap> DigraphEdges(D);
 gap> DigraphVertexLabels(D);
 [ 1, 2, 3, 6, [ 4, 5 ] ]
 
+# DigraphFromMeetTable
+gap> DigraphFromMeetTable([[1,1],[1,2]]);
+<immutable meet semilattice digraph with 2 vertices, 3 edges>
+gap> DigraphFromMeetTable([[1, 1, 1, 1],[1, 2, 1, 2],[1, 1, 3, 3],[1, 2, 3, 4]]);
+<immutable meet semilattice digraph with 4 vertices, 9 edges>
+gap> DigraphFromMeetTable([[1,3,2],[2,3,1],[3,3,3]]);
+fail
+
+# DigraphFromJoinTable
+gap> DigraphFromJoinTable([[1, 3, 3],[3, 2, 3],[3, 3, 3]]);
+<immutable join semilattice digraph with 3 vertices, 5 edges>
+gap> DigraphFromJoinTable([[1,3,2],[2,3,1],[3,3,3]]);
+fail
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(C);
 gap> Unbind(D);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -3235,17 +3235,17 @@ gap> DigraphVertexLabels(D);
 [ 1, 2, 3, 6, [ 4, 5 ] ]
 
 # DigraphFromMeetTable
-gap> DigraphFromMeetTable([[1,1],[1,2]]);
+gap> DigraphFromMeetTable([[1, 1], [1, 2]]);
 <immutable meet semilattice digraph with 2 vertices, 3 edges>
-gap> DigraphFromMeetTable([[1, 1, 1, 1],[1, 2, 1, 2],[1, 1, 3, 3],[1, 2, 3, 4]]);
+gap> DigraphFromMeetTable([[1, 1, 1, 1], [1, 2, 1, 2], [1, 1, 3, 3], [1, 2, 3, 4]]);
 <immutable meet semilattice digraph with 4 vertices, 9 edges>
-gap> DigraphFromMeetTable([[1,3,2],[2,3,1],[3,3,3]]);
+gap> DigraphFromMeetTable([[1, 3, 2], [2, 3, 1], [3, 3, 3]]);
 fail
 
 # DigraphFromJoinTable
-gap> DigraphFromJoinTable([[1, 3, 3],[3, 2, 3],[3, 3, 3]]);
+gap> DigraphFromJoinTable([[1, 3, 3], [3, 2, 3], [3, 3, 3]]);
 <immutable join semilattice digraph with 3 vertices, 5 edges>
-gap> DigraphFromJoinTable([[1,3,2],[2,3,1],[3,3,3]]);
+gap> DigraphFromJoinTable([[1, 3, 2], [2, 3, 1], [3, 3, 3]]);
 fail
 
 #  DIGRAPHS_UnbindVariables


### PR DESCRIPTION
Attempted to solve issue [#553 ](https://github.com/digraphs/Digraphs/issues/553) using a rather naive approach - creating an adjacency list from reading out the meet/join semilattice table in its entirety, and outputting a digraph from this list. Efficiency could be improved using known matrix properties.