### PR TITLE
Add `doc/title.xml` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ digraphs-config.h
 digraphs-lib
 doc/_*.xml
 doc/main.xml
+doc/title.xml
 gen/
 gh-pages/
 main.xml


### PR DESCRIPTION
This file was deleted in commit 8062ca7 because it is auto-generated, so we don't need it in the repo. So we should therefore ignore it.