### PR TITLE
Update the "Release" GitHub Action workflow to not wipe the website code with each new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,14 @@ jobs:
           dry-run: ${{ inputs.dry-run }}
       - uses: gap-actions/update-gh-pages@v1
         if: ${{ !inputs.dry-run }}
+        with:
+          # The <clean> option stops the action from updating the website with
+          # the latest GitHubPagesForGAP code, because we have customised our
+          # website (with e.g. a section linking to the Digraphs library, and
+          # the Digraphs library itself), and these changes would be overwritten
+          # if this option was set to <true>, which is the default. However,
+          # we might want to manually update the GitHubPagesForGAP code from
+          # time to time, to receive any bugfixes or updates to parts of the
+          # website code that we haven't customised. But this would have to be
+          # done carefully.
+          clean: false


### PR DESCRIPTION
I hadn't read the [`gap-actions/update-gh-pages` README](https://github.com/gap-actions/update-gh-pages/blob/main/README.md), so I didn't know about the existence of the `clean` option, which I think we want to be set to `false`.

I'll merge this as-is, but the real test will come when we make the next Digraphs release (which I'll do in the coming days, I hope).