### PR TITLE
Re-add codecov code coverage to the CI

### DIFF
--- a/.github/workflows/config_options.yml
+++ b/.github/workflows/config_options.yml
@@ -62,21 +62,21 @@ jobs:
       - name: "Build additional necessary GAP packages . . ."
         run: |
           cd ${GAPROOT}/pkg
-          ../bin/BuildPackages.sh --strict io orb datastructures grape NautyTracesInterface
+          ../bin/BuildPackages.sh --strict io orb datastructures profiling grape NautyTracesInterface
       - name: Build Digraphs . . .
         uses: gap-actions/build-pkg@v2
         with:
           CONFIGFLAGS: ${{ matrix.bliss }} ${{ matrix.planarity }}
       - name: Run Digraphs package's tst/teststandard.g . . .
         uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v5
         with:
-          coverage: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   all-options:
     name: ${{ matrix.debug }} ${{ matrix.warnings }} ${{ matrix.without-intrinsics }}
     runs-on: ubuntu-latest
-    env:
-      NO_COVERAGE: true
     strategy:
       fail-fast: false
       matrix:
@@ -111,10 +111,14 @@ jobs:
       - name: "Build additional necessary packages"
         run: |
           cd ${GAPROOT}/pkg
-          ../bin/BuildPackages.sh --strict io orb datastructures grape NautyTracesInterface
+          ../bin/BuildPackages.sh --strict io orb datastructures profiling grape NautyTracesInterface
       - name: Build Digraphs . . .
         uses: gap-actions/build-pkg@v2
         with:
           CONFIGFLAGS: ${{ matrix.debug }} ${{ matrix.without-intrinsics }} ${{ matrix.warnings && '--enable-compile-warnings WARNING_CXXFLAGS="-Werror" WARNING_CFLAGS="-Werror"' || '' }}
       - name: Run Digraphs package's tst/teststandard.g . . .
         uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -28,15 +28,15 @@ jobs:
           - os: ubuntu
             ABI: 32
             pkgs-to-clone: https://github.com/digraphs/graphviz.git
-            pkgs-to-build: io orb datastructures grape
+            pkgs-to-build: io orb datastructures grape profiling
           - os: macos
             ABI: 64
             pkgs-to-clone: https://github.com/digraphs/graphviz.git https://github.com/gap-packages/NautyTracesInterface.git
-            pkgs-to-build: io orb datastructures grape NautyTracesInterface
+            pkgs-to-build: io orb datastructures grape profiling NautyTracesInterface
           - os: windows
             ABI: 64
             pkgs-to-clone: https://github.com/digraphs/graphviz.git https://github.com/gap-packages/NautyTracesInterface.git
-            pkgs-to-build: io orb datastructures grape NautyTracesInterface
+            pkgs-to-build: io orb datastructures grape profiling NautyTracesInterface
 
 
     steps:
@@ -93,21 +93,21 @@ jobs:
       - name: Run DigraphsTestInstall . . .
         uses: gap-actions/run-pkg-tests@v4
         with:
-          coverage: false
           testfile: tst/github_actions/install.g
       - name: Run DigraphsTestStandard . . .
         uses: gap-actions/run-pkg-tests@v4
         with:
-          coverage: false
           testfile: tst/github_actions/standard.g
       - name: Run DigraphsTestManualExamples . . .
         uses: gap-actions/run-pkg-tests@v4
         with:
-          coverage: false
           testfile: tst/github_actions/examples.g
       - name: Run DigraphsTestExtreme . . .
         uses: gap-actions/run-pkg-tests@v4
         if: ${{ runner.os != 'Windows' }}
         with:
-          coverage: false
           testfile: tst/github_actions/extreme.g
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,11 +38,11 @@ jobs:
           - only-needed: true
             pkgs-to-clone: https://github.com/digraphs/graphviz.git
             # Remove asterisks * when we no longer support GAP 4.11
-            pkgs-to-build: io* orb* datastructures*
+            pkgs-to-build: io* orb* datastructures* profiling*
           - only-needed: false
             pkgs-to-clone: https://github.com/digraphs/graphviz.git https://github.com/gap-packages/NautyTracesInterface.git
             # Remove asterisks * when we no longer support GAP 4.11
-            pkgs-to-build: io* orb* datastructures* grape* NautyTracesInterface
+            pkgs-to-build: io* orb* datastructures* profiling* grape* NautyTracesInterface
 
     steps:
       - uses: actions/checkout@v5
@@ -71,24 +71,24 @@ jobs:
       - name: Run DigraphsTestInstall . . .
         uses: gap-actions/run-pkg-tests@v4
         with:
-          coverage: false
           testfile: tst/github_actions/install.g
           only-needed: ${{ matrix.only-needed }}
       - name: Run DigraphsTestStandard . . .
         uses: gap-actions/run-pkg-tests@v4
         with:
-          coverage: false
           testfile: tst/github_actions/standard.g
           only-needed: ${{ matrix.only-needed }}
       - name: Run DigraphsTestManualExamples . . .
         uses: gap-actions/run-pkg-tests@v4
         with:
-          coverage: false
           testfile: tst/github_actions/examples.g
           only-needed: ${{ matrix.only-needed }}
       - name: Run DigraphsTestExtreme . . .
         uses: gap-actions/run-pkg-tests@v4
         with:
-          coverage: false
           testfile: tst/github_actions/extreme.g
           only-needed: ${{ matrix.only-needed }}
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I have installed a global upload token for Codecov as a secret in the `digraphs` GitHub organisation. This is now necessary for uploading reports to codecov.io.