### PR TITLE
Digraph decode/encode

### DIFF
--- a/gap/io.gi
+++ b/gap/io.gi
@@ -2283,15 +2283,6 @@ function(D)
   # matrix, and appends a '&' to the start.  The old '+' format can be read by
   # DigraphFromDigraph6String, but can no longer be written by this function.
 
-  if IsMultiDigraph(D) then
-    if IsSymmetricDigraph(D) then
-      ErrorNoReturn("the argument <D> must not have multiple edges ",
-                  "consider encoding in Sparse6 or Disparse6, ");
-    fi;
-    ErrorNoReturn("the argument <D> must not have multiple edges ",
-                  "consider encoding in Disparse6, ");
-  fi;
-
   list := [];
   adj := OutNeighbours(D);
   n := Length(DigraphVertices(D));
@@ -2357,13 +2348,6 @@ InstallMethod(Sparse6String, "for a digraph by out-neighbours",
 function(D)
   local list, n, lenlist, adj, nredges, k, blist, v, nextbit, i, j,
         bitstopad, pos, block;
-  if not IsSymmetricDigraph(D) then
-    if IsMultiDigraph(D) then
-      ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Disparse6,");
-    fi;
-    else
-      ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Digraph6 or Disparse6,");
-  fi;
 
   if not IsSymmetricDigraph(D) then
     if IsMultiDigraph(D) then

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -2222,11 +2222,13 @@ InstallMethod(Graph6String, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 function(D)
   local list, adj, n, lenlist, tablen, blist, i, j, pos, block;
-  if (IsMultiDigraph(D) or not IsSymmetricDigraph(D)
-      or DigraphHasLoops(D)) then
-    ErrorNoReturn("the argument <D> must be a symmetric digraph ",
-                  "with no loops or multiple edges,");
-  fi;
+  if IsMultiDigraph(D) then
+    ErrorNoReturn("the argument <D> must not have multiple edges; consider encoding in Disparse6 or Digraph6");
+elif not IsSymmetricDigraph(D) then
+    ErrorNoReturn("the argument <D> must be a symmetric digraph; consider encoding in Sparse6 or Disparse6");
+elif DigraphHasLoops(D) then
+    ErrorNoReturn("the argument <D> must not have loops; consider encoding in Sparse6 or Disparse6");
+fi;
 
   list := [];
   adj := OutNeighbours(D);
@@ -2294,6 +2296,15 @@ function(D)
   adj := OutNeighbours(D);
   n := Length(DigraphVertices(D));
 
+  if IsMultiDigraph(D) then
+    if IsSymmetricDigraph(D) then
+      ErrorNoReturn("the argument <D> must not have multiple edges ",
+                  "consider encoding in Sparse6 or Disparse6, ");
+    fi;
+    ErrorNoReturn("the argument <D> must not have multiple edges ",
+                  "consider encoding in Disparse6, ");
+  fi;
+
   # First write the special character '&'
   Add(list, -25);
 
@@ -2352,6 +2363,14 @@ function(D)
     fi;
     else
       ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Digraph6 or Disparse6,");
+  fi;
+
+  if not IsSymmetricDigraph(D) then
+    if IsMultiDigraph(D) then
+        ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Disparse6,");
+    else
+        ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Digraph6 or Disparse6,");
+    fi;
   fi;
 
   list := [];

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -2223,12 +2223,21 @@ InstallMethod(Graph6String, "for a digraph by out-neighbours",
 function(D)
   local list, adj, n, lenlist, tablen, blist, i, j, pos, block;
   if IsMultiDigraph(D) then
-    ErrorNoReturn("the argument <D> must not have multiple edges; consider encoding in Disparse6 or Digraph6");
-elif not IsSymmetricDigraph(D) then
-    ErrorNoReturn("the argument <D> must be a symmetric digraph; consider encoding in Sparse6 or Disparse6");
-elif DigraphHasLoops(D) then
-    ErrorNoReturn("the argument <D> must not have loops; consider encoding in Sparse6 or Disparse6");
-fi;
+    ErrorNoReturn(
+      "the argument <D> must not have multiple edges; ",
+      "consider encoding in Disparse6 or Digraph6"
+    );
+  elif not IsSymmetricDigraph(D) then
+    ErrorNoReturn(
+      "the argument <D> must be a symmetric digraph; ",
+      "consider encoding in Sparse6 or Disparse6"
+    );
+  elif DigraphHasLoops(D) then
+    ErrorNoReturn(
+      "the argument <D> must not have loops; ",
+      "consider encoding in Sparse6 or Disparse6"
+    );
+  fi;
 
   list := [];
   adj := OutNeighbours(D);
@@ -2351,9 +2360,15 @@ function(D)
 
   if not IsSymmetricDigraph(D) then
     if IsMultiDigraph(D) then
-        ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Disparse6,");
+      ErrorNoReturn(
+        "the argument <D> must be a symmetric digraph; ",
+        "consider encoding in Disparse6"
+      );
     else
-        ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Digraph6 or Disparse6,");
+      ErrorNoReturn(
+        "the argument <D> must be a symmetric digraph; ",
+        "consider encoding in Digraph6 or Disparse6"
+      );
     fi;
   fi;
 

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -2281,6 +2281,15 @@ function(D)
   # matrix, and appends a '&' to the start.  The old '+' format can be read by
   # DigraphFromDigraph6String, but can no longer be written by this function.
 
+  if IsMultiDigraph(D) then
+    if IsSymmetricDigraph(D) then
+      ErrorNoReturn("the argument <D> must not have multiple edges ",
+                  "consider encoding in Sparse6 or Disparse6, ");
+    fi;
+    ErrorNoReturn("the argument <D> must not have multiple edges ",
+                  "consider encoding in Disparse6, ");
+  fi;
+
   list := [];
   adj := OutNeighbours(D);
   n := Length(DigraphVertices(D));
@@ -2338,7 +2347,11 @@ function(D)
   local list, n, lenlist, adj, nredges, k, blist, v, nextbit, i, j,
         bitstopad, pos, block;
   if not IsSymmetricDigraph(D) then
-    ErrorNoReturn("the argument <D> must be a symmetric digraph,");
+    if IsMultiDigraph(D) then
+      ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Disparse6,");
+    fi;
+    else
+      ErrorNoReturn("the argument <D> must be a symmetric digraph consider encoding in Digraph6 or Disparse6,");
   fi;
 
   list := [];

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -2222,15 +2222,15 @@ InstallMethod(Graph6String, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 function(D)
   local list, adj, n, lenlist, tablen, blist, i, j, pos, block;
-  if IsMultiDigraph(D) then
-    ErrorNoReturn("the argument <D> must not have multiple edges; ",
-      "consider encoding in Disparse6 or Digraph6");
-  elif not IsSymmetricDigraph(D) then
-    ErrorNoReturn("the argument <D> must be a symmetric digraph; ",
-      "consider encoding in Sparse6 or Disparse6");
+  if not IsSymmetricDigraph(D) then
+    ErrorNoReturn("the argument <D> must be a symmetric digraph;\n",
+                  "consider encoding in Digraph6 or Disparse6");
+  elif IsMultiDigraph(D) then
+    ErrorNoReturn("the argument <D> must not have multiple edges;\n",
+                  "consider encoding in Sparse6 or Disparse6");
   elif DigraphHasLoops(D) then
-    ErrorNoReturn("the argument <D> must not have loops; ",
-      "consider encoding in Sparse6 or Disparse6");
+    ErrorNoReturn("the argument <D> must not have loops;\n",
+                  "consider encoding in Sparse6, Digraph6, or Disparse6");
   fi;
 
   list := [];
@@ -2292,11 +2292,11 @@ function(D)
 
   if IsMultiDigraph(D) then
     if IsSymmetricDigraph(D) then
-      ErrorNoReturn("the argument <D> must not have multiple edges ",
-                  "consider encoding in Sparse6 or Disparse6, ");
+      ErrorNoReturn("the argument <D> must not have multiple edges;\n",
+                  "consider encoding in Sparse6 or Disparse6");
     fi;
-    ErrorNoReturn("the argument <D> must not have multiple edges ",
-                  "consider encoding in Disparse6, ");
+    ErrorNoReturn("the argument <D> must not have multiple edges;\n",
+                  "consider encoding in Disparse6");
   fi;
 
   # First write the special character '&'
@@ -2354,10 +2354,10 @@ function(D)
 
   if not IsSymmetricDigraph(D) then
     if IsMultiDigraph(D) then
-      ErrorNoReturn("the argument <D> must be a symmetric digraph; ",
+      ErrorNoReturn("the argument <D> must be a symmetric digraph;\n",
         "consider encoding in Disparse6");
     else
-      ErrorNoReturn("the argument <D> must be a symmetric digraph; ",
+      ErrorNoReturn("the argument <D> must be a symmetric digraph;\n",
         "consider encoding in Digraph6 or Disparse6");
     fi;
   fi;

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -2223,20 +2223,14 @@ InstallMethod(Graph6String, "for a digraph by out-neighbours",
 function(D)
   local list, adj, n, lenlist, tablen, blist, i, j, pos, block;
   if IsMultiDigraph(D) then
-    ErrorNoReturn(
-      "the argument <D> must not have multiple edges; ",
-      "consider encoding in Disparse6 or Digraph6"
-    );
+    ErrorNoReturn("the argument <D> must not have multiple edges; ",
+      "consider encoding in Disparse6 or Digraph6");
   elif not IsSymmetricDigraph(D) then
-    ErrorNoReturn(
-      "the argument <D> must be a symmetric digraph; ",
-      "consider encoding in Sparse6 or Disparse6"
-    );
+    ErrorNoReturn("the argument <D> must be a symmetric digraph; ",
+      "consider encoding in Sparse6 or Disparse6");
   elif DigraphHasLoops(D) then
-    ErrorNoReturn(
-      "the argument <D> must not have loops; ",
-      "consider encoding in Sparse6 or Disparse6"
-    );
+    ErrorNoReturn("the argument <D> must not have loops; ",
+      "consider encoding in Sparse6 or Disparse6");
   fi;
 
   list := [];
@@ -2360,15 +2354,11 @@ function(D)
 
   if not IsSymmetricDigraph(D) then
     if IsMultiDigraph(D) then
-      ErrorNoReturn(
-        "the argument <D> must be a symmetric digraph; ",
-        "consider encoding in Disparse6"
-      );
+      ErrorNoReturn("the argument <D> must be a symmetric digraph; ",
+        "consider encoding in Disparse6");
     else
-      ErrorNoReturn(
-        "the argument <D> must be a symmetric digraph; ",
-        "consider encoding in Digraph6 or Disparse6"
-      );
+      ErrorNoReturn("the argument <D> must be a symmetric digraph; ",
+        "consider encoding in Digraph6 or Disparse6");
     fi;
   fi;
 

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -546,8 +546,8 @@ Error, the 2nd argument <s> is not a valid disparse6 string,
 
 #  Special format characters
 gap> Sparse6String(ChainDigraph(3));
-Error, the argument <D> must be a symmetric digraph consider encoding in Digra\
-ph6 or Disparse6,
+Error, the argument <D> must be a symmetric digraph; consider encoding in Digr\
+aph6 or Disparse6
 gap> Sparse6String(CompleteDigraph(1));
 ":@"
 gap> gr := Digraph([[1], []]);;
@@ -559,6 +559,24 @@ gap> DigraphFromSparse6String(":TdBkJ`Kq?x");
 <immutable symmetric digraph with 21 vertices, 10 edges>
 gap> Sparse6String(last);
 ":TdBkJ`Kq?"
+
+# Multiple Edges Digraph6
+gap> gr := Digraph([[1,1], [2]]);;
+gap> Digraph6String(gr);
+Error, the argument <D> must not have multiple edges consider encoding in Spar\
+se6 or Disparse6, 
+
+# Non-symmetric Digraph in Sparse6
+gap> gr := Digraph([[2], []]);;
+gap> Sparse6String(gr);
+Error, the argument <D> must be a symmetric digraph; consider encoding in Digr\
+aph6 or Disparse6
+
+# Digraph with loops in Sparse6
+gap> gr := Digraph([[1], [2]]);;
+gap> Graph6String(gr);
+Error, the argument <D> must not have loops; consider encoding in Sparse6 or D\
+isparse6
 
 #  DigraphPlainTextLineDecoder: bad input
 gap> DigraphPlainTextLineDecoder(" ", "  ", 1, ".");

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -283,8 +283,8 @@ true
 gap> gr[3] := Digraph([[1, 2], [1, 2]]);
 <immutable digraph with 2 vertices, 4 edges>
 gap> WriteDigraphs(filename, Digraph([[2], []]), Graph6String);
-Error, the argument <D> must be a symmetric digraph; consider encoding in Spar\
-se6 or Disparse6
+Error, the argument <D> must be a symmetric digraph;
+consider encoding in Digraph6 or Disparse6
 gap> OnBreak := oldOnBreak;;
 gap> IO_Close(IO.OpenFiles[Length(IO.OpenFiles)]);;
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/test.s6.bz2");;
@@ -320,8 +320,8 @@ gap> ReadDigraphs(f);
 gap> IO_Close(f);;
 gap> f := DigraphFile(filename, "a");;
 gap> WriteDigraphs(f, CycleDigraph(5));
-Error, the argument <D> must be a symmetric digraph; consider encoding in Spar\
-se6 or Disparse6
+Error, the argument <D> must be a symmetric digraph;
+consider encoding in Digraph6 or Disparse6
 gap> WriteDigraphs(f, JohnsonDigraph(6, 3));
 IO_OK
 gap> IO_Close(f);;
@@ -546,8 +546,8 @@ Error, the 2nd argument <s> is not a valid disparse6 string,
 
 #  Special format characters
 gap> Sparse6String(ChainDigraph(3));
-Error, the argument <D> must be a symmetric digraph; consider encoding in Digr\
-aph6 or Disparse6
+Error, the argument <D> must be a symmetric digraph;
+consider encoding in Digraph6 or Disparse6
 gap> Sparse6String(CompleteDigraph(1));
 ":@"
 gap> gr := Digraph([[1], []]);;
@@ -563,20 +563,20 @@ gap> Sparse6String(last);
 # Multiple Edges Digraph6
 gap> gr := Digraph([[1, 1], [2]]);;
 gap> Digraph6String(gr);
-Error, the argument <D> must not have multiple edges consider encoding in Spar\
-se6 or Disparse6, 
+Error, the argument <D> must not have multiple edges;
+consider encoding in Sparse6 or Disparse6
 
 # Non-symmetric Digraph in Sparse6
 gap> gr := Digraph([[2], []]);;
 gap> Sparse6String(gr);
-Error, the argument <D> must be a symmetric digraph; consider encoding in Digr\
-aph6 or Disparse6
+Error, the argument <D> must be a symmetric digraph;
+consider encoding in Digraph6 or Disparse6
 
 # Digraph with loops in Sparse6
 gap> gr := Digraph([[1], [2]]);;
 gap> Graph6String(gr);
-Error, the argument <D> must not have loops; consider encoding in Sparse6 or D\
-isparse6
+Error, the argument <D> must not have loops;
+consider encoding in Sparse6, Digraph6, or Disparse6
 
 #  DigraphPlainTextLineDecoder: bad input
 gap> DigraphPlainTextLineDecoder(" ", "  ", 1, ".");
@@ -678,8 +678,8 @@ Error, cannot open the file given as the 1st argument <name>,
 
 #  DigraphPlainTextLineDecoder: bad input
 gap> Graph6String(ChainDigraph(4));
-Error, the argument <D> must be a symmetric digraph; consider encoding in Spar\
-se6 or Disparse6
+Error, the argument <D> must be a symmetric digraph;
+consider encoding in Digraph6 or Disparse6
 gap> DIGRAPHS_Graph6Length(-1);
 fail
 gap> DIGRAPHS_Graph6Length(68719476737);

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -561,7 +561,7 @@ gap> Sparse6String(last);
 ":TdBkJ`Kq?"
 
 # Multiple Edges Digraph6
-gap> gr := Digraph([[1,1], [2]]);;
+gap> gr := Digraph([[1, 1], [2]]);;
 gap> Digraph6String(gr);
 Error, the argument <D> must not have multiple edges consider encoding in Spar\
 se6 or Disparse6, 

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -283,8 +283,8 @@ true
 gap> gr[3] := Digraph([[1, 2], [1, 2]]);
 <immutable digraph with 2 vertices, 4 edges>
 gap> WriteDigraphs(filename, Digraph([[2], []]), Graph6String);
-Error, the argument <D> must be a symmetric digraph with no loops or multiple \
-edges,
+Error, the argument <D> must be a symmetric digraph; consider encoding in Spar\
+se6 or Disparse6
 gap> OnBreak := oldOnBreak;;
 gap> IO_Close(IO.OpenFiles[Length(IO.OpenFiles)]);;
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/test.s6.bz2");;
@@ -320,8 +320,8 @@ gap> ReadDigraphs(f);
 gap> IO_Close(f);;
 gap> f := DigraphFile(filename, "a");;
 gap> WriteDigraphs(f, CycleDigraph(5));
-Error, the argument <D> must be a symmetric digraph with no loops or multiple \
-edges,
+Error, the argument <D> must be a symmetric digraph; consider encoding in Spar\
+se6 or Disparse6
 gap> WriteDigraphs(f, JohnsonDigraph(6, 3));
 IO_OK
 gap> IO_Close(f);;
@@ -659,8 +659,8 @@ Error, cannot open the file given as the 1st argument <name>,
 
 #  DigraphPlainTextLineDecoder: bad input
 gap> Graph6String(ChainDigraph(4));
-Error, the argument <D> must be a symmetric digraph with no loops or multiple \
-edges,
+Error, the argument <D> must be a symmetric digraph; consider encoding in Spar\
+se6 or Disparse6
 gap> DIGRAPHS_Graph6Length(-1);
 fail
 gap> DIGRAPHS_Graph6Length(68719476737);

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -546,7 +546,8 @@ Error, the 2nd argument <s> is not a valid disparse6 string,
 
 #  Special format characters
 gap> Sparse6String(ChainDigraph(3));
-Error, the argument <D> must be a symmetric digraph,
+Error, the argument <D> must be a symmetric digraph consider encoding in Digra\
+ph6 or Disparse6,
 gap> Sparse6String(CompleteDigraph(1));
 ":@"
 gap> gr := Digraph([[1], []]);;


### PR DESCRIPTION
Addressing the latter part of #47 , makes it so that it is now impossible to encode a digraph into an improper format(ex: a graph with multiple edges into Digraph6) and also recommends alternatives for a proper encoding in the error message.