### PR TITLE
Implement IsBetweenCoverAndLattice

### DIFF
--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -55,6 +55,7 @@ DeclareProperty("IsDistributiveLatticeDigraph", IsDigraph);
 DeclareProperty("IsModularLatticeDigraph", IsDigraph);
 DeclareProperty("Is2EdgeTransitive", IsDigraph);
 DeclareProperty("IsCograph", IsDigraph);
+DeclareProperty("IsBetweenCoverAndLattice", IsDigraph);
 DeclareSynonymAttr("IsLatticeDigraph",
                    IsMeetSemilatticeDigraph and IsJoinSemilatticeDigraph);
 DeclareSynonymAttr("IsPreorderDigraph",
@@ -82,6 +83,7 @@ InstallTrueMethod(IsAcyclicDigraph, IsEmptyDigraph);
 InstallTrueMethod(IsAcyclicDigraph, IsTournament and IsTransitiveDigraph);
 InstallTrueMethod(IsAntisymmetricDigraph, IsAcyclicDigraph);
 InstallTrueMethod(IsAntisymmetricDigraph, IsDigraph and IsTournament);
+InstallTrueMethod(IsBetweenCoverAndLattice, IsLatticeDigraph);
 InstallTrueMethod(IsBipartiteDigraph, IsCompleteBipartiteDigraph);
 InstallTrueMethod(IsBipartiteDigraph, IsDigraph and IsUndirectedForest);
 InstallTrueMethod(IsCompleteMultipartiteDigraph, IsCompleteBipartiteDigraph);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -140,23 +140,36 @@ D -> DIGRAPHS_IsMeetSemilatticeAndMeetTable(D)[1]);
 InstallMethod(IsBetweenCoverAndLattice, "for a digraph",
 [IsDigraph],
 function(D)
-  local order, hasse;
+  local copy, order, hasse, neighbours, table;
 
   # 1. Topologically sort the nodes in D.
+  copy := DigraphRemoveLoops(DigraphMutableCopyIfMutable(D)); # protect from nasty mutable side effects i think
   order := DigraphTopologicalSort(copy);
   if order = fail then
     return false;
   fi;
 
   # 2. Iterate through pairs of nodes of D in topological order and construct a table of their meets.
-  hasse := DigraphTransitiveReduction(DigraphMutableCopyIfMutable(copy));
-  in := InNeighbours(hasse);
-  # something along the lines of DigraphMeetTable()
-  out := OutNeighbours(hasse);
-  # something along the lines of DigraphJoinTable()
+  hasse := DigraphTransitiveReduction(copy);
+  neighbours := InNeighbours(hasse);
+  table := DIGRAPHS_MeetJoinTableBetweenCover(
+    DigraphNrVertices(copy),
+    Reversed(order),
+    neighbours,
+    false
+  );
+  if table = fail then
+    return false;
+  fi;
 
-  # TODO: step 3
-  return true;
+  neighbours := OutNeighbours(hasse);
+  table := DIGRAPHS_MeetJoinTableBetweenCover(
+    DigraphNrVertices(copy),
+    order,
+    neighbours,
+    true
+  );
+  return table <> fail;
 end);
 
 InstallImmediateMethod(IsStronglyConnectedDigraph,

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -137,6 +137,28 @@ InstallMethod(IsMeetSemilatticeDigraph, "for a digraph",
 [IsDigraph],
 D -> DIGRAPHS_IsMeetSemilatticeAndMeetTable(D)[1]);
 
+InstallMethod(IsBetweenCoverAndLattice, "for a digraph",
+[IsDigraph],
+function(D)
+  local order, hasse;
+
+  # 1. Topologically sort the nodes in D.
+  order := DigraphTopologicalSort(copy);
+  if order = fail then
+    return false;
+  fi;
+
+  # 2. Iterate through pairs of nodes of D in topological order and construct a table of their meets.
+  hasse := DigraphTransitiveReduction(DigraphMutableCopyIfMutable(copy));
+  in := InNeighbours(hasse);
+  # something along the lines of DigraphMeetTable()
+  out := OutNeighbours(hasse);
+  # something along the lines of DigraphJoinTable()
+
+  # TODO: step 3
+  return true;
+end);
+
 InstallImmediateMethod(IsStronglyConnectedDigraph,
 IsDigraph and HasDigraphStronglyConnectedComponents, 0,
 D -> Length(DigraphStronglyConnectedComponents(D).comps) = 1);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -195,7 +195,9 @@ InstallMethod(IsBetweenCoverAndLattice, "for a digraph",
 [IsDigraph],
 function(D)
   local copy, order, hasse, neighbours, table;
-
+ if IsMultiDigraph(D) then
+    ErrorNoReturn("the argument must not be a multidigraph,");
+  fi;
   # 1. Topologically sort the nodes in D.
   copy := DigraphRemoveLoops(DigraphMutableCopyIfMutable(D));
   # ^ protect from nasty mutable side effects i think

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -200,7 +200,6 @@ function(D)
   fi;
   # 1. Topologically sort the nodes in D.
   copy := DigraphRemoveLoops(DigraphMutableCopyIfMutable(D));
-  # ^ protect from nasty mutable side effects i think
   order := DigraphTopologicalSort(copy);
   if order = fail then
     return false;

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -91,6 +91,59 @@ function(D, P, U, join)
   return tab;
 end);
 
+# Variant of DIGRAPHS_MeetJoinTable that does not require the input digraph
+# to have all transitive edges: reachability between previously processed
+# vertices is checked via the table being constructed, rather than via
+# direct edge queries on the input digraph.
+# Note: above descriptive comment is LLM-generated.
+BindGlobal("DIGRAPHS_MeetJoinTableBetweenCover",
+function(N, P, U, join)
+  local ord, tab, S, i, x, T, l, q, z, y;
+
+  tab := List([1 .. N], x -> []);
+
+  ord := [];
+  for i in [1 .. N] do
+    ord[P[i]] := i;
+  od;
+
+  S := [];
+
+  for x in P do
+    tab[x, x] := x;
+    for y in S do
+      T := [];
+      for z in U[x] do
+        Add(T, tab[y, z]);
+      od;
+      T := Set(T);
+      l := Length(T);
+      if l = 0 then
+        return fail;
+      fi;
+      q := T[l];
+      for i in [1 .. l - 1] do
+        z := T[i];
+        if ord[z] > ord[q] then
+          q := z;
+        fi;
+      od;
+      for z in T do
+        # the below conditions are the only part that differs from MeetJoinTable above
+        if join and tab[q, z] <> z then
+          return fail;
+        elif not join and tab[z, q] <> z then
+          return fail;
+        fi;
+      od;
+      tab[x, y] := q;
+      tab[y, x] := q;
+    od;
+    Add(S, x);
+  od;
+  return tab;
+end);
+
 InstallMethod(DIGRAPHS_IsJoinSemilatticeAndJoinTable, "for a digraph",
 [IsDigraph],
 function(D)

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -129,7 +129,8 @@ function(N, P, U, join)
         fi;
       od;
       for z in T do
-        # the below conditions are the only part that differs from MeetJoinTable above
+        # the below conditions are the only part that
+        # differs from MeetJoinTable above
         if join and tab[q, z] <> z then
           return fail;
         elif not join and tab[z, q] <> z then
@@ -196,21 +197,22 @@ function(D)
   local copy, order, hasse, neighbours, table;
 
   # 1. Topologically sort the nodes in D.
-  copy := DigraphRemoveLoops(DigraphMutableCopyIfMutable(D)); # protect from nasty mutable side effects i think
+  copy := DigraphRemoveLoops(DigraphMutableCopyIfMutable(D));
+  # ^ protect from nasty mutable side effects i think
   order := DigraphTopologicalSort(copy);
   if order = fail then
     return false;
   fi;
 
-  # 2. Iterate through pairs of nodes of D in topological order and construct a table of their meets.
+  # 2. Iterate through pairs of nodes of D in topological order
+  # and construct a table of their meets.
   hasse := DigraphTransitiveReduction(copy);
   neighbours := InNeighbours(hasse);
   table := DIGRAPHS_MeetJoinTableBetweenCover(
     DigraphNrVertices(copy),
     Reversed(order),
     neighbours,
-    false
-  );
+    false);
   if table = fail then
     return false;
   fi;
@@ -220,8 +222,7 @@ function(D)
     DigraphNrVertices(copy),
     order,
     neighbours,
-    true
-  );
+    true);
   return table <> fail;
 end);
 

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1427,6 +1427,48 @@ false
 gap> IsLatticeDigraph(gr);
 false
 
+#  IsBetweenCoverAndLattice
+gap> IsBetweenCoverAndLattice(Digraph([]));
+true
+gap> IsBetweenCoverAndLattice(Digraph([[]]));
+true
+gap> IsBetweenCoverAndLattice(Digraph([[1]]));
+true
+gap> IsBetweenCoverAndLattice(ChainDigraph(5));
+true
+gap> IsBetweenCoverAndLattice(DigraphReflexiveTransitiveClosure(ChainDigraph(5)));
+true
+gap> D := Digraph([[2, 3], [4], [4], []]);
+<immutable digraph with 4 vertices, 4 edges>
+gap> IsLatticeDigraph(D);
+false
+gap> IsBetweenCoverAndLattice(D);
+true
+gap> D := Digraph([[2, 3, 4], [4], [4], []]);
+<immutable digraph with 4 vertices, 5 edges>
+gap> IsBetweenCoverAndLattice(D);
+true
+gap> D := DigraphReflexiveTransitiveClosure(Digraph([[2, 3], [4], [4], []]));
+<immutable preorder digraph with 4 vertices, 9 edges>
+gap> IsLatticeDigraph(D);
+true
+gap> IsBetweenCoverAndLattice(D);
+true
+gap> D := Digraph([[3, 4], [3, 4], [5], [5], []]);
+<immutable digraph with 5 vertices, 6 edges>
+gap> IsBetweenCoverAndLattice(D);
+false
+gap> IsBetweenCoverAndLattice(CycleDigraph(3));
+false
+gap> IsBetweenCoverAndLattice(Digraph([[], []]));
+false
+gap> D := Digraph(IsMutable, [[2, 3], [4], [4], []]);
+<mutable digraph with 4 vertices, 4 edges>
+gap> IsBetweenCoverAndLattice(D);
+true
+gap> D;
+<mutable digraph with 4 vertices, 4 edges>
+
 # IsDistributiveLatticeDigraph
 gap> D := Digraph([[11, 10], [], [2], [2], [3], [4, 3], [6, 5], [7], [7],
 >      [8], [9, 8]]);


### PR DESCRIPTION
Prompted by conversation in #714, I believe this is a functional implementation of the `IsBetweenCoverAndLattice` function. My implementation is based on the three-step outline given by @Joseph-Edwards and also implements `DIGRAPHS_MeetJoinTableBetweenCover` (as a slightly modified/generalised version of `DIGRAPHS_MeetJoinTable`) in order to make this possible. I've thrown in some tests as well (due to my limited understanding of the maths I'm unsure how comprehensive they are though!) and they do appear to pass when building and running locally. (hopefully CI/CD can validate if they still work!)