### PR TITLE
Refactored DigraphReverse and UndirectedSpanningTree to use SwapDigraphs instead of directly assigning OutNeighbours

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2435,7 +2435,8 @@ function(D)
     SetDigraphReverseAttr(D, C);
     return C;
   fi;
-  D!.OutNeighbours := inn;
+  C := ConvertToMutableDigraphNC(inn);
+  SwapDigraphs(D, C);
   ClearDigraphEdgeLabels(D);
   return D;
 end);
@@ -3049,7 +3050,7 @@ function(D)
   if DigraphNrEdges(C) <> 2 * (DigraphNrVertices(D) - 1) then
     return fail;
   fi;
-  D!.OutNeighbours := OutNeighbors(C);
+  SwapDigraphs(D, C);
   return D;
 end);
 


### PR DESCRIPTION
For issue - https://github.com/digraphs/Digraphs/issues/872
```
devanshchopra@Devanshs-MacBook-Pro Digraphs % grep -R ".OutNeighbours :=" -n gap/
gap/oper.gi:1028:    D1!.OutNeighbours := nb2;
gap/oper.gi:1029:    D2!.OutNeighbours := nb1;
gap/oper.gi:1183:    D!.OutNeighbours := [];
gap/oper.gi:1214:  D!.OutNeighbours := old{list};
gap/oper.gi:1282:  D!.OutNeighbours := new;
gap/oper.gi:2257:    spanningtree!.OutNeighbours := nbs;
gap/constructors.gi:89:  D!.OutNeighbours := list;
gap/attr.gi:2438:  D!.OutNeighbours := inn;
gap/attr.gi:2541:  D!.OutNeighbours := List(DigraphVertices(D), v -> []);
gap/attr.gi:2668:      C!.OutNeighbours := out;
gap/attr.gi:2803:    C!.OutNeighbours := List([1 .. n], v -> ListBlist([1 .. n], out[v]));
gap/attr.gi:3016:  D!.OutNeighbours := DIGRAPH_SYMMETRIC_SPANNING_FOREST(D!.OutNeighbours);
gap/attr.gi:3052:  D!.OutNeighbours := OutNeighbors(C);
gap/digraph.gi:93:  record := rec(OutNeighbours := list);
```