### PR TITLE
Add perfectly good test files that nevertheless fail, to demonstrate that they fail

### DIFF
--- a/tst/standard/broken1.tst
+++ b/tst/standard/broken1.tst
@@ -1,0 +1,33 @@
+#
+gap> START_TEST("Digraphs package: standard/broken1.tst");
+gap> LoadPackage("digraphs", false);;
+
+#
+gap> DIGRAPHS_StartTest();
+
+# Runs fine
+gap> gr := TCodeDecoder(3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `TCodeDecoder' on 1 arguments
+
+# Gives a different error if <gr> does not exist as a global variable!
+gap> TCodeDecoder("gr 5");
+Error, the 2nd argument <s> must be a string of space-separated non-negative i\
+ntegers,
+
+# Let's see if assigning to <gr> helps
+gap> gr := CycleDigraph(5);;
+
+# Gives a different error if <xd> does not exist as a global variable!
+gap> TCodeDecoder("xd 5");
+Error, the 2nd argument <s> must be a string of space-separated non-negative i\
+ntegers,
+
+# Runs fine here, because line 19 creates gr as a global variable
+gap> TCodeDecoder("gr 5");
+Error, the 2nd argument <s> must be a string of space-separated non-negative i\
+ntegers,
+
+#
+gap> DIGRAPHS_StopTest();
+gap> STOP_TEST("Digraphs package: standard/broken1.tst", 0);

--- a/tst/standard/broken2.tst
+++ b/tst/standard/broken2.tst
@@ -1,0 +1,33 @@
+#@local gr
+gap> START_TEST("Digraphs package: standard/broken2.tst");
+gap> LoadPackage("digraphs", false);;
+
+#
+gap> DIGRAPHS_StartTest();
+
+# Runs fine
+gap> gr := TCodeDecoder(3);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `TCodeDecoder' on 1 arguments
+
+# Gives a different error if <gr> does not exist as a global variable!
+gap> TCodeDecoder("gr 5");
+Error, the 2nd argument <s> must be a string of space-separated non-negative i\
+ntegers,
+
+# Let's see if assigning to <gr> helps
+gap> gr := CycleDigraph(5);;
+
+# Gives a different error if <xd> does not exist as a global variable!
+gap> TCodeDecoder("xd 5");
+Error, the 2nd argument <s> must be a string of space-separated non-negative i\
+ntegers,
+
+# Gives a different error if <gr> does not exist as a global variable!
+gap> TCodeDecoder("gr 5");
+Error, the 2nd argument <s> must be a string of space-separated non-negative i\
+ntegers,
+
+#
+gap> DIGRAPHS_StopTest();
+gap> STOP_TEST("Digraphs package: standard/broken2.tst", 0);


### PR DESCRIPTION
I've added two test files that should pass, but they have this crazy behaviour because of the behaviour of `TCodeDecoder` (see #839):

Run the test file once, in a fresh GAP session:
```gap
gap> Test("tst/standard/broken1.tst");
########> Diff in tst/standard/broken1.tst:14
# Input is:
TCodeDecoder("gr 5");
# Expected output:
Error, the 2nd argument <s> must be a string of space-separated non-negative i\
ntegers,
# But found:
Error, Variable: 'gr' must have a value
Error, Could not evaluate string.

########
########> Diff in tst/standard/broken1.tst:22
# Input is:
TCodeDecoder("xd 5");
# Expected output:
Error, the 2nd argument <s> must be a string of space-separated non-negative i\
ntegers,
# But found:
Error, Variable: 'xd' must have a value
Error, Could not evaluate string.

########
Digraphs package: standard/broken1.tst
msecs: 1
false
```
We get two failures. Now assign something to `gr` as a global variable:
```gap
gap> gr := true;;
gap> Test("tst/standard/broken1.tst");
########> Diff in tst/standard/broken1.tst:22
# Input is:
TCodeDecoder("xd 5");
# Expected output:
Error, the 2nd argument <s> must be a string of space-separated non-negative i\
ntegers,
# But found:
Error, Variable: 'xd' must have a value
Error, Could not evaluate string.

########
Digraphs package: standard/broken1.tst
msecs: 1
false
```
and we now only have one error. Now assign something to the global variable `xd`:
```gap
gap> xd := true;;
gap> Test("tst/standard/broken1.tst");
Digraphs package: standard/broken1.tst
msecs: 0
true
```
And the test file passes! Crazy.

The test file `broken2.tst` is similar (it differs in using the `#@local` syntax).

This issue was found when trying to resolve #835, which makes things stricter about variables needing to be defined in tests.