### PR TITLE
Cliques coverage

### DIFF
--- a/tst/standard/cliques.tst
+++ b/tst/standard/cliques.tst
@@ -543,6 +543,19 @@ gap> f := function(a, b)
 gap> CliquesFinder(gr, f, [], 4, [], [], false, 2, true);
 [ 2, 2, 2, 2 ]
 
+# Test CliquesFinder on big graphs with specific sizes specified
+gap> D := DigraphMutableCopy(Digraph("hundredtwentycell"));;
+gap> DigraphAddVertex(D);;
+gap> DigraphAddEdges(D, [[43, 601], [601, 43], [63, 601], [601, 63]]);;
+gap> DigraphAddEdges(D, [[283, 601], [601, 283], [303, 601], [601, 303]]);;
+gap> DigraphAddVertex(D);;
+gap> Set(DigraphMaximalCliques(D, [], [], infinity, 3));
+[ [ 43, 63, 601 ], [ 283, 303, 601 ] ]
+gap> DigraphMaximalCliques(D, [], [], infinity, 1);
+[ [ 602 ] ]
+gap> Length(DigraphMaximalCliques(D, [], [], infinity, 2));
+1198
+
 # Test DigraphsCliqueFinder
 gap> DigraphsCliquesFinder(0);
 Error, there must be 8 or 9 arguments, found 1,

--- a/tst/standard/cliques.tst
+++ b/tst/standard/cliques.tst
@@ -556,6 +556,13 @@ gap> DigraphMaximalCliques(D, [], [], infinity, 1);
 gap> Length(DigraphMaximalCliques(D, [], [], infinity, 2));
 1198
 
+# Test CliquesFinder (reps) on graph with automorphisms and isolated vertices
+gap> D := DigraphAddVertex(Digraph("hundredtwentycell"));;
+gap> Size(AutomorphismGroup(D));
+14400
+gap> Set(DigraphMaximalCliquesReps(D));
+[ [ 1, 2 ], [ 601 ] ]
+
 # Test DigraphsCliqueFinder
 gap> DigraphsCliquesFinder(0);
 Error, there must be 8 or 9 arguments, found 1,

--- a/tst/standard/cliques.tst
+++ b/tst/standard/cliques.tst
@@ -158,6 +158,8 @@ gap> DigraphMaximalIndependentSets(gr);
 [ [ 1 ] ]
 gap> DigraphIndependentSets(gr);
 [ [ 1 ] ]
+gap> DigraphIndependentSets(gr);
+[ [ 1 ] ]
 gap> DigraphMaximalIndependentSetsReps(gr, []);
 [ [ 1 ] ]
 gap> DigraphIndependentSetsReps(gr, []);


### PR DESCRIPTION
This brings cliques.gi to 100% coverage. And it was a nice exercise in understanding the Bron–Kerbosch algorithm and @wilfwilson's excellent 10-year-old implementation of it.

The commits are again logical and distinct, so might want to avoid squashing when merging.