### PR TITLE
Correct Mutability of LineDigraph

### DIFF
--- a/doc/constructors.xml
+++ b/doc/constructors.xml
@@ -21,8 +21,9 @@
     if the terminal vertex of the edge associated with <K>v</K> is the start
     vertex of the edge associated with <K>u</K>.<P/>
 
-    Note that the returned digraph is always a new immutable digraph, and the
-    argument <A>digraph</A> is never modified.
+    Note that the returned digraph is always a new digraph with the same
+    mutability as the input <A>digraph</A>. The input <A>digraph</A> is never
+    modified.
     <Example><![CDATA[
 gap> LineDigraph(CompleteDigraph(3));
 <immutable digraph with 6 vertices, 12 edges>
@@ -45,8 +46,9 @@ gap> LineDigraph(ChainDigraph(3));
     between two vertices if and only if the corresponding edges have a vertex in
     common.<P/>
 
-    Note that the returned digraph is always a new immutable digraph, and the
-    argument <A>digraph</A> is never modified.
+    Note that the returned digraph is always a new digraph with the same
+    mutability as the input <A>digraph</A>. The input <A>digraph</A> is never
+    modified.
     <Example><![CDATA[
 gap> LineUndirectedDigraph(CompleteDigraph(3));
 <immutable digraph with 3 vertices, 6 edges>

--- a/gap/constructors.gi
+++ b/gap/constructors.gi
@@ -130,9 +130,7 @@ function(D, distance)
 end);
 
 # Warning: unlike the other methods the next two do not change their arguments
-# in place, and always return an immutable digraph. There is currently no
-# method for creating a mutable digraph with 4 arguments, as required by the
-# next two methods.
+# in place.
 
 InstallMethod(LineDigraph, "for a digraph", [IsDigraph],
 function(D)

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -568,6 +568,20 @@ gap> OutNeighbours(D);
 gap> OutNeighbours(C);
 [ [ 2, 3, 4 ], [ 1, 3, 4, 5 ], [ 1, 2 ], [ 5 ], [ 4 ] ]
 
+# LineDigraph for mutable digraphs: mutable output, unchanged input
+gap> D := Digraph(IsMutableDigraph, [[2, 3, 4], [1, 3, 4, 5], [1, 2], [5], [4]]);;
+gap> out := LineDigraph(D);;
+gap> IsMutableDigraph(out);
+true
+gap> D = out;
+false
+gap> D := DigraphSymmetricClosure(D);;
+gap> out := LineUndirectedDigraph(D);;
+gap> IsMutableDigraph(out);
+true
+gap> D = out;
+false
+
 #
 gap> DIGRAPHS_StopTest();
 gap> STOP_TEST("Digraphs package: testinstall.tst", 0);


### PR DESCRIPTION
In 2ffaaae1a (2019) @wilfwilson modified LineDigraph to output a digraph with the same mutability as the input. This PR updates the documentation to reflect this, and adds a test for it.

This brings constructors.gi code coverage to 100%.