### PR TITLE
CI: stop the codecov step from failing the job on Windows, since it is buggy

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -110,4 +110,5 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          # codecov/codecov-action seems unreliable on Windows
+          fail_ci_if_error: ${{ runner.os != 'Windows' }}


### PR DESCRIPTION
It is currently making the "OS" Windows job fail. Let's just allow errors in the `codecov/codecov-action` bit of the Windows job.