### PR TITLE
Make the bundled bliss timer portable plain C

### DIFF
--- a/extern/bliss-0.73/timer.cc
+++ b/extern/bliss-0.73/timer.cc
@@ -1,5 +1,4 @@
-#include <unistd.h>
-#include <sys/times.h>
+#include <time.h>
 #include "timer.hh"
 
 /*
@@ -32,7 +31,7 @@
 
 namespace bliss_digraphs {
 
-static const double numTicksPerSec = (double)(sysconf(_SC_CLK_TCK));
+static const double numTicksPerSec = (double)CLOCKS_PER_SEC;
 
 Timer::Timer()
 {
@@ -41,23 +40,13 @@ Timer::Timer()
 
 void Timer::reset()
 {
-  struct tms clkticks;
-
-//  times(&clkticks);
-  start_time =
-    ((double) clkticks.tms_utime + (double) clkticks.tms_stime) /
-    numTicksPerSec;
+  start_time = (double)clock() / numTicksPerSec;
 }
 
 
 double Timer::get_duration()
 {
-  struct tms clkticks;
-
-//  times(&clkticks);
-  double intermediate =
-    ((double) clkticks.tms_utime + (double) clkticks.tms_stime) /
-    numTicksPerSec;
+  double intermediate = (double)clock() / numTicksPerSec;
   return intermediate - start_time;
 }
 


### PR DESCRIPTION
timer.cc did not compile on native Windows (mingw, see
gap-system/gap#4157) for lack of sys/times.h. Its times() calls were
already commented out, so the timer computed durations from an
uninitialized struct; use clock() with the matching CLOCKS_PER_SEC
divisor instead, which is standard C, needs no unistd.h or
sys/times.h, and actually measures something.

With this, the whole digraphs kernel module builds and loads on
native Windows.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
