### PR TITLE
Discard fewer tests when GRAPE isn't loaded

### DIFF
--- a/read.g
+++ b/read.g
@@ -9,7 +9,9 @@
 ##
 
 if not DIGRAPHS_IsGrapeLoaded() then
-  Add(DIGRAPHS_OmitFromTests, "Graph(");
+  Add(DIGRAPHS_OmitFromTests, " Graph(");
+  Add(DIGRAPHS_OmitFromTests, "(Graph(");
+  Add(DIGRAPHS_OmitFromTests, "AsGraph(");
 fi;
 
 _NautyTracesInterfaceVersion :=


### PR DESCRIPTION
When GRAPE isn't loaded, we want to avoid using the GRAPE functions `Graph()` and `AsGraph()`. Previously, we were ensuring this by discarding tests that included the string `Graph(`. However, this was discarding too much, since we have many Digraphs functions that contain the substring `Graph`, such as `PathGraph` and `DualPlanarGraph` and `BurntPancakeGraph`, and we can test these functions just fine when GRAPE isn't loaded.

Searching instead for `AsGraph(`, `(Graph(` and ` Graph(` seems to give us exactly the result we want.

When GRAPE isn't loaded, we now (for instance) run about 323 manual examples rather than 261 previously; when GRAPE is loaded, we run 327, which means that we're only needing to exclude 4 manual example. This shows that we were excluding far too much!

Fixes #821.