### PR TITLE
PackageInfo.g: remove XML entities from `AbstractHTML`

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -621,7 +621,10 @@ AutoDoc := rec(
           on work by Max Neunh&#246;ffer, and independently Artur Sch&#228;fer.
         """)),
 
-        AbstractHTML := ~.AutoDoc.TitlePage.Abstract));
+        AbstractHTML := ReplacedString(ReplacedString(
+            ~.AutoDoc.TitlePage.Abstract,
+            "&Digraphs;", "<Strong>Digraphs</Strong>"),
+            "&GAP;", "<Strong>GAP</Strong>")));
 
 if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
   Unbind(IsKernelExtensionAvailable);


### PR DESCRIPTION
For the HTML version of the abstract, just string-replace `&Digraphs;` and `&GAP;` by `<Strong>Digraphs</Strong>` and `<Strong>GAP</Strong>` respectively; that's how we want them anyway.

You can already see the result of this at https://digraphs.github.io/Digraphs.

Resolves #711.