### PR TITLE
CI: test against GAP `stable-4.15` as the latest stable branch

### DIFF
--- a/.github/workflows/config_options.yml
+++ b/.github/workflows/config_options.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           GAP_PKGS_TO_CLONE: NautyTracesInterface digraphs/graphviz
           GAP_PKGS_TO_BUILD: io orb datastructures grape NautyTracesInterface
-          GAPBRANCH: stable-4.14
+          GAPBRANCH: stable-4.15
       - name: Build Digraphs . . .
         uses: gap-actions/build-pkg@v1
         with:
@@ -95,7 +95,7 @@ jobs:
         with:
           GAP_PKGS_TO_CLONE: NautyTracesInterface digraphs/graphviz
           GAP_PKGS_TO_BUILD: io orb datastructures grape NautyTracesInterface
-          GAPBRANCH: stable-4.14
+          GAPBRANCH: stable-4.15
       - name: Build Digraphs . . .
         uses: gap-actions/build-pkg@v1
         with:

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   test-unix:
-    name: ${{ matrix.os }}${{ matrix.ABI }} / GAP stable-4.14
+    name: ${{ matrix.os }}${{ matrix.ABI }} / GAP stable-4.15
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -47,7 +47,7 @@ jobs:
         with:
           GAP_PKGS_TO_CLONE: ${{ matrix.pkgs-to-clone }}
           GAP_PKGS_TO_BUILD: ${{ matrix.pkgs-to-build }}
-          GAPBRANCH: stable-4.14
+          GAPBRANCH: stable-4.15
           ABI: ${{ matrix.ABI }}
       - name: Build Digraphs . . .
         uses: gap-actions/build-pkg@v1
@@ -79,7 +79,7 @@ jobs:
           GAP_TESTFILE: tst/github_actions/extreme.g
 
   test-cygwin:
-    name: cygwin / GAP stable-4.14
+    name: cygwin / GAP stable-4.15
     runs-on: windows-latest
     env:
       CHERE_INVOKING: 1
@@ -90,7 +90,7 @@ jobs:
         with:
           GAP_PKGS_TO_CLONE: NautyTracesInterface digraphs/graphviz
           GAP_PKGS_TO_BUILD: io orb datastructures grape NautyTracesInterface
-          GAPBRANCH: stable-4.14
+          GAPBRANCH: stable-4.15
       - uses: gap-actions/build-pkg@cygwin-v1
       - name: Install digraphs-lib . . .
         run: |

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -85,7 +85,9 @@ jobs:
       CHERE_INVOKING: 1
     steps:
       - uses: actions/checkout@v5
-      - uses: gap-actions/setup-cygwin@v1
+      - uses: gap-actions/setup-cygwin@v2
+        with:
+          extra-pkgs-to-install: automake
       - uses: gap-actions/setup-gap@v2
         with:
           GAP_PKGS_TO_CLONE: NautyTracesInterface digraphs/graphviz
@@ -96,6 +98,6 @@ jobs:
         run: |
           curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${{ env.DIGRAPHS_LIB }}.tar.gz"
           tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
-      - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/run-pkg-tests@v3
         with:
           NO_COVERAGE: true

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -86,16 +86,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: gap-actions/setup-cygwin@v1
-      - uses: gap-actions/setup-gap@cygwin-v2
+      - uses: gap-actions/setup-gap@v2
         with:
           GAP_PKGS_TO_CLONE: NautyTracesInterface digraphs/graphviz
           GAP_PKGS_TO_BUILD: io orb datastructures grape NautyTracesInterface
           GAPBRANCH: stable-4.15
-      - uses: gap-actions/build-pkg@cygwin-v1
+      - uses: gap-actions/build-pkg@v1
       - name: Install digraphs-lib . . .
         run: |
           curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${{ env.DIGRAPHS_LIB }}.tar.gz"
           tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
-      - uses: gap-actions/run-pkg-tests@cygwin-v2
+      - uses: gap-actions/run-pkg-tests@v2
         with:
           NO_COVERAGE: true

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -31,6 +31,7 @@ jobs:
           - stable-4.12
           - stable-4.13
           - stable-4.14
+          - stable-4.15
         only-needed:
           - true
           - false

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   test-valgrind:
-    name: Ubuntu / GAP stable-4.14 / valgrind
+    name: Ubuntu / GAP stable-4.15 / valgrind
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -33,7 +33,7 @@ jobs:
         with:
           GAP_PKGS_TO_CLONE: NautyTracesInterface digraphs/graphviz
           GAP_PKGS_TO_BUILD: io orb datastructures grape NautyTracesInterface
-          GAPBRANCH: stable-4.14
+          GAPBRANCH: stable-4.15
           CONFIGFLAGS: --enable-valgrind
       - name: Build Digraphs . . .
         uses: gap-actions/build-pkg@v1


### PR DESCRIPTION
The latest GAP stable branch is GAP `stable-4.15`.  Where we test against all available supported GAP stable branches, I've added `stable-4.15` as an additional job. Where we were previously using just `stable-4.14` (i.e. as the "latest" stable branch, presumably), I've changed from `stable-4.14` to `stable-4.15`.

Also I'm attempting to incorporate a working version of #799.