### PR TITLE
Release CI: clone NautyTracesInterface so that we know its URL for `_data/package.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: gap-actions/setup-gap@v2
         with:
+          GAP_PKGS_TO_CLONE: NautyTracesInterface
           GAP_PKGS_TO_BUILD: json
       - uses: gap-actions/build-pkg-docs@v1
         with:


### PR DESCRIPTION
I'm hoping that this fixes #798.