### PR TITLE
attr.gi code coverage

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -959,8 +959,7 @@ InstallMethod(DigraphHash, "for a digraph", [IsDigraph], DIGRAPH_HASH);
 # To make built in Orbit function use DigraphHash
 InstallMethod(SparseIntKey, "for an object and digraph",
 [IsObject, IsDigraph],
-{coll, D} -> DigraphHash
-);
+{coll, D} -> DigraphHash);
 
 # To make orb package use DigraphHash
 InstallMethod(ChooseHashFunction, "for a digraph and positive integer",

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1787,22 +1787,18 @@ function(D, maxLength)
     local T, C, u, pair, x, y, labels;
     T := [];
     C := [];
+    labels := DigraphVertexLabels(D);
     for u in DigraphVertices(D) do
       for pair in Combinations(OutNeighboursOfVertex(D, u), 2) do
+        SortBy(pair, i -> labels[i]);
         x := pair[1];
         y := pair[2];
-        labels := DigraphVertexLabels(D);
-        if labels[u] < labels[x] and labels[x] < labels[y] then
+        Assert(1, labels[x] < labels[y]);
+        if labels[u] < labels[x] then
           if not IsDigraphEdge(D, x, y) then
             Add(T, [x, u, y]);
           else
             Add(C, [x, u, y]);
-          fi;
-        elif labels[u] < labels[y] and labels[y] < labels[x] then
-          if not IsDigraphEdge(D, x, y) then
-            Add(T, [y, u, x]);
-          else
-            Add(C, [y, u, x]);
           fi;
         fi;
       od;

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2073,6 +2073,11 @@ gap> tree := UndirectedSpanningTree(DigraphMutableCopy(D));
 <mutable digraph with 10 vertices, 18 edges>
 gap> IsUndirectedSpanningTree(D, tree);
 true
+gap> D := Digraph(IsMutableDigraph, [[1, 2, 1, 3], [1], [4], [2, 3, 4, 3]]);;
+gap> UndirectedSpanningTree(D);
+fail
+gap> DigraphNrEdges(UndirectedSpanningForest(D));
+4
 
 # ArticulationPoints
 gap> ArticulationPoints(CycleDigraph(5));

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -9,14 +9,14 @@
 #############################################################################
 ##
 
-#@local A, B, D, D1, D2
+#@local A, B, D, D1, D2, D3
 #@local G, H, M, M1, P, S, a, adj, adj1, adj2, adjacencies, b
 #@local circuit, complete15, comps, cycle12, e, edgeCut, erev, filename, forest
 #@local g, gNew, gr, gr1, gr2, gr3, gr4, grid, group, i, id, isGraph, j, mat
 #@local multiple, names, nbs, nonPlanar, order, planar, probs, proj, r, rd
 #@local reflextrans, reflextrans1, reflextrans2, representatives, rev, rgr
 #@local rotationSy, rotationSystem, scc, schreierVector, sink, soccer, str
-#@local temp, topo, trans, trans1, trans2, tree, wcc, x, y, z
+#@local table, temp, topo, trans, trans1, trans2, tree, wcc, x, y, z
 gap> START_TEST("Digraphs package: standard/attr.tst");
 gap> LoadPackage("digraphs", false);;
 
@@ -3484,17 +3484,33 @@ Error, the 2nd argument <digraph2> must have at most 65534 vertices, found 655\
 # This has a small chance to randomly fail. Sorry if it does!
 gap> D1 := RandomMultiDigraph(100);;
 gap> D2 := Digraph(List(OutNeighbours(D1), x -> Shuffle(ShallowCopy(x))));;
+gap> repeat D3 := RandomMultiDigraph(100); until D1 <> D3;
 gap> D1 = D2;
 true
+gap> D1 = D3;
+false
 gap> OutNeighbours(D1) = OutNeighbours(D2);
 false
 gap> DigraphHash(D1) = DigraphHash(D2);
 true
-gap> while D1 = D2 do
-> D2 := RandomMultiDigraph(100);
-> od;;
-gap> DigraphHash(D1) = DigraphHash(D2);
+gap> DigraphHash(D1) = DigraphHash(D3);
 false
+gap> table := SparseHashTable();;  # DigraphHash should be used for this
+gap> AddDictionary(table, D1);
+gap> LookupDictionary(table, D1);
+true
+gap> LookupDictionary(table, D2);
+true
+gap> LookupDictionary(table, D3);
+fail
+gap> table := HTCreate(Digraph([]));;  # DigraphHash should be used for this too
+gap> HTAdd(table, D1, "first digraph");;
+gap> HTValue(table, D1);
+"first digraph"
+gap> HTValue(table, D2);
+"first digraph"
+gap> HTValue(table, D3);
+fail
 
 #
 gap> DIGRAPHS_StopTest();

--- a/tst/standard/examples.tst
+++ b/tst/standard/examples.tst
@@ -259,6 +259,12 @@ gap> DigraphUndirectedGirth(D);
 3
 gap> LollipopGraph(IsMutableDigraph, 5, 3);
 <mutable digraph with 8 vertices, 26 edges>
+gap> D := LollipopGraph(2, 4);
+<immutable connected symmetric digraph with 6 vertices, 10 edges>
+gap> DigraphUndirectedGirth(D);
+infinity
+gap> IsomorphismDigraphs(D, DigraphSymmetricClosure(ChainDigraph(6))) <> fail;
+true
 
 #  SquareGridGraph
 gap> SquareGridGraph(7, 7);


### PR DESCRIPTION
These PR fixes the four untested sections of code from attr.gi, some by adding tests, and some by amending the code.

The four commits are logically separate, so it might be better not to squash.

Code coverage of attr.gi should now be 100%.