### PR TITLE
Fix `AutomorphismGroup` for `CompleteBipartiteDigraph(1,n)`

### DIFF
--- a/gap/examples.gi
+++ b/gap/examples.gi
@@ -68,14 +68,22 @@ InstallMethod(CompleteBipartiteDigraphCons,
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(_, m, n)
   local D, aut;
+
+  if Maximum(m, n) = 1 then
+    return CompleteDigraph(IsImmutableDigraph, 2);
+  fi;
+
   D := MakeImmutable(CompleteBipartiteDigraph(IsMutableDigraph, m, n));
   SetIsSymmetricDigraph(D, true);
   SetDigraphNrEdges(D, 2 * m * n);
   SetIsCompleteBipartiteDigraph(D, true);
   if m = n then
-    aut := WreathProduct(SymmetricGroup(m), Group((1, 2)));
+    aut := WreathProduct(SymmetricGroup([1 .. m]), Group((1, m + 1)));
+  elif m = 1 then
+    aut := SymmetricGroup([2 .. n + 1]);
   else
-    aut := DirectProduct(SymmetricGroup(m), SymmetricGroup(n));
+    aut := DirectProduct(SymmetricGroup([1 .. m]),
+                         SymmetricGroup([m + 1 .. m + n]));
   fi;
   SetAutomorphismGroup(D, aut);
   SetIsPlanarDigraph(D, m <= 2 or n <= 2);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -509,6 +509,33 @@ rec( comps := [  ], id := [  ] )
 gap> IsConnectedDigraph(D);
 true
 
+# Issue #850: Problems with AutomorphismGroup for CompleteBipartiteDigraph
+gap> D := CompleteBipartiteDigraph(1, 5);
+<immutable complete bipartite digraph with bicomponent sizes 1 and 5>
+gap> AutomorphismGroup(D) = SymmetricGroup([2 .. 6]);
+true
+gap> not DIGRAPHS_IsGrapeLoaded() or
+> (DIGRAPHS_IsGrapeLoaded() and
+>  IsomorphismDigraphs(Digraph(Graph(D)), D) <> fail);
+true
+gap> not DIGRAPHS_IsGrapeLoaded() or
+> (DIGRAPHS_IsGrapeLoaded() and
+>  OnDigraphs(D, IsomorphismDigraphs(Digraph(Graph(D)), D)) = D);
+true
+gap> D := CompleteBipartiteDigraph(5, 1);
+<immutable complete bipartite digraph with bicomponent sizes 5 and 1>
+gap> AutomorphismGroup(D) = SymmetricGroup([1 .. 5]);
+true
+gap> D := CompleteBipartiteDigraph(1, 1);
+<immutable complete digraph with 2 vertices>
+gap> AutomorphismGroup(D) = Group([(1, 2)]);
+true
+gap> D := CompleteBipartiteDigraph(3, 3);
+<immutable complete bipartite digraph with bicomponents of size 3>
+gap> AutomorphismGroup(D)
+> = Group([(1, 2, 3), (1, 2), (4, 5, 6), (4, 5), (1, 4)(2, 5)(3, 6)]);
+true
+
 #
 gap> DIGRAPHS_StopTest();
 gap> STOP_TEST("Digraphs package: testinstall.tst", 0);


### PR DESCRIPTION
This resolves the following bug:
```gap
gap> G:=CompleteBipartiteDigraph(1,5);
<immutable complete bipartite digraph with bicomponent sizes 1 and 5>
gap> DigraphBicomponents(G);
[ [ 1 ], [ 2, 3, 4, 5, 6 ] ]
gap> AutomorphismGroup(G);
Group([ (1,2,3,4,5), (1,2) ])
```
Simply put, our code was assuming that for `DirectProduct(SymmetricGroup([1]), SymmetricGroup([2..6]))`, GAP would return `SymmetricGroup([2..6])`. But in fact, GAP returns (the isomorphic, but not identical) `SymmetricGroup([1..5])`.

This bug is what was behind the wrong result reported by @bojankuzma000 in #850.