### PR TITLE
Make `DIGRAPHS_OmitFromTests` be dynamically calculated

### DIFF
--- a/gap/utils.gd
+++ b/gap/utils.gd
@@ -8,7 +8,7 @@
 #############################################################################
 ##
 
-BindGlobal("DIGRAPHS_OmitFromTests", []);
+DeclareGlobalFunction("DIGRAPHS_OmitFromTests");
 
 DeclareGlobalFunction("DIGRAPHS_Dir");
 DeclareGlobalFunction("DIGRAPHS_ManualExamples");

--- a/gap/utils.gi
+++ b/gap/utils.gi
@@ -254,7 +254,7 @@ function(arg...)
                     ",");
     fi;
   else
-    omit := DIGRAPHS_OmitFromTests;
+    omit := DIGRAPHS_OmitFromTests();
     if Length(omit) > 0 then
       if Length(omit) = 1 then
         Print("# not testing examples containing the string ");

--- a/read.g
+++ b/read.g
@@ -8,11 +8,17 @@
 #############################################################################
 ##
 
-if not DIGRAPHS_IsGrapeLoaded() then
-  Add(DIGRAPHS_OmitFromTests, " Graph(");
-  Add(DIGRAPHS_OmitFromTests, "(Graph(");
-  Add(DIGRAPHS_OmitFromTests, "AsGraph(");
-fi;
+InstallGlobalFunction(DIGRAPHS_OmitFromTests,
+function()
+  local omit;
+  omit := [];
+  if not DIGRAPHS_IsGrapeLoaded() then
+    Add(omit, " Graph(");
+    Add(omit, "(Graph(");
+    Add(omit, "AsGraph(");
+  fi;
+  return omit;
+end);
 
 _NautyTracesInterfaceVersion :=
   First(PackageInfo("digraphs")[1].Dependencies.SuggestedOtherPackages,


### PR DESCRIPTION
It changes `DIGRAPHS_OmitFromTests` to be a list, it's now a function that returns a list. This means that, for instance, whether or not GRAPE tests will be excluded from being tested will depend on whether or not GRAPE is loaded at that point, which can change during a GAP session.

Resolves #536.