### PR TITLE
Load GAPDoc for the tests

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -576,6 +576,7 @@ Dependencies := rec(
                              ["GRAPE", ">=4.8.1"],
                              ["NautyTracesInterface", ">=0.2"],
                              ["AutoDoc", ">=2020.08.11"]],
+  TestPackages := [["GAPDoc", ">=1.6.3"]],
   ExternalConditions := [],
 ),
 

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -8,6 +8,9 @@
 #############################################################################
 ##
 LoadPackage("digraphs", false);;
+# DigraphsTestManualExamples extracts the examples from the manual,
+# which needs GAPDoc; it is only a suggested package of Digraphs.
+LoadPackage("GAPDoc", false);;
 if SizeBlist([DigraphsTestInstall(),
               DigraphsTestStandard(rec(earlyStop := false)),
               DIGRAPHS_RunTest(DigraphsTestManualExamples)]) = 3 then


### PR DESCRIPTION
tst/teststandard.g runs DigraphsTestManualExamples, which extracts the
examples from the manual and therefore needs GAPDoc. GAPDoc is only a
suggested package of Digraphs, so in a GAP where it is not loaded, e.g.
one started with `gap --bare', the test run ended with

    Error, Variable: 'ExtractExamples' must have an assigned value

Declare GAPDoc in TestPackages and load it in tst/teststandard.g. Note
that TestPackages alone does not suffice: it makes the CI install the
package, but does not load it.

Digraphs itself does not need GAPDoc; all of its uses are in the test and
documentation helpers in gap/utils.gi.

See https://github.com/gap-system/gap/issues/2434

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
