### PR TITLE
CI: Update the concurrency settings to allow concurrent `main` and `stable-*.*` builds, and to only cancel in-progress pull request builds

### DIFF
--- a/.github/workflows/config_options.yml
+++ b/.github/workflows/config_options.yml
@@ -11,8 +11,11 @@ on:
     - cron: 30 3 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the default/stable branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != github.event.repository.default_branch && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   with-external-planarity-bliss:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,11 @@ on:
     - cron: 30 3 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the default/stable branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != github.event.repository.default_branch && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   lint:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -11,8 +11,11 @@ on:
     - cron: "20 3 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the default/stable branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != github.event.repository.default_branch && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   manual:

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -14,8 +14,11 @@ env:
   DIGRAPHS_LIB: digraphs-lib-0.7
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the default/stable branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != github.event.repository.default_branch && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   test:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,8 +14,11 @@ env:
   DIGRAPHS_LIB: digraphs-lib-0.7
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the default/stable branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != github.event.repository.default_branch && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   test-unix:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -15,8 +15,11 @@ env:
   NO_COVERAGE: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by workflow and ref; the last component ensures that for pull requests
+  # we limit to one concurrent job, but for the default/stable branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != github.event.repository.default_branch && !startsWith(github.ref, 'refs/heads/stable-')) || github.run_number }}
+  # Only cancel intermediate pull request builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   test-valgrind:


### PR DESCRIPTION
I noticed that `stable-1.12` builds were getting cancelled in-progress. That's not what we want, I don't think, because it's useful to know whether any push to `stable-1.12` fails, even if there is a new commit (that may or may not fail).