### PR TITLE
Restore compatibility with GAP 4.10 and test against it in the CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,19 +33,24 @@ jobs:
           - v4.14
           - v4.13
           - v4.12
-          - v4.11
         mode:
           - onlyneeded
           - default
         include:
           - mode: onlyneeded
             pkgs-to-clone: https://github.com/digraphs/graphviz.git
-            # Remove asterisks * when we no longer support GAP 4.11
-            pkgs-to-build: io* orb* datastructures* profiling*
+            pkgs-to-build: io orb datastructures profiling
           - mode: default
             pkgs-to-clone: https://github.com/digraphs/graphviz.git https://github.com/gap-packages/NautyTracesInterface.git
-            # Remove asterisks * when we no longer support GAP 4.11
-            pkgs-to-build: io* orb* datastructures* profiling* grape* NautyTracesInterface
+            pkgs-to-build: io orb datastructures profiling grape NautyTracesInterface
+
+          - gap-version: v4.11  # Note: NautyTracesInterface requires GAP 4.12
+            mode: default  # There wouldn't be much point testing GAP v4.11 with only needed packages. The only difference is whether Grape is loaded.
+            pkgs-to-clone: https://github.com/digraphs/graphviz.git
+            pkgs-to-build: io* orb* datastructures* profiling* grape*
+          - gap-version: v4.10  # Note: NautyTracesInterface requires GAP 4.12
+            mode: default  # There wouldn't be much point testing GAP v4.10 with only needed packages. The only difference is whether Grape is loaded.
+            pkgs-to-build: io* orb* datastructures profiling* grape*
 
     steps:
       - uses: actions/checkout@v5
@@ -56,11 +61,19 @@ jobs:
         with:
           gap-version: ${{ matrix.gap-version }}
       - name: "Install necessary GAP package clones . . ."
+        if: ${{ matrix.gap-version != 'v4.10' }}
         run: |
           for PKG in ${{ matrix.pkgs-to-clone }}; do
             cd ${GAPROOT}/pkg
             git clone $PKG
           done
+      # Add a special case for GAP v4.10 because it requires checking out a
+      # specific version of the repository (not the default branch).
+      - name: "Install datastructures v0.2.5 for GAP 4.10"
+        if: ${{ matrix.gap-version == 'v4.10' }}
+        run: |
+            cd ${GAPROOT}/pkg
+            git clone -b v0.2.5 https://github.com/gap-packages/datastructures datastructures
       - name: "Build additional necessary GAP packages . . ."
         run: |
           cd ${GAPROOT}/pkg

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1814,12 +1814,12 @@ function(D, maxLength)
     # Extends a given chordless path if possible
     CCExtension := function(digraph, path, C, key, blocked)
         local v, extendedPath, data;
-        blocked := BlockNeighbours(digraph, Last(path), blocked);
-        for v in OutNeighboursOfVertex(digraph, Last(path)) do
+        blocked := BlockNeighbours(digraph, path[Length(path)], blocked);
+        for v in OutNeighboursOfVertex(digraph, path[Length(path)]) do
             if DigraphVertexLabel(digraph, v) > key and blocked[v] = 1
               and Length(path) < maxLength then
                 extendedPath := Concatenation(path, [v]);
-                if IsDigraphEdge(digraph, v, First(path)) then
+                if IsDigraphEdge(digraph, v, path[1]) then
                     Add(C, extendedPath);
                 else
                     data := CCExtension(digraph, extendedPath, C, key, blocked);
@@ -1828,7 +1828,7 @@ function(D, maxLength)
                 fi;
             fi;
         od;
-        blocked := UnblockNeighbours(digraph, Last(path), blocked);
+        blocked := UnblockNeighbours(digraph, path[Length(path)], blocked);
         return [C, blocked];
     end;
 

--- a/makedoc.g
+++ b/makedoc.g
@@ -53,7 +53,8 @@ for Pkg in Concatenation(PkgInfo.Dependencies.NeededOtherPackages,
 od;
 
 ARCHIVENAME := SplitString(PkgInfo.ArchiveURL, "/");
-ARCHIVENAME := Concatenation(Last(ARCHIVENAME), PkgInfo.ArchiveFormats);
+ARCHIVENAME := Concatenation(ARCHIVENAME[Length(ARCHIVENAME)],
+                             PkgInfo.ArchiveFormats);
 XMLEntities.ARCHIVENAME := ARCHIVENAME;
 
 XMLEntities.DIGRAPHS := PackageEntity("Digraphs");

--- a/read.g
+++ b/read.g
@@ -30,6 +30,12 @@ BindGlobal("DIGRAPHS_NautyAvailable",
 
 Unbind(_NautyTracesInterfaceVersion);
 
+# Delete this when we no longer support GAP 4.10
+if not CompareVersionNumbers(ReplacedString(GAPInfo.Version, "dev", ""), "4.11")
+    and not IsBound(INTOBJ_MAX) then
+  BindGlobal("INTOBJ_MAX", 1152921504606846975);
+fi;
+
 ReadPackage("digraphs", "gap/utils.gi");
 ReadPackage("digraphs", "gap/digraph.gi");
 ReadPackage("digraphs", "gap/constructors.gi");

--- a/src/gap-includes.h
+++ b/src/gap-includes.h
@@ -26,5 +26,9 @@
 #endif
 // GAP headers
 #include "gap_all.h"  // for Obj, Int
+                      //
+#ifdef GAP410_OR_OLDER
+#include "compiled.h"  // FIXME Remove include when we don't support GAP 4.10
+#endif
 
 #endif  // DIGRAPHS_SRC_GAP_INCLUDES_H_

--- a/src/gap_all.h
+++ b/src/gap_all.h
@@ -1,0 +1,20 @@
+/*******************************************************************************
+**
+*A  gap_all.h                   GAP package Digraphs          Julius Jonusas
+**                                                            James Mitchell
+**                                                            Wilf A. Wilson
+**                                                            Michael Young
+**
+**  Copyright (C) 2014-25 - Julius Jonusas, James Mitchell, Wilf A. Wilson,
+**  Michael Young
+**
+**  This file is free software, see the digraphs/LICENSE.
+**
+*******************************************************************************/
+
+#ifndef DIGRAPHS_SRC_GAP_ALL_H_
+#define DIGRAPHS_SRC_GAP_ALL_H_
+// Delete this file once we no longer support GAP 4.10.
+// This is a hack to get Digraphs to compile on GAP 4.10 still.
+#define GAP410_OR_OLDER
+#endif  // DIGRAPHS_SRC_GAP_ALL_H_


### PR DESCRIPTION
Also remove the test against GAP v4.11 with only needed Digraphs packages. Since NautyTracesInterface doesn't run on GAP v4.11, the only difference between the default or only-needed jobs would be whether Grape is loaded - and I think that is tested sufficiently on the other jobs. So we can save those resources.