### PR TITLE
Use gap_all.h instead of compiled.h

### DIFF
--- a/src/gap-includes.h
+++ b/src/gap-includes.h
@@ -25,6 +25,6 @@
 #pragma GCC diagnostic ignored "-Winline"
 #endif
 // GAP headers
-#include "compiled.h"  // for Obj, Int
+#include "gap_all.h"  // for Obj, Int
 
 #endif  // DIGRAPHS_SRC_GAP_INCLUDES_H_


### PR DESCRIPTION
Available since GAP 4.12, which this package requires anyway.
