### PR TITLE
Clone digraphs-lib rather than download a tarball

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -10,9 +10,6 @@ on:
     # Every day at 3:30 AM UTC
     - cron: 30 3 * * *
 
-env:
-  DIGRAPHS_LIB: digraphs-lib-0.7
-
 concurrency:
   # Group by workflow and ref; the last component ensures that for pull requests
   # we limit to one concurrent job, but for the main/stable branches we don't
@@ -91,9 +88,7 @@ jobs:
         with:
           ABI: ${{ matrix.ABI }}
       - name: Install digraphs-lib . . .
-        run: |
-          curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${{ env.DIGRAPHS_LIB }}.tar.gz"
-          tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
+        run: git clone https://github.com/digraphs/digraphs-lib.git
       - name: Run DigraphsTestInstall . . .
         uses: gap-actions/run-pkg-tests@v4
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,9 +10,6 @@ on:
     # Every day at 3:30 AM UTC
     - cron: 30 3 * * *
 
-env:
-  DIGRAPHS_LIB: digraphs-lib-0.7
-
 concurrency:
   # Group by workflow and ref; the last component ensures that for pull requests
   # we limit to one concurrent job, but for the main/stable branches we don't
@@ -68,9 +65,7 @@ jobs:
       - name: Build Digraphs . . .
         uses: gap-actions/build-pkg@v2
       - name: Install digraphs-lib . . .
-        run: |
-          curl --retry 5 -L -O "https://digraphs.github.io/Digraphs/${{ env.DIGRAPHS_LIB }}.tar.gz"
-          tar xf "${{ env.DIGRAPHS_LIB }}.tar.gz"
+        run: git clone https://github.com/digraphs/digraphs-lib.git
       - name: Run DigraphsTestInstall . . .
         uses: gap-actions/run-pkg-tests@v4
         with:


### PR DESCRIPTION
I like this for now. We can always go back to downloading a hardcoded specific tarball from one of the releases at the git repo <https://github.com/digraphs/digraphs-lib/releases>, or checking out a specific tag/branch.