### PR TITLE
Implementation of DigraphInsertEdge and DigraphReduceEdge

### DIFF
--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -2037,7 +2037,7 @@ true
   <Description>
     If <A>edge</A> is a pair of vertices of <A>digraph</A>, or <A>src</A> and
     <A>ran</A> are vertices of <A>digraph</A>, where <A>ran</A> &lt;&gt; <A>src</A>, 
-    then then this operation merges the two vertices of the edge given into one. 
+    then this operation merges the two vertices of the edge given into one. 
     Edges incident to <A>src</A> and <A>ran</A> will now be incident to <C>v</C>, 
     the new vertex, with their direction preserved. <P/>
     
@@ -2083,13 +2083,13 @@ gap> DigraphVertexLabels(D);
   <Returns>A digraph.</Returns>
   <Description>
     If <A>edge1</A> and <A>edge2</A> are distinct pairs of vertices of <A>digraph</A>,
-    then then this operation inserts a new edge between <A>edge1</A> and
+    then this operation inserts a new edge between <A>edge1</A> and
     <A>edge2</A>.
     <A>edge1</A> and <A>edge2</A> are split up into two new edges each, which are
     all adjacent to the inserted edge. Hence, the vertices of the inserted edge both
-    have a degree of 3.
+    have a degree of 3.<P/>
 
-    The opposite operation is <Ref Oper="DigraphReduceEdge"/>.
+    The opposite operation is <Ref Oper="DigraphReduceEdge"/>.<P/>
 
     A new digraph constructed from <A>digraph</A> is returned,
     unless <A>digraph</A> belongs to <Ref Filt="IsMutableDigraph"/>;
@@ -2125,9 +2125,9 @@ gap> DigraphEdges(D2);
     If <A>edge</A> is an edge of <A>digraph</A> and adjacent to four edges, then this
     operation reduces this <A>edge</A>: <A>edge</A> will be removed, and for both
     vertices of <A>edge</A> the two adjacent edges are combined to a single edge.
-    The vertices of <A>edge</A> must both have a degree of 3.
+    The vertices of <A>edge</A> must both have a degree of 3.<P/>
 
-    The opposite operation is <Ref Oper="DigraphInsertEdge"/>.
+    The opposite operation is <Ref Oper="DigraphInsertEdge"/>.<P/>
 
     A new digraph constructed from <A>digraph</A> is returned,
     unless <A>digraph</A> belongs to <Ref Filt="IsMutableDigraph"/>;

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -2076,6 +2076,84 @@ gap> DigraphVertexLabels(D);
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DigraphInsertEdge">
+<ManSection>
+    <Oper Name="DigraphInsertEdge" Arg="digraph, edge1, edge2"
+        Label="for a symmeric digraph and two lists of positive integers"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+    If <A>edge1</A> and <A>edge2</A> are distinct pairs of vertices of <A>digraph</A>,
+    then then this operation inserts a new edge between <A>edge1</A> and
+    <A>edge2</A>.
+    <A>edge1</A> and <A>edge2</A> are split up into two new edges each, which are
+    all adjacent to the inserted edge. Hence, the vertices of the inserted edge both
+    have a degree of 3.
+
+    The opposite operation is <Ref Oper="DigraphReduceEdge"/>.
+
+    A new digraph constructed from <A>digraph</A> is returned,
+    unless <A>digraph</A> belongs to <Ref Filt="IsMutableDigraph"/>;
+    in this case changes are made directly to <A>digraph</A>, which is then returned. 
+    The <A>digraph</A> must not belong to <Ref Filt="IsMultiDigraph"/>. <P/>
+
+    <Example><![CDATA[
+gap> D := DigraphByEdges([[1, 2], [2, 1], [3, 4], [4, 3]]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> D2 := DigraphInsertEdge(D, [1, 2], [3, 4]);
+<immutable digraph with 6 vertices, 10 edges>
+gap> DigraphEdges(D2);
+[ [ 1, 5 ], [ 2, 5 ], [ 3, 6 ], [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], 
+  [ 6, 3 ], [ 6, 4 ], [ 6, 5 ] ]
+gap> D := DigraphByEdges([[1, 2], [2, 1], [2, 3], [3, 2]]);
+<immutable digraph with 3 vertices, 4 edges>
+gap> D2 := DigraphInsertEdge(D, [1, 2], [2, 3]);
+<immutable digraph with 5 vertices, 10 edges>
+gap> DigraphEdges(D2);
+[ [ 1, 4 ], [ 2, 4 ], [ 2, 5 ], [ 3, 5 ], [ 4, 1 ], [ 4, 2 ], [ 4, 5 ], 
+  [ 5, 2 ], [ 5, 3 ], [ 5, 4 ] ]
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DigraphReduceEdge">
+<ManSection>
+    <Oper Name="DigraphReduceEdge" Arg="digraph, edge"
+        Label="for a symmeric digraph and a list of positive integers"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+    If <A>edge</A> is an edge of <A>digraph</A> and adjacent to four edges, then this
+    operation reduces this <A>edge</A>: <A>edge</A> will be removed, and for both
+    vertices of <A>edge</A> the two adjacent edges are combined to a single edge.
+    The vertices of <A>edge</A> must both have a degree of 3.
+
+    The opposite operation is <Ref Oper="DigraphInsertEdge"/>.
+
+    A new digraph constructed from <A>digraph</A> is returned,
+    unless <A>digraph</A> belongs to <Ref Filt="IsMutableDigraph"/>;
+    in this case changes are made directly to <A>digraph</A>, which is then returned. 
+    The <A>digraph</A> must not belong to <Ref Filt="IsMultiDigraph"/>. <P/>
+
+    <Example><![CDATA[
+gap> D := DigraphByEdges([[1, 5], [5, 1], [2, 5], [5, 2], [3, 6],
+  [6, 3], [4, 6], [6, 4], [5, 6], [6, 5]]);
+<immutable digraph with 6 vertices, 10 edges>
+gap> D2 := DigraphReduceEdge(D, [5, 6]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> DigraphEdges(D2);
+[ [ 1, 2 ], [ 2, 1 ], [ 3, 4 ], [ 4, 3 ] ]
+gap> D := DigraphByEdges([[1, 4], [4, 1], [2, 4], [4, 2], [2, 5],
+  [5, 2], [3, 5], [5, 3], [4, 5], [5, 4]]);
+<immutable digraph with 5 vertices, 10 edges>
+gap> D2 := DigraphReduceEdge(D, [4, 5]);
+<immutable digraph with 3 vertices, 4 edges>
+gap> DigraphEdges(D2);
+[ [ 1, 2 ], [ 2, 1 ], [ 2, 3 ], [ 3, 2 ] ]
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="IsMatching">
 <ManSection>
   <Oper Name="IsMatching" Arg="digraph, list"/>

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -38,6 +38,10 @@ DeclareOperation("DigraphClosure", [IsDigraph, IsPosInt]);
 DeclareOperation("DigraphContractEdge", [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("DigraphContractEdge", [IsDigraph, IsDenseList]);
 
+DeclareOperation("DigraphInsertEdge", [IsDigraph, IsDenseList, IsDenseList]);
+
+DeclareOperation("DigraphReduceEdge", [IsDigraph, IsDenseList]);
+
 # 3. Ways of combining digraphs . . .
 DeclareGlobalFunction("DigraphDisjointUnion");
 DeclareGlobalFunction("DigraphJoin");

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -603,46 +603,39 @@ function(D, edge)
   return DigraphContractEdge(D, edge[1], edge[2]);
 end);
 
-DIGRAPHS_CheckInsertEdgeDigraph := function(D, edge1, edge2)
-  if IsEmptyDigraph(D) then
-    ErrorNoReturn("the 1st argument <D> must not be an empty digraph");
-  fi;
-  if not IsSymmetricDigraph(D) then
-    ErrorNoReturn("the 1st argument <D> must be a symmetric digraph");
-  fi;
-
-  if Length(edge1) <> 2 then
-    ErrorNoReturn("the 2nd argument <edge1> must be a list of length 2");
-  fi;
-  if not IsDigraphEdge(D, edge1) then
-    ErrorNoReturn("the 2nd argument <edge1> must be an edge of the ",
-                  "digraph <D>");
-  fi;
-
-  if Length(edge2) <> 2 then
-    ErrorNoReturn("the 3rd argument <edge2> must be a list of length 2");
-  fi;
-  if not IsDigraphEdge(D, edge2) then
-    ErrorNoReturn("the 3rd argument <edge2> must be an edge of the ",
-                  "digraph <D>");
-  fi;
-
-  if Length(Union(edge1, edge2)) < 3 then
-    ErrorNoReturn("the 2nd and 3rd argument <edge1> and <edge2> must ",
-                  "be two different edges");
-  fi;
-
-end;
-
 InstallMethod(DigraphInsertEdge,
 "for a symmetric digraph and two dense lists",
 [IsMutableDigraph, IsDenseList, IsDenseList],
 function(D, edge1, edge2)
   local numVertices;
 
-  DIGRAPHS_CheckInsertEdgeDigraph(D, edge1, edge2);
+  if IsEmptyDigraph(D) then
+    ErrorNoReturn("the 1st argument <D> must not be an empty digraph");
+  elif not IsSymmetricDigraph(D) then
+    ErrorNoReturn("the 1st argument <D> must be a symmetric digraph");
+  elif IsMultiDigraph(D) then
+    ErrorNoReturn("The 1st argument <D> must not satisfy IsMultiDigraph");
+  fi;
 
-  numVertices := Maximum(DigraphVertices(D));
+  if Length(edge1) <> 2 then
+    ErrorNoReturn("the 2nd argument <edge1> must be a list of length 2");
+  elif not IsDigraphEdge(D, edge1) then
+    ErrorNoReturn("the 2nd argument <edge1> must be an edge of the ",
+                  "digraph <D>");
+  fi;
+  if Length(edge2) <> 2 then
+    ErrorNoReturn("the 3rd argument <edge2> must be a list of length 2");
+  elif not IsDigraphEdge(D, edge2) then
+    ErrorNoReturn("the 3rd argument <edge2> must be an edge of the ",
+                  "digraph <D>");
+  fi;
+
+  if Length(Union(edge1, edge2)) < 3 then
+    ErrorNoReturn("the 2nd and 3rd argument <edge1> and <edge2> must ",
+                  "be distinct edges");
+  fi;
+
+  numVertices := DigraphNrVertices(D);
 
   D := DigraphRemoveEdge(D, edge1);
   D := DigraphRemoveEdge(D, Reversed(edge1));
@@ -681,34 +674,32 @@ end);
 InstallMethod(DigraphInsertEdge,
 "for a symmetric digraph and two dense lists",
 [IsImmutableDigraph, IsDenseList, IsDenseList],
-function(D, edge1, edge2)
-  D := DigraphInsertEdge(DigraphMutableCopy(D), edge1, edge2);
+{D, edge1, edge2} -> MakeImmutable(DigraphInsertEdge(
+              DigraphMutableCopy(D), edge1, edge2)));
 
-  return MakeImmutable(D);
-end);
-
-DIGRAPHS_CheckReduceEdgeDigraph := function(D, edge)
+InstallMethod(DigraphReduceEdge,
+"for a symmetric digraph and a dense list",
+[IsMutableDigraph, IsDenseList],
+function(D, edge)
   local leftVertexOutNeighbours, rightVertexOutNeighbours,
-        allVertexOutNeighbours;
+        allVertexOutNeighbours, neighbours, neighbour, newEdge;
 
   if IsEmptyDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must not be an empty digraph");
-  fi;
-  if not IsSymmetricDigraph(D) then
+  elif not IsSymmetricDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must be a symmetric digraph");
+  elif IsMultiDigraph(D) then
+    ErrorNoReturn("The 1st argument <D> must not satisfy IsMultiDigraph");
   fi;
 
   if Length(edge) <> 2 then
     ErrorNoReturn("the 2nd argument <edge> must be a list of length 2");
-  fi;
-  if not IsDigraphEdge(D, edge) then
+  elif not IsDigraphEdge(D, edge) then
     ErrorNoReturn("the 2nd argument <edge> must be an edge of the digraph <D>");
   fi;
 
   leftVertexOutNeighbours := OutNeighboursOfVertex(D, edge[1]);
   rightVertexOutNeighbours := OutNeighboursOfVertex(D, edge[2]);
-  allVertexOutNeighbours := Union(leftVertexOutNeighbours,
-                                  rightVertexOutNeighbours);
 
   # Check if edge vertices have degree three
   if Length(leftVertexOutNeighbours) <> 3 or
@@ -716,27 +707,21 @@ DIGRAPHS_CheckReduceEdgeDigraph := function(D, edge)
     ErrorNoReturn("the 2nd argument <edge> must be an edge where the ",
                   "incident vertices have degree three");
   fi;
+
+  allVertexOutNeighbours := Union(leftVertexOutNeighbours,
+                                  rightVertexOutNeighbours);
+
   if not Length(allVertexOutNeighbours) in [5, 6] then
     ErrorNoReturn("the 2nd argument <edge> must be an edge where the ",
                   "incident vertices have a maximum of one common ",
                   "neighbour");
   fi;
 
-end;
-
-InstallMethod(DigraphReduceEdge,
-"for a symmetric digraph and a dense list",
-[IsMutableDigraph, IsDenseList],
-function(D, edge)
-  local neighbours, neighbour, newEdge;
-
-  DIGRAPHS_CheckReduceEdgeDigraph(D, edge);
-
   # Add new edges
   #
   # left side of edge
   newEdge := [];
-  neighbours := OutNeighboursOfVertex(D, edge[1]);
+  neighbours := leftVertexOutNeighbours;
   for neighbour in neighbours do
     if neighbour <> edge[2] then
       Add(newEdge, neighbour);
@@ -774,11 +759,8 @@ end);
 InstallMethod(DigraphReduceEdge,
 "for a symmetric digraph and a dense list",
 [IsImmutableDigraph, IsDenseList],
-function(D, edge)
-  D := DigraphReduceEdge(DigraphMutableCopy(D), edge);
-
-  return MakeImmutable(D);
-end);
+{D, edge} -> MakeImmutable(DigraphReduceEdge(DigraphMutableCopy(D), edge))
+);
 
 #############################################################################
 # 3. Ways of combining digraphs

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -603,6 +603,187 @@ function(D, edge)
   return DigraphContractEdge(D, edge[1], edge[2]);
 end);
 
+DIGRAPHS_CheckInsertEdgeDigraph := function(D, edge1, edge2)
+  if IsEmptyDigraph(D) then
+    ErrorNoReturn("the 1st argument <D> must not be an empty digraph");
+  fi;
+  if not IsSymmetricDigraph(D) then
+    ErrorNoReturn("the 1st argument <D> must be a symmetric digraph");
+  fi;
+
+  if Length(edge1) <> 2 then
+    ErrorNoReturn("the 2nd argument <edge1> must be a list of length 2");
+  fi;
+  if not IsDigraphEdge(D, edge1) then
+    ErrorNoReturn("the 2nd argument <edge1> must be an edge of the digraph <D>");
+  fi;
+
+  if Length(edge2) <> 2 then
+    ErrorNoReturn("the 3rd argument <edge2> must be a list of length 2");
+  fi;
+  if not IsDigraphEdge(D, edge2) then
+    ErrorNoReturn("the 3rd argument <edge2> must be an edge of the digraph <D>");
+  fi;
+
+  if Length(Union(edge1, edge2)) < 3 then
+    ErrorNoReturn("the 2nd and 3rd argument <edge1> and <edge2> must be two different edges");
+  fi;
+
+end;
+
+InstallMethod(DigraphInsertEdge,
+"for a symmetric digraph and two dense lists",
+[IsMutableDigraph, IsDenseList, IsDenseList],
+function(D, edge1, edge2)
+  local numVertices;
+
+  DIGRAPHS_CheckInsertEdgeDigraph(D, edge1, edge2);
+
+  numVertices := Maximum(DigraphVertices(D));
+
+  D := DigraphRemoveEdge(D, edge1);
+  D := DigraphRemoveEdge(D, Reversed(edge1));
+  D := DigraphRemoveEdge(D, edge2);
+  D := DigraphRemoveEdge(D, Reversed(edge2));
+
+  DigraphAddVertex(D, numVertices + 1); # vertex A
+  DigraphAddVertex(D, numVertices + 2); # vertex B
+
+  # Add two connected edges between each former edge
+  #
+  # Add edges intersecting former edge1 with vertex A
+  DigraphAddEdge(D, edge1[1], numVertices + 1);
+  DigraphAddEdge(D, numVertices + 1, edge1[1]);
+  #
+  DigraphAddEdge(D, edge1[2], numVertices + 1);
+  DigraphAddEdge(D, numVertices + 1, edge1[2]);
+  #
+  # Add edges intersecting former edge2 with vertex B
+  DigraphAddEdge(D, edge2[1], numVertices + 2);
+  DigraphAddEdge(D, numVertices + 2, edge2[1]);
+  #
+  DigraphAddEdge(D, edge2[2], numVertices + 2);
+  DigraphAddEdge(D, numVertices + 2, edge2[2]);
+  #
+  # Add edges connecting vertex A and vertex B
+  DigraphAddEdge(D, numVertices + 1, numVertices + 2);
+  DigraphAddEdge(D, numVertices + 2, numVertices + 1);
+
+  # TODO: Call SetIsSymmetricDigraph and/or
+  # SetDigraphSymmetricClosureAttr here?
+
+  return D;
+end);
+
+InstallMethod(DigraphInsertEdge,
+"for a symmetric digraph and two dense lists",
+[IsImmutableDigraph, IsDenseList, IsDenseList],
+function(D, edge1, edge2)
+  D := DigraphInsertEdge(DigraphMutableCopy(D), edge1, edge2);
+
+  return MakeImmutable(D);
+end);
+
+InstallMethod(DigraphInsertEdge,
+"for a symmetric digraph and two dense lists",
+[IsDigraph, IsDenseList, IsDenseList],
+function(D, edge1, edge2)
+  return DigraphInsertEdge(D, edge1, edge2);
+end);
+
+DIGRAPHS_CheckReduceEdgeDigraph := function(D, edge)
+  local leftVertexOutNeighbours, rightVertexOutNeighbours;
+
+  if IsEmptyDigraph(D) then
+    ErrorNoReturn("the 1st argument <D> must not be an empty digraph");
+  fi;
+  if not IsSymmetricDigraph(D) then
+    ErrorNoReturn("the 1st argument <D> must be a symmetric digraph");
+  fi;
+
+  if Length(edge) <> 2 then
+    ErrorNoReturn("the 2nd argument <edge> must be a list of length 2");
+  fi;
+  if not IsDigraphEdge(D, edge) then
+    ErrorNoReturn("the 2nd argument <edge> must be an edge of the digraph <D>");
+  fi;
+
+  leftVertexOutNeighbours := OutNeighboursOfVertex(D, edge[1]);
+  rightVertexOutNeighbours := OutNeighboursOfVertex(D, edge[2]);
+
+  # Check if edge vertices have degree three
+  if Length(leftVertexOutNeighbours) <> 3 or Length(rightVertexOutNeighbours) <> 3 then
+    ErrorNoReturn("the 2nd argument <edge> must be an edge where the incident vertices have degree three");
+  fi;
+  if not Length(Union(leftVertexOutNeighbours, rightVertexOutNeighbours)) in [5, 6] then
+    ErrorNoReturn("the 2nd argument <edge> must be an edge that is adjacent to four edges");
+  fi;
+
+end;
+
+InstallMethod(DigraphReduceEdge,
+"for a symmetric digraph and a dense list",
+[IsMutableDigraph, IsDenseList],
+function(D, edge)
+  local neighbours, neighbour, newEdge;
+
+  DIGRAPHS_CheckReduceEdgeDigraph(D, edge);
+
+  # Add new edges
+  #
+  # left side of edge
+  newEdge := [];
+  neighbours := OutNeighboursOfVertex(D, edge[1]);
+  for neighbour in neighbours do
+    if neighbour <> edge[2] then
+      Add(newEdge, neighbour);
+    fi;
+  od;
+  for neighbour in neighbours do
+    DigraphRemoveEdge(D, [edge[1], neighbour]);
+  od;
+  DigraphAddEdge(D, newEdge[1], newEdge[2]);
+  DigraphAddEdge(D, newEdge[2], newEdge[1]);
+  #
+  # right side of intersecting edge
+  newEdge := [];
+  neighbours := OutNeighboursOfVertex(D, edge[2]);
+  for neighbour in neighbours do
+    if neighbour <> edge[1] then
+      Add(newEdge, neighbour);
+    fi;
+  od;
+  for neighbour in neighbours do
+    DigraphRemoveEdge(D, [edge[2], neighbour]);
+  od;
+  DigraphAddEdge(D, newEdge[1], newEdge[2]);
+  DigraphAddEdge(D, newEdge[2], newEdge[1]);
+
+  # Remove old vertices
+  DigraphRemoveVertices(D, edge);
+
+  # TODO: Call SetIsSymmetricDigraph and/or
+  # SetDigraphSymmetricClosureAttr here?
+
+  return D;
+end);
+
+InstallMethod(DigraphReduceEdge,
+"for a symmetric digraph and a dense list",
+[IsImmutableDigraph, IsDenseList],
+function(D, edge)
+  D := DigraphReduceEdge(DigraphMutableCopy(D), edge);
+
+  return MakeImmutable(D);
+end);
+
+InstallMethod(DigraphReduceEdge,
+"for a symmetric digraph and a dense list",
+[IsDigraph, IsDenseList],
+function(D, edge)
+  return DigraphReduceEdge(D, edge);
+end);
+
 #############################################################################
 # 3. Ways of combining digraphs
 #############################################################################

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -615,18 +615,21 @@ DIGRAPHS_CheckInsertEdgeDigraph := function(D, edge1, edge2)
     ErrorNoReturn("the 2nd argument <edge1> must be a list of length 2");
   fi;
   if not IsDigraphEdge(D, edge1) then
-    ErrorNoReturn("the 2nd argument <edge1> must be an edge of the digraph <D>");
+    ErrorNoReturn("the 2nd argument <edge1> must be an edge of the ",
+                  "digraph <D>");
   fi;
 
   if Length(edge2) <> 2 then
     ErrorNoReturn("the 3rd argument <edge2> must be a list of length 2");
   fi;
   if not IsDigraphEdge(D, edge2) then
-    ErrorNoReturn("the 3rd argument <edge2> must be an edge of the digraph <D>");
+    ErrorNoReturn("the 3rd argument <edge2> must be an edge of the ",
+                  "digraph <D>");
   fi;
 
   if Length(Union(edge1, edge2)) < 3 then
-    ErrorNoReturn("the 2nd and 3rd argument <edge1> and <edge2> must be two different edges");
+    ErrorNoReturn("the 2nd and 3rd argument <edge1> and <edge2> must ",
+                  "be two different edges");
   fi;
 
 end;
@@ -646,8 +649,8 @@ function(D, edge1, edge2)
   D := DigraphRemoveEdge(D, edge2);
   D := DigraphRemoveEdge(D, Reversed(edge2));
 
-  DigraphAddVertex(D, numVertices + 1); # vertex A
-  DigraphAddVertex(D, numVertices + 2); # vertex B
+  DigraphAddVertex(D, numVertices + 1);  # vertex A
+  DigraphAddVertex(D, numVertices + 2);  # vertex B
 
   # Add two connected edges between each former edge
   #
@@ -684,15 +687,9 @@ function(D, edge1, edge2)
   return MakeImmutable(D);
 end);
 
-InstallMethod(DigraphInsertEdge,
-"for a symmetric digraph and two dense lists",
-[IsDigraph, IsDenseList, IsDenseList],
-function(D, edge1, edge2)
-  return DigraphInsertEdge(D, edge1, edge2);
-end);
-
 DIGRAPHS_CheckReduceEdgeDigraph := function(D, edge)
-  local leftVertexOutNeighbours, rightVertexOutNeighbours;
+  local leftVertexOutNeighbours, rightVertexOutNeighbours,
+        allVertexOutNeighbours;
 
   if IsEmptyDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must not be an empty digraph");
@@ -710,13 +707,18 @@ DIGRAPHS_CheckReduceEdgeDigraph := function(D, edge)
 
   leftVertexOutNeighbours := OutNeighboursOfVertex(D, edge[1]);
   rightVertexOutNeighbours := OutNeighboursOfVertex(D, edge[2]);
+  allVertexOutNeighbours := Union(leftVertexOutNeighbours,
+                                  rightVertexOutNeighbours);
 
   # Check if edge vertices have degree three
-  if Length(leftVertexOutNeighbours) <> 3 or Length(rightVertexOutNeighbours) <> 3 then
-    ErrorNoReturn("the 2nd argument <edge> must be an edge where the incident vertices have degree three");
+  if Length(leftVertexOutNeighbours) <> 3 or
+      Length(rightVertexOutNeighbours) <> 3 then
+    ErrorNoReturn("the 2nd argument <edge> must be an edge where the ",
+                  "incident vertices have degree three");
   fi;
-  if not Length(Union(leftVertexOutNeighbours, rightVertexOutNeighbours)) in [5, 6] then
-    ErrorNoReturn("the 2nd argument <edge> must be an edge that is adjacent to four edges");
+  if not Length(allVertexOutNeighbours) in [5, 6] then
+    ErrorNoReturn("the 2nd argument <edge> must be an edge that is adjacent ",
+                  "to four edges");
   fi;
 
 end;
@@ -775,13 +777,6 @@ function(D, edge)
   D := DigraphReduceEdge(DigraphMutableCopy(D), edge);
 
   return MakeImmutable(D);
-end);
-
-InstallMethod(DigraphReduceEdge,
-"for a symmetric digraph and a dense list",
-[IsDigraph, IsDenseList],
-function(D, edge)
-  return DigraphReduceEdge(D, edge);
 end);
 
 #############################################################################

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -717,8 +717,9 @@ DIGRAPHS_CheckReduceEdgeDigraph := function(D, edge)
                   "incident vertices have degree three");
   fi;
   if not Length(allVertexOutNeighbours) in [5, 6] then
-    ErrorNoReturn("the 2nd argument <edge> must be an edge that is adjacent ",
-                  "to four edges");
+    ErrorNoReturn("the 2nd argument <edge> must be an edge where the ",
+                  "incident vertices have a maximum of one common ",
+                  "neighbour");
   fi;
 
 end;

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -3378,8 +3378,7 @@ Error, the 3rd argument <edge2> must be an edge of the digraph <D>
 gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
 gap> DigraphInsertEdge(D, [1, 2], [1, 2]);
-Error, the 2nd and 3rd argument <edge1> and <edge2> must be two different edge\
-s
+Error, the 2nd and 3rd argument <edge1> and <edge2> must be distinct edges
 
 # DigraphInsertEdge: standard insertion (mutable digraph D)
 gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -3324,6 +3324,177 @@ gap> DigraphEdges(D);
 gap> DigraphVertexLabels(D);
 [ 1, 2, 3, 6, [ 4, 5 ] ]
 
+# DigraphInsertEdge
+
+# DigraphInsertEdge: D is empty digraph test
+gap> D := NullDigraph(0);
+<immutable empty digraph with 0 vertices>
+gap> DigraphInsertEdge(D, [1,2], [3,4]);
+Error, the 1st argument <D> must not be an empty digraph
+
+# DigraphInsertEdge: D is not a symmetric digraph
+gap> D := DigraphByEdges([[1,2], [3,4], [1,3], [2,4]]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> DigraphInsertEdge(D, [1,2], [3,4]);
+Error, the 1st argument <D> must be a symmetric digraph
+
+# DigraphInsertEdge: edge1 is not a list of length 2
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphInsertEdge(D, [], [3,4]);
+Error, the 2nd argument <edge1> must be a list of length 2
+gap> DigraphInsertEdge(D, [1], [3,4]);
+Error, the 2nd argument <edge1> must be a list of length 2
+gap> DigraphInsertEdge(D, [1,2,3], [3,4]);
+Error, the 2nd argument <edge1> must be a list of length 2
+
+# DigraphInsertEdge: edge2 is not a list of length 2
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphInsertEdge(D, [1,2], []);
+Error, the 3rd argument <edge2> must be a list of length 2
+gap> DigraphInsertEdge(D, [1,2], [3]);
+Error, the 3rd argument <edge2> must be a list of length 2
+gap> DigraphInsertEdge(D, [1,2], [2,3,4]);
+Error, the 3rd argument <edge2> must be a list of length 2
+
+# DigraphInsertEdge: edge1 is not an edge in D
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphInsertEdge(D, [1,4], [3,4]);
+Error, the 2nd argument <edge1> must be an edge of the digraph <D>
+gap> DigraphInsertEdge(D, [5,6], [3,4]);
+Error, the 2nd argument <edge1> must be an edge of the digraph <D>
+
+# DigraphInsertEdge: edge2 is not an edge in D
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphInsertEdge(D, [1,2], [3,2]);
+Error, the 3rd argument <edge2> must be an edge of the digraph <D>
+gap> DigraphInsertEdge(D, [1,2], [5,6]);
+Error, the 3rd argument <edge2> must be an edge of the digraph <D>
+
+# DigraphInsertEdge: edge1 and edge2 are identical
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphInsertEdge(D, [1,2], [1,2]);
+Error, the 2nd and 3rd argument <edge1> and <edge2> must be two different edge\
+s
+
+# DigraphInsertEdge: standard insertion (mutable digraph D)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphInsertEdge(D, [1,2], [3,4]);
+<mutable digraph with 6 vertices, 14 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ], [ 3, 1 ], [ 3, 6 ], [ 4, 2 ], 
+  [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 3 ], [ 6, 4 ], [ 6, 5 ] ]
+
+# DigraphInsertEdge: standard insertion (immutable digraph D)
+gap> D := DigraphByEdges(IsImmutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<immutable digraph with 4 vertices, 8 edges>
+gap> D := DigraphInsertEdge(D, [1,2], [3,4]);
+<immutable digraph with 6 vertices, 14 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ], [ 3, 1 ], [ 3, 6 ], [ 4, 2 ], 
+  [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 3 ], [ 6, 4 ], [ 6, 5 ] ]
+
+# DigraphInsertEdge: triangle insertion (mutable digraph D)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphInsertEdge(D, [1,2], [2,4]);
+<mutable digraph with 6 vertices, 14 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 5 ], [ 2, 5 ], [ 2, 6 ], [ 3, 4 ], [ 3, 1 ], [ 4, 3 ], 
+  [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 2 ], [ 6, 4 ], [ 6, 5 ] ]
+
+# DigraphInsertEdge: triangle insertion (immutable digraph D)
+gap> D := DigraphByEdges(IsImmutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<immutable digraph with 4 vertices, 8 edges>
+gap> D := DigraphInsertEdge(D, [1,2], [2,4]);
+<immutable digraph with 6 vertices, 14 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 5 ], [ 2, 5 ], [ 2, 6 ], [ 3, 4 ], [ 3, 1 ], [ 4, 3 ], 
+  [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 2 ], [ 6, 4 ], [ 6, 5 ] ]
+
+# DigraphReduceEdge
+
+# DigraphReduceEdge: D is empty digraph test
+gap> D := NullDigraph(0);
+<immutable empty digraph with 0 vertices>
+gap> DigraphReduceEdge(D, [1,2]);
+Error, the 1st argument <D> must not be an empty digraph
+
+# DigraphReduceEdge: D is not a symmetric digraph
+gap> D := DigraphByEdges([[1,2], [3,4], [1,3], [2,4]]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> DigraphReduceEdge(D, [1,2]);
+Error, the 1st argument <D> must be a symmetric digraph
+
+# DigraphReduceEdge: edge is not a list of length 2
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphReduceEdge(D, []);
+Error, the 2nd argument <edge> must be a list of length 2
+gap> DigraphReduceEdge(D, [1]);
+Error, the 2nd argument <edge> must be a list of length 2
+gap> DigraphReduceEdge(D, [1,2,2]);
+Error, the 2nd argument <edge> must be a list of length 2
+
+# DigraphReduceEdge: edge is not an edge in D
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphReduceEdge(D, [1,4]);
+Error, the 2nd argument <edge> must be an edge of the digraph <D>
+gap> DigraphReduceEdge(D, [5,6]);
+Error, the 2nd argument <edge> must be an edge of the digraph <D>
+
+# DigraphReduceEdge: vertex at edge[1] or edge[2] does not have a degree of 3
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,3], [3,1], [2,4], [4,2], [1,5], [5,1], [2,5], [5,2], [3,6], [6,3], [4,6], [6,4], [5,6], [6,5]]);
+<mutable digraph with 6 vertices, 14 edges>
+gap> DigraphReduceEdge(D, [4,6]);
+Error, the 2nd argument <edge> must be an edge where the incident vertices hav\
+e degree three
+gap> DigraphReduceEdge(D, [6,4]);
+Error, the 2nd argument <edge> must be an edge where the incident vertices hav\
+e degree three
+
+# DigraphReduceEdge: standard reduction (mutable digraph D)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,3], [3,1], [2,4], [4,2], [1,5], [5,1], [2,5], [5,2], [3,6], [6,3], [4,6], [6,4], [5,6], [6,5]]);
+<mutable digraph with 6 vertices, 14 edges>
+gap> DigraphReduceEdge(D, [5,6]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 2 ], [ 2, 4 ], [ 2, 1 ], [ 3, 1 ], [ 3, 4 ], [ 4, 2 ], 
+  [ 4, 3 ] ]
+
+# DigraphReduceEdge: standard reduction (immutable digraph D)
+gap> D := DigraphByEdges(IsImmutableDigraph, [[1,3], [3,1], [2,4], [4,2], [1,5], [5,1], [2,5], [5,2], [3,6], [6,3], [4,6], [6,4], [5,6], [6,5]]);
+<immutable digraph with 6 vertices, 14 edges>
+gap> D := DigraphReduceEdge(D, [5,6]);
+<immutable digraph with 4 vertices, 8 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 2 ], [ 2, 4 ], [ 2, 1 ], [ 3, 1 ], [ 3, 4 ], [ 4, 2 ], 
+  [ 4, 3 ] ]
+
+# DigraphReduceEdge: triangle reduction (mutable digraph D)
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,3], [3,1], [1,5], [5,1], [2,5], [5,2], [2,6], [6,2], [3,4], [4,3], [4,6], [6,4], [5,6], [6,5]]);
+<mutable digraph with 6 vertices, 14 edges>
+gap> DigraphReduceEdge(D, [5,6]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 2 ], [ 2, 1 ], [ 2, 4 ], [ 3, 1 ], [ 3, 4 ], [ 4, 3 ], 
+  [ 4, 2 ] ]
+
+# DigraphReduceEdge: triangle reduction (immutable digraph D)
+gap> D := DigraphByEdges(IsImmutableDigraph, [[1,3], [3,1], [1,5], [5,1], [2,5], [5,2], [2,6], [6,2], [3,4], [4,3], [4,6], [6,4], [5,6], [6,5]]);
+<immutable digraph with 6 vertices, 14 edges>
+gap> D := DigraphReduceEdge(D, [5,6]);
+<immutable digraph with 4 vertices, 8 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 2 ], [ 2, 1 ], [ 2, 4 ], [ 3, 1 ], [ 3, 4 ], [ 4, 3 ], 
+  [ 4, 2 ] ]
+
 #
 gap> DIGRAPHS_StopTest();
 gap> STOP_TEST("Digraphs package: standard/oper.tst", 0);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -3329,89 +3329,89 @@ gap> DigraphVertexLabels(D);
 # DigraphInsertEdge: D is empty digraph test
 gap> D := NullDigraph(0);
 <immutable empty digraph with 0 vertices>
-gap> DigraphInsertEdge(D, [1,2], [3,4]);
+gap> DigraphInsertEdge(D, [1, 2], [3, 4]);
 Error, the 1st argument <D> must not be an empty digraph
 
 # DigraphInsertEdge: D is not a symmetric digraph
-gap> D := DigraphByEdges([[1,2], [3,4], [1,3], [2,4]]);
+gap> D := DigraphByEdges([[1, 2], [3, 4], [1, 3], [2, 4]]);
 <immutable digraph with 4 vertices, 4 edges>
-gap> DigraphInsertEdge(D, [1,2], [3,4]);
+gap> DigraphInsertEdge(D, [1, 2], [3, 4]);
 Error, the 1st argument <D> must be a symmetric digraph
 
 # DigraphInsertEdge: edge1 is not a list of length 2
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphInsertEdge(D, [], [3,4]);
+gap> DigraphInsertEdge(D, [], [3, 4]);
 Error, the 2nd argument <edge1> must be a list of length 2
-gap> DigraphInsertEdge(D, [1], [3,4]);
+gap> DigraphInsertEdge(D, [1], [3, 4]);
 Error, the 2nd argument <edge1> must be a list of length 2
-gap> DigraphInsertEdge(D, [1,2,3], [3,4]);
+gap> DigraphInsertEdge(D, [1, 2, 3], [3, 4]);
 Error, the 2nd argument <edge1> must be a list of length 2
 
 # DigraphInsertEdge: edge2 is not a list of length 2
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphInsertEdge(D, [1,2], []);
+gap> DigraphInsertEdge(D, [1, 2], []);
 Error, the 3rd argument <edge2> must be a list of length 2
-gap> DigraphInsertEdge(D, [1,2], [3]);
+gap> DigraphInsertEdge(D, [1, 2], [3]);
 Error, the 3rd argument <edge2> must be a list of length 2
-gap> DigraphInsertEdge(D, [1,2], [2,3,4]);
+gap> DigraphInsertEdge(D, [1, 2], [2, 3, 4]);
 Error, the 3rd argument <edge2> must be a list of length 2
 
 # DigraphInsertEdge: edge1 is not an edge in D
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphInsertEdge(D, [1,4], [3,4]);
+gap> DigraphInsertEdge(D, [1, 4], [3, 4]);
 Error, the 2nd argument <edge1> must be an edge of the digraph <D>
-gap> DigraphInsertEdge(D, [5,6], [3,4]);
+gap> DigraphInsertEdge(D, [5, 6], [3, 4]);
 Error, the 2nd argument <edge1> must be an edge of the digraph <D>
 
 # DigraphInsertEdge: edge2 is not an edge in D
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphInsertEdge(D, [1,2], [3,2]);
+gap> DigraphInsertEdge(D, [1, 2], [3, 2]);
 Error, the 3rd argument <edge2> must be an edge of the digraph <D>
-gap> DigraphInsertEdge(D, [1,2], [5,6]);
+gap> DigraphInsertEdge(D, [1, 2], [5, 6]);
 Error, the 3rd argument <edge2> must be an edge of the digraph <D>
 
 # DigraphInsertEdge: edge1 and edge2 are identical
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphInsertEdge(D, [1,2], [1,2]);
+gap> DigraphInsertEdge(D, [1, 2], [1, 2]);
 Error, the 2nd and 3rd argument <edge1> and <edge2> must be two different edge\
 s
 
 # DigraphInsertEdge: standard insertion (mutable digraph D)
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphInsertEdge(D, [1,2], [3,4]);
+gap> DigraphInsertEdge(D, [1, 2], [3, 4]);
 <mutable digraph with 6 vertices, 14 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ], [ 3, 1 ], [ 3, 6 ], [ 4, 2 ], 
   [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 3 ], [ 6, 4 ], [ 6, 5 ] ]
 
 # DigraphInsertEdge: standard insertion (immutable digraph D)
-gap> D := DigraphByEdges(IsImmutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsImmutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <immutable digraph with 4 vertices, 8 edges>
-gap> D := DigraphInsertEdge(D, [1,2], [3,4]);
+gap> D := DigraphInsertEdge(D, [1, 2], [3, 4]);
 <immutable digraph with 6 vertices, 14 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ], [ 3, 1 ], [ 3, 6 ], [ 4, 2 ], 
   [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 3 ], [ 6, 4 ], [ 6, 5 ] ]
 
 # DigraphInsertEdge: triangle insertion (mutable digraph D)
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphInsertEdge(D, [1,2], [2,4]);
+gap> DigraphInsertEdge(D, [1, 2], [2, 4]);
 <mutable digraph with 6 vertices, 14 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 5 ], [ 2, 5 ], [ 2, 6 ], [ 3, 4 ], [ 3, 1 ], [ 4, 3 ], 
   [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 2 ], [ 6, 4 ], [ 6, 5 ] ]
 
 # DigraphInsertEdge: triangle insertion (immutable digraph D)
-gap> D := DigraphByEdges(IsImmutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsImmutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <immutable digraph with 4 vertices, 8 edges>
-gap> D := DigraphInsertEdge(D, [1,2], [2,4]);
+gap> D := DigraphInsertEdge(D, [1, 2], [2, 4]);
 <immutable digraph with 6 vertices, 14 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 5 ], [ 2, 5 ], [ 2, 6 ], [ 3, 4 ], [ 3, 1 ], [ 4, 3 ], 
@@ -3422,74 +3422,81 @@ gap> DigraphEdges(D);
 # DigraphReduceEdge: D is empty digraph test
 gap> D := NullDigraph(0);
 <immutable empty digraph with 0 vertices>
-gap> DigraphReduceEdge(D, [1,2]);
+gap> DigraphReduceEdge(D, [1, 2]);
 Error, the 1st argument <D> must not be an empty digraph
 
 # DigraphReduceEdge: D is not a symmetric digraph
-gap> D := DigraphByEdges([[1,2], [3,4], [1,3], [2,4]]);
+gap> D := DigraphByEdges([[1, 2], [3, 4], [1, 3], [2, 4]]);
 <immutable digraph with 4 vertices, 4 edges>
-gap> DigraphReduceEdge(D, [1,2]);
+gap> DigraphReduceEdge(D, [1, 2]);
 Error, the 1st argument <D> must be a symmetric digraph
 
 # DigraphReduceEdge: edge is not a list of length 2
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
 gap> DigraphReduceEdge(D, []);
 Error, the 2nd argument <edge> must be a list of length 2
 gap> DigraphReduceEdge(D, [1]);
 Error, the 2nd argument <edge> must be a list of length 2
-gap> DigraphReduceEdge(D, [1,2,2]);
+gap> DigraphReduceEdge(D, [1, 2, 2]);
 Error, the 2nd argument <edge> must be a list of length 2
 
 # DigraphReduceEdge: edge is not an edge in D
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphReduceEdge(D, [1,4]);
+gap> DigraphReduceEdge(D, [1, 4]);
 Error, the 2nd argument <edge> must be an edge of the digraph <D>
-gap> DigraphReduceEdge(D, [5,6]);
+gap> DigraphReduceEdge(D, [5, 6]);
 Error, the 2nd argument <edge> must be an edge of the digraph <D>
 
 # DigraphReduceEdge: vertex at edge[1] or edge[2] does not have a degree of 3
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,3], [3,1], [2,4], [4,2], [1,5], [5,1], [2,5], [5,2], [3,6], [6,3], [4,6], [6,4], [5,6], [6,5]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 3], [3, 1], [2, 4], [4, 2], [1, 5], [5, 1], [2, 5], [5, 2], [3, 6], [6, 3], [4, 6], [6, 4], [5, 6], [6, 5]]);
 <mutable digraph with 6 vertices, 14 edges>
-gap> DigraphReduceEdge(D, [4,6]);
+gap> DigraphReduceEdge(D, [4, 6]);
 Error, the 2nd argument <edge> must be an edge where the incident vertices hav\
 e degree three
-gap> DigraphReduceEdge(D, [6,4]);
+gap> DigraphReduceEdge(D, [6, 4]);
 Error, the 2nd argument <edge> must be an edge where the incident vertices hav\
 e degree three
 
+# DigraphReduceEdge: vertices of edge have two common neighbours
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [1, 3], [3, 1], [2, 3], [3, 2], [1, 4], [4, 1], [2, 4], [4, 2]]);
+<mutable digraph with 4 vertices, 10 edges>
+gap> DigraphReduceEdge(D, [1, 2]);
+Error, the 2nd argument <edge> must be an edge where the incident vertices hav\
+e a maximum of one common neighbour
+
 # DigraphReduceEdge: standard reduction (mutable digraph D)
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,3], [3,1], [2,4], [4,2], [1,5], [5,1], [2,5], [5,2], [3,6], [6,3], [4,6], [6,4], [5,6], [6,5]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 3], [3, 1], [2, 4], [4, 2], [1, 5], [5, 1], [2, 5], [5, 2], [3, 6], [6, 3], [4, 6], [6, 4], [5, 6], [6, 5]]);
 <mutable digraph with 6 vertices, 14 edges>
-gap> DigraphReduceEdge(D, [5,6]);
+gap> DigraphReduceEdge(D, [5, 6]);
 <mutable digraph with 4 vertices, 8 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 2 ], [ 2, 4 ], [ 2, 1 ], [ 3, 1 ], [ 3, 4 ], [ 4, 2 ], 
   [ 4, 3 ] ]
 
 # DigraphReduceEdge: standard reduction (immutable digraph D)
-gap> D := DigraphByEdges(IsImmutableDigraph, [[1,3], [3,1], [2,4], [4,2], [1,5], [5,1], [2,5], [5,2], [3,6], [6,3], [4,6], [6,4], [5,6], [6,5]]);
+gap> D := DigraphByEdges(IsImmutableDigraph, [[1, 3], [3, 1], [2, 4], [4, 2], [1, 5], [5, 1], [2, 5], [5, 2], [3, 6], [6, 3], [4, 6], [6, 4], [5, 6], [6, 5]]);
 <immutable digraph with 6 vertices, 14 edges>
-gap> D := DigraphReduceEdge(D, [5,6]);
+gap> D := DigraphReduceEdge(D, [5, 6]);
 <immutable digraph with 4 vertices, 8 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 2 ], [ 2, 4 ], [ 2, 1 ], [ 3, 1 ], [ 3, 4 ], [ 4, 2 ], 
   [ 4, 3 ] ]
 
 # DigraphReduceEdge: triangle reduction (mutable digraph D)
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,3], [3,1], [1,5], [5,1], [2,5], [5,2], [2,6], [6,2], [3,4], [4,3], [4,6], [6,4], [5,6], [6,5]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 3], [3, 1], [1, 5], [5, 1], [2, 5], [5, 2], [2, 6], [6, 2], [3, 4], [4, 3], [4, 6], [6, 4], [5, 6], [6, 5]]);
 <mutable digraph with 6 vertices, 14 edges>
-gap> DigraphReduceEdge(D, [5,6]);
+gap> DigraphReduceEdge(D, [5, 6]);
 <mutable digraph with 4 vertices, 8 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 2 ], [ 2, 1 ], [ 2, 4 ], [ 3, 1 ], [ 3, 4 ], [ 4, 3 ], 
   [ 4, 2 ] ]
 
 # DigraphReduceEdge: triangle reduction (immutable digraph D)
-gap> D := DigraphByEdges(IsImmutableDigraph, [[1,3], [3,1], [1,5], [5,1], [2,5], [5,2], [2,6], [6,2], [3,4], [4,3], [4,6], [6,4], [5,6], [6,5]]);
+gap> D := DigraphByEdges(IsImmutableDigraph, [[1, 3], [3, 1], [1, 5], [5, 1], [2, 5], [5, 2], [2, 6], [6, 2], [3, 4], [4, 3], [4, 6], [6, 4], [5, 6], [6, 5]]);
 <immutable digraph with 6 vertices, 14 edges>
-gap> D := DigraphReduceEdge(D, [5,6]);
+gap> D := DigraphReduceEdge(D, [5, 6]);
 <immutable digraph with 4 vertices, 8 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 2 ], [ 2, 1 ], [ 2, 4 ], [ 3, 1 ], [ 3, 4 ], [ 4, 3 ], 

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -475,6 +475,24 @@ gap> C := DigraphContractEdge(D, 2, 1);
 gap> DigraphEdges(C);
 [ [ 2, 1 ] ]
 
+# DigraphInsertEdge
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphInsertEdge(D, [1,2], [3,4]);
+<mutable digraph with 6 vertices, 14 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ], [ 3, 1 ], [ 3, 6 ], [ 4, 2 ], 
+  [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 3 ], [ 6, 4 ], [ 6, 5 ] ]
+
+# DigraphReduceEdge
+gap> D := DigraphByEdges(IsMutableDigraph, [[1,3], [3,1], [2,4], [4,2], [1,5], [5,1], [2,5], [5,2], [3,6], [6,3], [4,6], [6,4], [5,6], [6,5]]);
+<mutable digraph with 6 vertices, 14 edges>
+gap> DigraphReduceEdge(D, [5,6]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphEdges(D);
+[ [ 1, 3 ], [ 1, 2 ], [ 2, 4 ], [ 2, 1 ], [ 3, 1 ], [ 3, 4 ], [ 4, 2 ], 
+  [ 4, 3 ] ]
+
 # Issue #704 SubdigraphsMonomorphisms bug
 gap> d := Digraph([[2, 3, 4, 5], [1, 3, 4], [1, 2, 4, 5], [1, 2, 3, 5], 
 > [1, 3, 4]]);;

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -476,18 +476,18 @@ gap> DigraphEdges(C);
 [ [ 2, 1 ] ]
 
 # DigraphInsertEdge
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,2], [2,1], [3,4], [4,3], [1,3], [3,1], [2,4], [4,2]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 2], [2, 1], [3, 4], [4, 3], [1, 3], [3, 1], [2, 4], [4, 2]]);
 <mutable digraph with 4 vertices, 8 edges>
-gap> DigraphInsertEdge(D, [1,2], [3,4]);
+gap> DigraphInsertEdge(D, [1, 2], [3, 4]);
 <mutable digraph with 6 vertices, 14 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ], [ 3, 1 ], [ 3, 6 ], [ 4, 2 ], 
   [ 4, 6 ], [ 5, 1 ], [ 5, 2 ], [ 5, 6 ], [ 6, 3 ], [ 6, 4 ], [ 6, 5 ] ]
 
 # DigraphReduceEdge
-gap> D := DigraphByEdges(IsMutableDigraph, [[1,3], [3,1], [2,4], [4,2], [1,5], [5,1], [2,5], [5,2], [3,6], [6,3], [4,6], [6,4], [5,6], [6,5]]);
+gap> D := DigraphByEdges(IsMutableDigraph, [[1, 3], [3, 1], [2, 4], [4, 2], [1, 5], [5, 1], [2, 5], [5, 2], [3, 6], [6, 3], [4, 6], [6, 4], [5, 6], [6, 5]]);
 <mutable digraph with 6 vertices, 14 edges>
-gap> DigraphReduceEdge(D, [5,6]);
+gap> DigraphReduceEdge(D, [5, 6]);
 <mutable digraph with 4 vertices, 8 edges>
 gap> DigraphEdges(D);
 [ [ 1, 3 ], [ 1, 2 ], [ 2, 4 ], [ 2, 1 ], [ 3, 1 ], [ 3, 4 ], [ 4, 2 ], 


### PR DESCRIPTION
Implemented DigraphInsertEdge and DigraphReduceEdge.
These functions already exist in the Simplicial Surfaces package, which I am currently working on with Meike Weiß at RWTH Aachen University.
For reference, the corresponding functions there are implemented as EdgeInsertion and EdgeReduction.

Both DigraphInsertEdge and DigraphReduceEdge check whether the given digraph D is symmetric, and modifications to D preserve this symmetry.
Should D therefore retain the symmetric tag by explicitly calling SetIsSymmetricDigraph after modification?
If so, is an additional call to SetDigraphSymmetricClosureAttr required?