### PR TITLE
Remove the redundant `.covignore` file

### DIFF
--- a/.covignore
+++ b/.covignore
@@ -1,2 +1,0 @@
-utils.tst
-io.tst

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           use-latex: true
       - name: Clean up additional files
         run: |
-          rm -f  .covignore .mailmap .codespellrc Dockerfile
+          rm -f  .mailmap .codespellrc Dockerfile
           rm -rf etc
       - name: Extract the latest CHANGELOG entry to use as the GitHub release text
         run: |


### PR DESCRIPTION
We used to use this in the old Travis setup; we had a job that verified that each `tst/standard/FILE.tst` individually gave at least 95% code coverage of the corresponding `gap/FILE.gi` file. We couldn't realistically achieve this for `utils.tst` and `io.tst`, so we excluded them via a file that we named `.covignore`.

But this setup is long gone, so let's remove the corresponding stuff.