### PR TITLE
Automatically copy the latest CHANGELOG.md to the website when making a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
           dry-run: ${{ inputs.dry-run }}
           force: ${{ inputs.force }}
           body-text: ${{ env.BODY }}
+
       - uses: gap-actions/update-gh-pages@v1
-        if: ${{ !inputs.dry-run }}
         with:
           # The <clean> option stops the action from updating the website with
           # the latest GitHubPagesForGAP code, because we have customised our
@@ -89,3 +89,5 @@ jobs:
           # website code that we haven't customised. But this would have to be
           # done carefully.
           clean: false
+          dry-run: ${{ inputs.dry-run }}
+          extra-files: "CHANGELOG.md"


### PR DESCRIPTION
This will use the latest `gap-actions/update-gh-pages`, once my PR https://github.com/gap-actions/update-gh-pages/pull/8 has been merged and the `v1` tag updated on that repository (which hasn't happened yet, so the changes in this PR won't do anything yet).