### PR TITLE
Use the `CHANGELOG` entry for the GitHub release in the GitHub Actions "Release" workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         type: boolean
         required: false
         default: false
+      force:
+        description: "Allow overwriting an existing release, or making a release with an incorrect date"
+        type: boolean
+        required: false
+        default: false
 
 permissions: write-all
 
@@ -30,9 +35,40 @@ jobs:
         run: |
           rm -f  .covignore .mailmap .codespellrc Dockerfile
           rm -rf etc scripts
+      - name: Extract the latest CHANGELOG entry to use as the GitHub release text
+        run: |
+          # Extract the part of CHANGELOG that is relevant to this release
+          LINES=`grep -n "## Version " CHANGELOG.md | head -2 | cut -d':' -f1`
+
+          # Find the line number where the relevant section starts
+          # (Increment by 1 if that first line is empty)
+          START=`echo $LINES | cut -d' ' -f1`;
+          START=$((START + 1))
+          if [ "`sed \"${START}q;d\" CHANGELOG.md`" == "" ]; then
+            START=$(( START + 1 ));
+          fi
+
+          # Find the line number where the relevant section ends
+          # (Decrement by 1 if that last line is empty)
+          STOP=`echo $LINES | cut -d' ' -f2`;
+          STOP=$((STOP - 1))
+          if [ "`sed \"${STOP}q;d\" CHANGELOG.md`" == "" ]; then
+            STOP=$(( STOP - 1 ));
+          fi
+
+          # Store the potentially multi-line text in the BODY environment so
+          # that we can pass it to the release-pkg action as an input
+          {
+            echo 'BODY<<EOF'
+            sed -n "${START},${STOP}p" CHANGELOG.md
+            echo EOF
+          } >> "$GITHUB_ENV"
+
       - uses: gap-actions/release-pkg@v1
         with:
           dry-run: ${{ inputs.dry-run }}
+          force: ${{ inputs.force }}
+          body-text: ${{ env.BODY }}
       - uses: gap-actions/update-gh-pages@v1
         if: ${{ !inputs.dry-run }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,45 +7,26 @@ Licensing information can be found in the `LICENSE` file.
 ## Version 1.12.0 (released 02/09/2025)
 
 ## What's Changed
-* [@wilfwilson](https://github.com/wilfwilson) added `IsDirectedForest` in
-[PR #794](https://github.com/digraphs/Digraphs/pull/794).
+* [@wilfwilson](https://github.com/wilfwilson) added `IsDirectedForest` in [PR #794](https://github.com/digraphs/Digraphs/pull/794).
 
 **Full Changelog**: <https://github.com/digraphs/Digraphs/compare/v1.11.0...v1.12.0>
 
 ## Version 1.11.0 (released 28/08/2025)
 
 ## What's Changed
-* Added `IsTwoEdgeTransitive` by [@frankiegillis](https://github.com/frankiegillis) in
-[PR #733](https://github.com/digraphs/Digraphs/pull/733).
-* [@flsmith](https://github.com/flsmith) made `RandomDigraph` more random in
-[PR #738](https://github.com/digraphs/Digraphs/pull/738).
-* Added `BurntPancakeGraph` and `BurntPancakeGraph` in
-[PR #403](https://github.com/digraphs/Digraphs/pull/403).
-* Added a new optional first argument for mutability in `CayleyDigraph` by
-[@james-d-mitchell](https://github.com/james-d-mitchell) in [PR #403](https://github.com/digraphs/Digraphs/pull/403).
-* Added `MinimalCyclicEdgeCut` by [@MeikeWeiss](https://github.com/MeikeWeiss) in
-[PR #754](https://github.com/digraphs/Digraphs/pull/754).
-* Added `DigraphAllChordlessCyclesOfMaximalLength` by [@MeikeWeiss](https://github.com/MeikeWeiss) in
-[PR #754](https://github.com/digraphs/Digraphs/pull/754).
-* Added `DigraphKings` and `DigraphIsKing` by [@hrj4](https://github.com/hrj4) in
-[PR #521](https://github.com/digraphs/Digraphs/pull/521).
-* [@wilfwilson](https://github.com/wilfwilson) improved `ViewString` for digraphs in
-[PR #783](https://github.com/digraphs/Digraphs/pull/783).
-* [@EwanGilligan](https://github.com/EwanGilligan) implemented Zykov's and Christofides's algorithms and made them
-available as options for `ChromaticNumber` in
-[PR #491](https://github.com/digraphs/Digraphs/pull/491).
-* [@ChrisJefferson](https://github.com/ChrisJefferson) sped up `OnDigraphs` for a digraph and a permutation in
-[PR #267](https://github.com/digraphs/Digraphs/pull/267).
-* [@pramothragavan](https://github.com/pramothragavan) added dreadnaut support in
-[PR #651](https://github.com/digraphs/Digraphs/pull/651), along with the functions
-`DreadnautString`, `DigraphFromDreadnautString`, `DIMACSString`, and
-`DigraphFromDIMACSString`; and the variables `WholeFileEncoders` and
-`WholeFileDecoders` and the functions `IsWholeFileEncoder` and
-`IsWholeFileDecoder`.
-* [@RaiyanC](https://github.com/RaiyanC) added `DigraphMaximumFlow` in
-[PR #751](https://github.com/digraphs/Digraphs/pull/751).
-* [@RaiyanC](https://github.com/RaiyanC) added `RandomUniqueEdgeWeightedDigraph`
-[PR #755](https://github.com/digraphs/Digraphs/pull/755).
+* Added `IsTwoEdgeTransitive` by [@frankiegillis](https://github.com/frankiegillis) in [PR #733](https://github.com/digraphs/Digraphs/pull/733).
+* [@flsmith](https://github.com/flsmith) made `RandomDigraph` more random in [PR #738](https://github.com/digraphs/Digraphs/pull/738).
+* Added `BurntPancakeGraph` and `BurntPancakeGraph` in [PR #403](https://github.com/digraphs/Digraphs/pull/403).
+* Added a new optional first argument for mutability in `CayleyDigraph` by [@james-d-mitchell](https://github.com/james-d-mitchell) in [PR #403](https://github.com/digraphs/Digraphs/pull/403).
+* Added `MinimalCyclicEdgeCut` by [@MeikeWeiss](https://github.com/MeikeWeiss) in [PR #754](https://github.com/digraphs/Digraphs/pull/754).
+* Added `DigraphAllChordlessCyclesOfMaximalLength` by [@MeikeWeiss](https://github.com/MeikeWeiss) in [PR #754](https://github.com/digraphs/Digraphs/pull/754).
+* Added `DigraphKings` and `DigraphIsKing` by [@hrj4](https://github.com/hrj4) in [PR #521](https://github.com/digraphs/Digraphs/pull/521).
+* [@wilfwilson](https://github.com/wilfwilson) improved `ViewString` for digraphs in [PR #783](https://github.com/digraphs/Digraphs/pull/783).
+* [@EwanGilligan](https://github.com/EwanGilligan) implemented Zykov's and Christofides's algorithms and made them available as options for `ChromaticNumber` in [PR #491](https://github.com/digraphs/Digraphs/pull/491).
+* [@ChrisJefferson](https://github.com/ChrisJefferson) sped up `OnDigraphs` for a digraph and a permutation in [PR #267](https://github.com/digraphs/Digraphs/pull/267).
+* [@pramothragavan](https://github.com/pramothragavan) added dreadnaut support in [PR #651](https://github.com/digraphs/Digraphs/pull/651), along with the functions `DreadnautString`, `DigraphFromDreadnautString`, `DIMACSString`, and `DigraphFromDIMACSString`; and the variables `WholeFileEncoders` and `WholeFileDecoders` and the functions `IsWholeFileEncoder` and `IsWholeFileDecoder`.
+* [@RaiyanC](https://github.com/RaiyanC) added `DigraphMaximumFlow` in [PR #751](https://github.com/digraphs/Digraphs/pull/751).
+* [@RaiyanC](https://github.com/RaiyanC) added `RandomUniqueEdgeWeightedDigraph` [PR #755](https://github.com/digraphs/Digraphs/pull/755).
 
 ## New Contributors
 * [@BaseMax](https://github.com/BaseMax) made their first contribution in [PR #749](https://github.com/digraphs/Digraphs/pull/749).


### PR DESCRIPTION
This uses some bash (involving some peculiar GitHub Actions syntax for getting multiline strings into an environment variable) with `grep` and `cut` and `sed` to extract the latest part of the `CHANGELOG.md` file, and pass it as input to the `release-pkg` action.

Also adds a "force" option to this workflow.